### PR TITLE
Set any parameter to SparkConf() from Interpreter GUI

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -241,19 +241,19 @@ public class SparkInterpreter extends Interpreter {
 
     for (Object k : intpProperty.keySet()) {
       String key = (String) k;
-      if (key.startsWith("spark.")) {
-        Object value = intpProperty.get(key);
-        if (value != null
-            && value instanceof String
-            && !((String) value).trim().isEmpty()) {
-          logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, value));
-          conf.set(key, (String) value);
-        }
+      Object value = intpProperty.get(key);
+      if (!isEmptyString(value)) {
+        logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, value));
+        conf.set(key, (String) value);
       }
     }
 
     SparkContext sparkContext = new SparkContext(conf);
     return sparkContext;
+  }
+
+  public static boolean isEmptyString(Object val) {
+    return val instanceof String && ((String) val).trim().isEmpty();
   }
 
   public static String getSystemDefault(


### PR DESCRIPTION
Only "spark.*" we propagated from Interpreter GUI but there are external tools that require custom configuration, i.e [couchbase-spark-connector](https://github.com/couchbaselabs/couchbase-spark-connector/wiki/Connection-Management#connecting-to-one-bucket)

This PR removes restriction.