### PR TITLE
Run sequence is not preserved

### DIFF
--- a/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -84,7 +84,6 @@ public class LazyOpenInterpreter
 
   @Override
   public FormType getFormType() {
-    open();
     return intp.getFormType();
   }
 

--- a/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/scheduler/JobProgressPoller.java
+++ b/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/scheduler/JobProgressPoller.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * TODO(moon) : add description.
- * 
+ *
  * @author Leemoonsoo
  *
  */
@@ -21,6 +21,7 @@ public class JobProgressPoller extends Thread {
     this.intervalMs = intervalMs;
   }
 
+  @Override
   public void run() {
     if (intervalMs < 0) {
       return;
@@ -32,7 +33,9 @@ public class JobProgressPoller extends Thread {
       JobListener listener = job.getListener();
       if (listener != null) {
         try {
-          listener.onProgressUpdate(job, job.progress());
+          if (job.isRunning()) {
+            listener.onProgressUpdate(job, job.progress());
+          }
         } catch (Exception e) {
           logger.error("Can not get or update progress", e);
         }

--- a/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -18,26 +20,35 @@ import org.junit.Test;
 import com.nflabs.zeppelin.display.GUI;
 import com.nflabs.zeppelin.interpreter.InterpreterContext;
 import com.nflabs.zeppelin.interpreter.InterpreterGroup;
+import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.remote.mock.MockInterpreterA;
 import com.nflabs.zeppelin.interpreter.remote.mock.MockInterpreterB;
+import com.nflabs.zeppelin.scheduler.Job;
+import com.nflabs.zeppelin.scheduler.Job.Status;
+import com.nflabs.zeppelin.scheduler.Scheduler;
 
 public class RemoteInterpreterTest {
 
 
+  private InterpreterGroup intpGroup;
+  private HashMap<String, String> env;
+
   @Before
   public void setUp() throws Exception {
+    intpGroup = new InterpreterGroup();
+    env = new HashMap<String, String>();
+    env.put("ZEPPELIN_CLASSPATH", new File("./target/test-classes").getAbsolutePath());
   }
 
   @After
   public void tearDown() throws Exception {
+    intpGroup.clone();
+    intpGroup.destroy();
   }
 
   @Test
   public void testRemoteInterperterCall() throws TTransportException, IOException {
     Properties p = new Properties();
-    InterpreterGroup intpGroup = new InterpreterGroup();
-    Map<String, String> env = new HashMap<String, String>();
-    env.put("ZEPPELIN_CLASSPATH", new File("./target/test-classes").getAbsolutePath());
 
     RemoteInterpreter intpA = new RemoteInterpreter(
         p,
@@ -97,9 +108,6 @@ public class RemoteInterpreterTest {
   @Test
   public void testRemoteSchedulerSharing() throws TTransportException, IOException {
     Properties p = new Properties();
-    InterpreterGroup intpGroup = new InterpreterGroup();
-    Map<String, String> env = new HashMap<String, String>();
-    env.put("ZEPPELIN_CLASSPATH", new File("./target/test-classes").getAbsolutePath());
 
     RemoteInterpreter intpA = new RemoteInterpreter(
         p,
@@ -127,21 +135,23 @@ public class RemoteInterpreterTest {
     intpB.open();
 
     long start = System.currentTimeMillis();
-    intpA.interpret("500",
+    InterpreterResult ret = intpA.interpret("500",
         new InterpreterContext(
             "id",
             "title",
             "text",
             new HashMap<String, Object>(),
             new GUI()));
+    assertEquals("500", ret.message());
 
-    intpB.interpret("500",
+    ret = intpB.interpret("500",
         new InterpreterContext(
             "id",
             "title",
             "text",
             new HashMap<String, Object>(),
             new GUI()));
+    assertEquals("1000", ret.message());
     long end = System.currentTimeMillis();
     assertTrue(end - start >= 1000);
 
@@ -151,6 +161,268 @@ public class RemoteInterpreterTest {
 
     RemoteInterpreterProcess process = intpA.getInterpreterProcess();
     assertFalse(process.isRunning());
+  }
 
+  @Test
+  public void testRemoteSchedulerSharingSubmit() throws TTransportException, IOException, InterruptedException {
+    Properties p = new Properties();
+
+    final RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpGroup.add(intpA);
+    intpA.setInterpreterGroup(intpGroup);
+
+    final RemoteInterpreter intpB = new RemoteInterpreter(
+        p,
+        MockInterpreterB.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpGroup.add(intpB);
+    intpB.setInterpreterGroup(intpGroup);
+
+    intpA.open();
+    intpB.open();
+
+    long start = System.currentTimeMillis();
+    Job jobA = new Job("jobA", null) {
+
+      @Override
+      public int progress() {
+        return 0;
+      }
+
+      @Override
+      public Map<String, Object> info() {
+        return null;
+      }
+
+      @Override
+      protected Object jobRun() throws Throwable {
+        return intpA.interpret("500",
+            new InterpreterContext(
+                "jobA",
+                "title",
+                "text",
+                new HashMap<String, Object>(),
+                new GUI()));
+      }
+
+      @Override
+      protected boolean jobAbort() {
+        return false;
+      }
+
+    };
+    intpA.getScheduler().submit(jobA);
+
+    Job jobB = new Job("jobB", null) {
+
+      @Override
+      public int progress() {
+        return 0;
+      }
+
+      @Override
+      public Map<String, Object> info() {
+        return null;
+      }
+
+      @Override
+      protected Object jobRun() throws Throwable {
+        return intpB.interpret("500",
+            new InterpreterContext(
+                "jobB",
+                "title",
+                "text",
+                new HashMap<String, Object>(),
+                new GUI()));
+      }
+
+      @Override
+      protected boolean jobAbort() {
+        return false;
+      }
+
+    };
+    intpB.getScheduler().submit(jobB);
+
+    // wait until both job finished
+    while (jobA.getStatus() != Status.FINISHED ||
+           jobB.getStatus() != Status.FINISHED) {
+      Thread.sleep(100);
+    }
+
+    long end = System.currentTimeMillis();
+    assertTrue(end - start >= 1000);
+
+    assertEquals("1000", ((InterpreterResult) jobB.getReturn()).message());
+
+    intpA.close();
+    intpB.close();
+
+    RemoteInterpreterProcess process = intpA.getInterpreterProcess();
+    assertFalse(process.isRunning());
+  }
+
+  @Test
+  public void testRunOrderPreserved() throws InterruptedException {
+    Properties p = new Properties();
+
+    final RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpGroup.add(intpA);
+    intpA.setInterpreterGroup(intpGroup);
+
+    intpA.open();
+
+    int concurrency = 3;
+    final List<String> results = new LinkedList<String>();
+
+    Scheduler scheduler = intpA.getScheduler();
+    for (int i = 0; i < concurrency; i++) {
+      final String jobId = Integer.toString(i);
+      scheduler.submit(new Job(jobId, Integer.toString(i), null, 200) {
+
+        @Override
+        public int progress() {
+          return 0;
+        }
+
+        @Override
+        public Map<String, Object> info() {
+          return null;
+        }
+
+        @Override
+        protected Object jobRun() throws Throwable {
+          InterpreterResult ret = intpA.interpret(getJobName(), new InterpreterContext(
+              jobId,
+              "title",
+              "text",
+              new HashMap<String, Object>(),
+              new GUI()));
+
+          synchronized (results) {
+            results.add(ret.message());
+            results.notify();
+          }
+          return null;
+        }
+
+        @Override
+        protected boolean jobAbort() {
+          return false;
+        }
+
+      });
+    }
+
+    // wait for job finished
+    synchronized (results) {
+      while (results.size() != concurrency) {
+        results.wait(300);
+      }
+    }
+
+    int i = 0;
+    for (String result : results) {
+      assertEquals(Integer.toString(i++), result);
+    }
+    assertEquals(concurrency, i);
+
+    intpA.close();
+  }
+
+
+  @Test
+  public void testRunParallel() throws InterruptedException {
+    Properties p = new Properties();
+    p.put("parallel", "true");
+
+    final RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpGroup.add(intpA);
+    intpA.setInterpreterGroup(intpGroup);
+
+    intpA.open();
+
+    int concurrency = 4;
+    final int timeToSleep = 1000;
+    final List<String> results = new LinkedList<String>();
+    long start = System.currentTimeMillis();
+
+    Scheduler scheduler = intpA.getScheduler();
+    for (int i = 0; i < concurrency; i++) {
+      final String jobId = Integer.toString(i);
+      scheduler.submit(new Job(jobId, Integer.toString(i), null, 300) {
+
+        @Override
+        public int progress() {
+          return 0;
+        }
+
+        @Override
+        public Map<String, Object> info() {
+          return null;
+        }
+
+        @Override
+        protected Object jobRun() throws Throwable {
+          String stmt = Integer.toString(timeToSleep);
+          InterpreterResult ret = intpA.interpret(stmt, new InterpreterContext(
+              jobId,
+              "title",
+              "text",
+              new HashMap<String, Object>(),
+              new GUI()));
+
+          synchronized (results) {
+            results.add(ret.message());
+            results.notify();
+          }
+          return stmt;
+        }
+
+        @Override
+        protected boolean jobAbort() {
+          return false;
+        }
+
+      });
+    }
+
+    // wait for job finished
+    synchronized (results) {
+      while (results.size() != concurrency) {
+        results.wait(300);
+      }
+    }
+
+    long end = System.currentTimeMillis();
+
+    assertTrue(end - start < timeToSleep * concurrency);
+
+    intpA.close();
   }
 }

--- a/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/mock/MockInterpreterA.java
+++ b/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/mock/MockInterpreterA.java
@@ -22,23 +22,31 @@ public class MockInterpreterA extends Interpreter {
             .add("p1", "v1", "property1").build());
 
   }
+
+  private String lastSt;
+
   public MockInterpreterA(Properties property) {
     super(property);
   }
 
   @Override
   public void open() {
-
+    //new RuntimeException().printStackTrace();
   }
 
   @Override
   public void close() {
   }
 
+  public String getLastStatement() {
+    return lastSt;
+  }
+
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     try {
       Thread.sleep(Long.parseLong(st));
+      this.lastSt = st;
     } catch (NumberFormatException | InterruptedException e) {
       throw new InterpreterException(e);
     }
@@ -67,6 +75,10 @@ public class MockInterpreterA extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetFIFOScheduler("interpreter_" + this.hashCode());
+    if (getProperty("parallel") != null && getProperty("parallel").equals("true")) {
+      return SchedulerFactory.singleton().createOrGetParallelScheduler("interpreter_" + this.hashCode(), 10);
+    } else {
+      return SchedulerFactory.singleton().createOrGetFIFOScheduler("interpreter_" + this.hashCode());
+    }
   }
 }

--- a/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/mock/MockInterpreterB.java
+++ b/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/interpreter/remote/mock/MockInterpreterB.java
@@ -10,6 +10,7 @@ import com.nflabs.zeppelin.interpreter.InterpreterGroup;
 import com.nflabs.zeppelin.interpreter.InterpreterPropertyBuilder;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
+import com.nflabs.zeppelin.interpreter.WrappedInterpreter;
 import com.nflabs.zeppelin.scheduler.Scheduler;
 
 public class MockInterpreterB extends Interpreter {
@@ -28,7 +29,7 @@ public class MockInterpreterB extends Interpreter {
 
   @Override
   public void open() {
-
+    //new RuntimeException().printStackTrace();
   }
 
   @Override
@@ -37,12 +38,18 @@ public class MockInterpreterB extends Interpreter {
 
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
+    MockInterpreterA intpA = getInterpreterA();
+    String intpASt = intpA.getLastStatement();
+    long timeToSleep = Long.parseLong(st);
+    if (intpASt != null) {
+      timeToSleep += Long.parseLong(intpASt);
+    }
     try {
-      Thread.sleep(Long.parseLong(st));
+      Thread.sleep(timeToSleep);
     } catch (NumberFormatException | InterruptedException e) {
       throw new InterpreterException(e);
     }
-    return new InterpreterResult(Code.SUCCESS, st);
+    return new InterpreterResult(Code.SUCCESS, Long.toString(timeToSleep));
   }
 
   @Override
@@ -62,6 +69,20 @@ public class MockInterpreterB extends Interpreter {
 
   @Override
   public List<String> completion(String buf, int cursor) {
+    return null;
+  }
+
+  public MockInterpreterA getInterpreterA() {
+    InterpreterGroup interpreterGroup = getInterpreterGroup();
+    for (Interpreter intp : interpreterGroup) {
+      if (intp.getClassName().equals(MockInterpreterA.class.getName())) {
+        Interpreter p = intp;
+        while (p instanceof WrappedInterpreter) {
+          p = ((WrappedInterpreter) p).getInnerInterpreter();
+        }
+        return (MockInterpreterA) p;
+      }
+    }
     return null;
   }
 

--- a/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -53,7 +53,7 @@ public class RemoteSchedulerTest {
         intpA.getInterpreterProcess(),
         10);
 
-    scheduler.submit(new Job("jobName", null) {
+    Job job = new Job("jobId", "jobName", null, 200) {
 
       @Override
       public int progress() {
@@ -68,7 +68,7 @@ public class RemoteSchedulerTest {
       @Override
       protected Object jobRun() throws Throwable {
         intpA.interpret("500", new InterpreterContext(
-            "id",
+            "jobId",
             "title",
             "text",
             new HashMap<String, Object>(),
@@ -80,8 +80,12 @@ public class RemoteSchedulerTest {
       protected boolean jobAbort() {
         return false;
       }
+    };
+    scheduler.submit(job);
 
-    });
+    while (job.isTerminated() == false) {
+      Thread.sleep(200);
+    }
 
     intpA.close();
     schedulerSvc.removeScheduler("test");

--- a/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/com/nflabs/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -1,5 +1,7 @@
 package com.nflabs.zeppelin.scheduler;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,13 +69,13 @@ public class RemoteSchedulerTest {
 
       @Override
       protected Object jobRun() throws Throwable {
-        intpA.interpret("500", new InterpreterContext(
+        intpA.interpret("1000", new InterpreterContext(
             "jobId",
             "title",
             "text",
             new HashMap<String, Object>(),
             new GUI()));
-        return "500";
+        return "1000";
       }
 
       @Override
@@ -83,9 +85,18 @@ public class RemoteSchedulerTest {
     };
     scheduler.submit(job);
 
-    while (job.isTerminated() == false) {
-      Thread.sleep(200);
+    while (job.isRunning() == false) {
+      Thread.sleep(100);
     }
+
+    Thread.sleep(500);
+    assertEquals(0, scheduler.getJobsWaiting().size());
+    assertEquals(1, scheduler.getJobsRunning().size());
+
+    Thread.sleep(500);
+
+    assertEquals(0, scheduler.getJobsWaiting().size());
+    assertEquals(0, scheduler.getJobsRunning().size());
 
     intpA.close();
     schedulerSvc.removeScheduler("test");


### PR DESCRIPTION
This PR came from https://github.com/NFLabs/zeppelin/pull/397

After https://github.com/NFLabs/zeppelin/pull/364, order of submitted job to the remote interpreter is not preserved.
Result is, when user run a lot of paragraphs in a short time, they run in random order(like click run 'Run all paragraphs). https://github.com/NFLabs/zeppelin/issues/395 is one of the possible problem.

this PR adds some unittests and fix the problem.

Ready to merge.