### PR TITLE
Updated frontend-maven-plugin to version 0.0.23

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -20,7 +20,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.20</version>
+        <version>0.0.23</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
Maven fails to retrieve the plugin with v.0.0.20. The plugin v0.0.20 has a dependency from google code domain, that might be the cause.  I've updated the plugin to 0.0.23 with no side effects so far.

contexts: 
https://github.com/NFLabs/zeppelin/issues/403
https://issues.apache.org/jira/browse/ZEPPELIN-2
https://github.com/NFLabs/zeppelin/pull/405 