### PR TITLE
Replace ngMin by ngAnnotate

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -27,6 +27,18 @@ module.exports = function (grunt) {
     // Project settings
     yeoman: appConfig,
 
+    // use ngAnnotate instead og ngMin
+    ngAnnotate: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '.tmp/concat/scripts',
+          src: '*.js',
+          dest: '.tmp/concat/scripts'
+        }]
+      }
+    },
+
     // Watches files for changes and runs tasks based on the changed files
     watch: {
       bower: {
@@ -265,20 +277,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // ngmin tries to make the code safe for minification automatically by
-    // using the Angular long form for dependency injection. It doesn't work on
-    // things like resolve or inject so those have to be done manually.
-    ngmin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/concat/scripts',
-          src: '*.js',
-          dest: '.tmp/concat/scripts'
-        }]
-      }
-    },
-
     // Copies remaining files to places other tasks can use
     copy: {
       dist: {
@@ -388,7 +386,7 @@ module.exports = function (grunt) {
     'concurrent:dist',
     'autoprefixer',
     'concat',
-    'ngmin',
+    'ngAnnotate',
     'copy:dist',
     'cssmin',
     'uglify',

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^0.2.1",
     "grunt-newer": "^0.7.0",
-    "grunt-ngmin": "^0.0.3",
+    "grunt-ng-annotate": "^0.10.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "~2.0.0",


### PR DESCRIPTION
Improve Grunt Build, by replacing ngMin with ngAnnotate

ngMin is deprecated and ngAnnotate is its replacement.

Zeppelin-web compilation time got a 50-70% boost thanks to that change 