### PR TITLE
[ZEPPELIN-17] PySpark Interpreter should allow starting with a specific version of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ If you set `SPARK_HOME`, you should deploy spark binary on the same location to 
 Yarn
 
     # ./conf/zeppelin-env.sh
-    export export SPARK_YARN_JAR=/path/to/spark-assembly-*.jar
+    export SPARK_YARN_JAR=/path/to/spark-assembly-*.jar
     export HADOOP_CONF_DIR=/path/to/hadoop_conf_dir
 
-`SPARK_YARN_JAR` is deployed for running executor. `HADOOP_CONF_DIR` should contains yarn-site.xml and core-site.xml. 
+`SPARK_YARN_JAR` is deployed for running executor, this could be a local path or HDFS. HDFS allows YARN to cache it on nodes so that it doesn't need to be distributed each time an application runs. To point to a jar on HDFS, for example, set this configuration to "hdfs:///some/path".  
+`HADOOP_CONF_DIR` should contains yarn-site.xml and core-site.xml.
 
 ### Run
     ./bin/zeppelin-daemon.sh start

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/PySparkInterpreter.java
@@ -64,7 +64,10 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
         new InterpreterPropertyBuilder()
           .add("spark.home",
                SparkInterpreter.getSystemDefault("SPARK_HOME", "spark.home", ""),
-               "Spark home path. Should be provided for pyspark").build());
+               "Spark home path. Should be provided for pyspark")
+          .add("zeppelin.pyspark.python",
+               SparkInterpreter.getSystemDefault("PYSPARK_PYTHON", null, "python"),
+               "Python command to run pyspark with").build());
   }
 
   public PySparkInterpreter(Properties property) {
@@ -115,7 +118,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     gatewayServer.start();
 
     // Run python shell
-    CommandLine cmd = CommandLine.parse("python");
+    CommandLine cmd = CommandLine.parse(getProperty("zeppelin.pyspark.python"));
     cmd.addArgument(scriptPath, false);
     cmd.addArgument(Integer.toString(port), false);
     executor = new DefaultExecutor();


### PR DESCRIPTION
Add PYSPARK_PYTHON.
We could also add PYSPARK_DRIVER_PYTHON (Zeppelin Interpreter is the driver) but it doesn't seem to be documented, and more importantly running different Python between driver and worker can cause errors.

http://spark.apache.org/docs/1.3.0/configuration.html
http://spark.apache.org/docs/1.3.0/configuration.html#environment-variables