### PR TITLE
[ZEPPELIN-13] ZEPPELIN_CONF_DIR cannot be reached until ZEPPELIN_CONF_DIR become set

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -28,13 +28,6 @@ if [ $# -le 1 ]; then
   exit 1
 fi
 
-if [ -L ${BASH_SOURCE-$0} ]; then
-  BIN=$(dirname $(readlink "${BASH_SOURCE-$0}"))
-else
-  BIN=$(dirname ${BASH_SOURCE-$0})
-fi
-BIN=$(cd "${BIN}">/dev/null; pwd)
-
 if [ "$1" == "--config" ]
 then
   shift
@@ -50,6 +43,12 @@ then
   shift
 fi
 
+if [ -L ${BASH_SOURCE-$0} ]; then
+  BIN=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+else
+  BIN=$(dirname ${BASH_SOURCE-$0})
+fi
+BIN=$(cd "${BIN}">/dev/null; pwd)
 
 . "${BIN}/common.sh"
 . "${BIN}/functions.sh"

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -23,11 +23,6 @@
 
 USAGE="Usage: zeppelin-daemon.sh [--config <conf-dir>] {start|stop|restart|reload|status}"
 
-if [ $# -le 1 ]; then
-  echo $USAGE
-  exit 1
-fi
-
 if [ "$1" == "--config" ]
 then
   shift

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -21,12 +21,35 @@
 # description: Start and stop daemon script for.
 #
 
+USAGE="Usage: zeppelin-daemon.sh [--config <conf-dir>] {start|stop|restart|reload|status}"
+
+if [ $# -le 1 ]; then
+  echo $USAGE
+  exit 1
+fi
+
 if [ -L ${BASH_SOURCE-$0} ]; then
   BIN=$(dirname $(readlink "${BASH_SOURCE-$0}"))
 else
   BIN=$(dirname ${BASH_SOURCE-$0})
 fi
 BIN=$(cd "${BIN}">/dev/null; pwd)
+
+if [ "$1" == "--config" ]
+then
+  shift
+  conf_dir="$1"
+  if [ ! -d "$conf_dir" ]
+  then
+    echo "ERROR : $conf_dir is not a directory"
+    echo ${USAGE}
+    exit 1
+  else
+    export ZEPPELIN_CONF_DIR="$conf_dir"
+  fi
+  shift
+fi
+
 
 . "${BIN}/common.sh"
 . "${BIN}/functions.sh"
@@ -205,5 +228,5 @@ case "${1}" in
     find_zeppelin_process
     ;;
   *)
-    echo "Usage: $0 {start|stop|restart|reload|status}"
+    echo ${USAGE}
 esac

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -22,9 +22,29 @@
 #
 
 function usage() {
-  echo "Usage: bin/zeppelin.sh [spark options] [application options]"
+  echo "Usage: bin/zeppelin.sh [--config <conf-dir>] [spark options] [application options]"
   exit 0
 }
+
+if [ $# -le 1 ]; then
+  echo $USAGE
+  exit 1
+fi
+
+if [ "$1" == "--config" ]
+then
+  shift
+  conf_dir="$1"
+  if [ ! -d "$conf_dir" ]
+  then
+    echo "ERROR : $conf_dir is not a directory"
+    echo ${USAGE}
+    exit 1
+  else
+    export ZEPPELIN_CONF_DIR="$conf_dir"
+  fi
+  shift
+fi
 
 bin=$(dirname "${BASH_SOURCE-$0}")
 bin=$(cd "${bin}">/dev/null; pwd)

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -26,11 +26,6 @@ function usage() {
   exit 0
 }
 
-if [ $# -le 1 ]; then
-  echo $USAGE
-  exit 1
-fi
-
 if [ "$1" == "--config" ]
 then
   shift

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -7,7 +7,6 @@
 # export ZEPPELIN_INTP_MEM       # zeppelin interpreter process jvm mem options. Defualt = ZEPPELIN_MEM
 # export ZEPPELIN_INTP_JAVA_OPTS # zeppelin interpreter process jvm options. Default = ZEPPELIN_JAVA_OPTS
 
-# export ZEPPELIN_CONF_DIR       # Alternate zeppelin conf dir. Default is ${ZEPPELIN_HOME}/conf.
 # export ZEPPELIN_LOG_DIR        # Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        # The pid files are stored. /tmp by default.
 # export ZEPPELIN_NOTEBOOK_DIR   # Where notebook saved

--- a/notebook/2A94M5J1Z/note.json
+++ b/notebook/2A94M5J1Z/note.json
@@ -279,19 +279,7 @@
       "progressUpdateIntervalMs": 500
     },
     {
-      "text": "%pyspark\nprint \"hello, world\"",
-      "config": {
-        "colWidth": 12.0,
-        "graph": {
-          "mode": "table",
-          "height": 300.0,
-          "optionOpen": false,
-          "keys": [],
-          "values": [],
-          "groups": [],
-          "scatter": {}
-        }
-      },
+      "config": {},
       "settings": {
         "params": {},
         "forms": {}
@@ -299,18 +287,6 @@
       "jobName": "paragraph_1423836471379_293523076",
       "id": "20150213-230751_1038476812",
       "dateCreated": "Feb 13, 2015 11:07:51 PM",
-      "status": "READY",
-      "progressUpdateIntervalMs": 500
-    },
-    {
-      "config": {},
-      "settings": {
-        "params": {},
-        "forms": {}
-      },
-      "jobName": "paragraph_1427850802691_-422382127",
-      "id": "20150401-101322_1217450604",
-      "dateCreated": "Apr 1, 2015 10:13:22 AM",
       "status": "READY",
       "progressUpdateIntervalMs": 500
     }

--- a/notebook/2A94M5J1Z/note.json
+++ b/notebook/2A94M5J1Z/note.json
@@ -279,7 +279,19 @@
       "progressUpdateIntervalMs": 500
     },
     {
-      "config": {},
+      "text": "%pyspark\nprint \"hello, world\"",
+      "config": {
+        "colWidth": 12.0,
+        "graph": {
+          "mode": "table",
+          "height": 300.0,
+          "optionOpen": false,
+          "keys": [],
+          "values": [],
+          "groups": [],
+          "scatter": {}
+        }
+      },
       "settings": {
         "params": {},
         "forms": {}
@@ -287,6 +299,18 @@
       "jobName": "paragraph_1423836471379_293523076",
       "id": "20150213-230751_1038476812",
       "dateCreated": "Feb 13, 2015 11:07:51 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "config": {},
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph_1427850802691_-422382127",
+      "id": "20150401-101322_1217450604",
+      "dateCreated": "Apr 1, 2015 10:13:22 AM",
       "status": "READY",
       "progressUpdateIntervalMs": 500
     }


### PR DESCRIPTION
bin/common.sh tries to find and set ZEPPELIN_CONF_DIR in order to read zeppelin-env.sh, but ZEPPELIN_CONF_DIR is defined in zeppelin-env.sh, so we cannot use different ZEPPELIN_CONF_DIR.