### PR TITLE
[ZEPPELIN-7] Minor. Removed SPARK_YARN_JAR from zeppelin-env.sh.template

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -15,7 +15,6 @@
 # export ZEPPELIN_NICENESS       # The scheduling priority for daemons. Defaults to 0.
 
 # Options read in YARN client mode
-# export SPARK_YARN_JAR          # Yarn executor needs spark-assembly-*.jar for running tasks in a yarn cluster.
 # export HADOOP_CONF_DIR         # yarn-site.xml is located in configuration directory in HADOOP_CONF_DIR.
 
 # Pyspark (supported with Spark 1.2.1 and above)


### PR DESCRIPTION
I missed removing configuration option.