### PR TITLE
ZEPPELIN-22 PySparkInterpreter hanging without error message

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -23,6 +23,8 @@ java_import(gateway.jvm, "org.apache.spark.api.python.*")
 java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
 
 intp = gateway.entry_point
+intp.onPythonScriptInitialized()
+
 jsc = intp.getJavaSparkContext()
 
 if jsc.version().startswith("1.2"):
@@ -36,7 +38,6 @@ elif jsc.version().startswith("1.3"):
 
 
 java_import(gateway.jvm, "scala.Tuple2")
-
 
 jconf = intp.getSparkConf()
 conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
@@ -61,7 +62,6 @@ class Logger(object):
 output = Logger()
 sys.stdout = output
 sys.stderr = output
-
 
 while True :
   req = intp.getStatements()


### PR DESCRIPTION
When something goes wrong, like misconfiguring spark.home property, %pyspark is hanging.
This PR makes Zeppelin prints some error instead of waiting forever.

Here's example of error message printed when it failed to load py4j package. Previously it was just hanging.
![image](https://cloud.githubusercontent.com/assets/1540981/6978258/9e10caa8-da09-11e4-82da-80f935502f5b.png)
