### PR TITLE
ZEPPELIN-28 propagate empty interpreter vars to Spark conf

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -259,10 +259,8 @@ public class SparkInterpreter extends Interpreter {
     for (Object k : intpProperty.keySet()) {
       String key = (String) k;
       Object value = intpProperty.get(key);
-      if (!isEmptyString(value)) {
-        logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, value));
-        conf.set(key, (String) value);
-      }
+      logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, value));
+      conf.set(key, (String) value);
     }
 
     SparkContext sparkContext = new SparkContext(conf);


### PR DESCRIPTION
Is needed for CouchDB support, see https://issues.apache.org/jira/browse/ZEPPELIN-28