### PR TITLE
Fix header for directive template

### DIFF
--- a/zeppelin-web/app/views/popover-html-unsafe-popup.html
+++ b/zeppelin-web/app/views/popover-html-unsafe-popup.html
@@ -1,9 +1,10 @@
+<div class="popover {{placement}}" ng-class="{ in: isOpen(), fade: animation() }">
 <!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -11,12 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-<div class="popover {{placement}}" ng-class="{ in: isOpen(), fade: animation() }">
   <div class="arrow"></div>
 
   <div class="popover-inner">
-      <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
-      <div class="popover-content" bind-html-unsafe="content"></div>
+    <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
+    <div class="popover-content" bind-html-unsafe="content"></div>
   </div>
 </div>


### PR DESCRIPTION
Change the header position in the directive template.
When the header is at the top level it counts as a node root in the DOM and throw an error in angularjs.
src: https://docs.angularjs.org/error/$compile/tplrt
This issue as been fixed in Angularjs 1.4 beta, so we won't have problems in the future (currently 1.3.8)