### PR TITLE
ZEPPELIN-33 Need a maven profile for Hadoop 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1415,6 +1415,16 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.6</id>
+      <properties>
+        <hadoop.version>2.6.0</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.3</jets3t.version>
+        <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
Trivial change to create a new maven profile for Hadoop 2.6, tested by running 

mvn clean install -DskipTests -Pspark-1.2 -Phadoop-2.6 -Pyarn