### PR TITLE
Gh pages update git url and package/groupId

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -22,7 +22,7 @@
             {% assign pages_list = site.pages %}
             {% assign group = 'nav-right' %}
             {% include JB/pages_list %}
-            <li><a href="https://github.com/NFLabs/zeppelin">GitHub</a></li>
+            <li><a href="https://github.com/apache/incubator-zeppelin">GitHub</a></li>
             <li id="apache">
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>
                <ul class="dropdown-menu">

--- a/docs/current
+++ b/docs/current
@@ -1,1 +1,0 @@
-zengine-api/0.2.0/

--- a/docs/development/howtocontribute.md
+++ b/docs/development/howtocontribute.md
@@ -17,7 +17,7 @@ Here are some things you will need to build and test Zeppelin.
 
 #### Software Configuration Management(SCM)
 
-Zeppelin uses Git for it's SCM system. Hosted by github.com. https://github.com/nflabs/zeppelin You'll need git client installed in your development machine. 
+Zeppelin uses Git for it's SCM system. Hosted by github.com. `https://github.com/apache/incubator-zeppelin` You'll need git client installed in your development machine. 
 
 #### Integrated Development Environment(IDE)
 
@@ -30,20 +30,20 @@ Oracle Java 7
 Apache Maven
 
 ### Getting the source code
-First of all, you need the Zeppelin source code. The official location for Zeppelin is [https://github.com/nflabs/zeppelin](https://github.com/nflabs/zeppelin)
+First of all, you need the Zeppelin source code. The official location for Zeppelin is [https://github.com/apache/incubator-zeppelin](https://github.com/apache/incubator-zeppelin)
 
 #### git access
 
 Get the source code on your development machine using git.
 
 ```
-git clone https://github.com/NFLabs/zeppelin.git zeppelin
+git clone https://github.com/apache/incubator-zeppelin.git zeppelin
 ```
 
 You may also want to develop against a specific release. For example, for branch-0.1
 
 ```
-git clone -b branch-0.1 https://github.com/NFLabs/zeppelin.git zeppelin
+git clone -b branch-0.1 https://github.com/apache/incubator-zeppelin.git zeppelin
 ```
 
 
@@ -74,7 +74,7 @@ mvn install -Dspark.version=1.0.1 -Dhadoop.version=2.2.0
 
 ```
 cd zeppelin-server
-HADOOP_HOME=YOUR_HADOOP_HOME JAVA_HOME=YOUR_JAVA_HOME mvn exec:java -Dexec.mainClass="com.nflabs.zeppelin.server.ZeppelinServer" -Dexec.args=""
+HADOOP_HOME=YOUR_HADOOP_HOME JAVA_HOME=YOUR_JAVA_HOME mvn exec:java -Dexec.mainClass="org.apache.zeppelin.server.ZeppelinServer" -Dexec.args=""
 ```
 
 or use daemon script

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -18,9 +18,9 @@ Interpreter can be launched either using separate classloader or separate JVM pr
 
 ### Make your own Interpreter
 
-Creating a new interpreter is quite simple. Just extends [com.nflabs.zeppelin.interpreter](https://github.com/NFLabs/zeppelin/blob/master/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
+Creating a new interpreter is quite simple. Just extends [org.apache.zeppelin.interpreter](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
 
-You can include com.nflabs.zeppelin:zeppelin-interpreter:[VERSION] artifact in your build system.
+You can include org.apache.zeppelin:zeppelin-interpreter:[VERSION] artifact in your build system.
 
 ### Install your interpreter binary
 
@@ -40,7 +40,7 @@ for example,
 ```
 <property>
   <name>zeppelin.interpreters</name>
-  <value>com.nflabs.zeppelin.spark.SparkInterpreter,com.nflabs.zeppelin.spark.SparkSqlInterpreter,com.nflabs.zeppelin.markdown.Markdown,com.nflabs.zeppelin.shell.ShellInterpreter,com.me.MyNewInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,com.me.MyNewInterpreter</value>
 </property>
 ```
 
@@ -63,7 +63,7 @@ println(a)
 
 Check some interpreters shipped by default.
 
- - [spark](https://github.com/NFLabs/zeppelin/tree/master/spark)
- - [markdown](https://github.com/NFLabs/zeppelin/tree/master/markdown)
- - [shell](https://github.com/NFLabs/zeppelin/tree/master/shell)
+ - [spark](https://github.com/apache/incubator-zeppelin/tree/master/spark)
+ - [markdown](https://github.com/apache/incubator-zeppelin/tree/master/markdown)
+ - [shell](https://github.com/apache/incubator-zeppelin/tree/master/shell)
 

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -40,7 +40,7 @@ for example,
 ```
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,com.me.MyNewInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,com.me.MyNewInterpreter</value>
 </property>
 ```
 
@@ -66,4 +66,5 @@ Check some interpreters shipped by default.
  - [spark](https://github.com/apache/incubator-zeppelin/tree/master/spark)
  - [markdown](https://github.com/apache/incubator-zeppelin/tree/master/markdown)
  - [shell](https://github.com/apache/incubator-zeppelin/tree/master/shell)
+ - [hive](https://github.com/apache/incubator-zeppelin/tree/master/hive)
 

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -40,7 +40,7 @@ for example,
 ```
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,com.me.MyNewInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,com.me.MyNewInterpreter</value>
 </property>
 ```
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -18,7 +18,7 @@ group: install
 
 Build tested on OSX, CentOS 6.
 
-Checkout source code from [https://github.com/NFLabs/zeppelin](https://github.com/NFLabs/zeppelin)
+Checkout source code from [https://github.com/apache/incubator-zeppelin](https://github.com/apache/incubator-zeppelin)
 
 #### Local mode
 
@@ -79,7 +79,7 @@ Configuration can be done by both environment variable(conf/zeppelin-env.sh) and
     <td>ZEPPELIN_INTERPRETERS</td>
     <td>zeppelin.interpreters</td>
   <description></description>
-    <td>spark:com.nflabs.zeppelin.spark.SparkInterpreter,<br />sql:com.nflabs.zeppelin.spark.SparkSqlInterpreter,<br />md:com.nflabs.zeppelin.markdown.Markdown,<br />sh:com.nflabs.zeppelin.shell.ShellInterpreter</td>
+    <td>spark:org.apache.zeppelin.spark.SparkInterpreter,<br />sql:org.apache.zeppelin.spark.SparkSqlInterpreter,<br />md:org.apache.zeppelin.markdown.Markdown,<br />sh:org.apache.zeppelin.shell.ShellInterpreter</td>
     <td>Comma separated interpreter configurations [Name]:[Class]. First interpreter become a default</td>
   </tr>
   <tr>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -79,7 +79,7 @@ Configuration can be done by both environment variable(conf/zeppelin-env.sh) and
     <td>ZEPPELIN_INTERPRETERS</td>
     <td>zeppelin.interpreters</td>
   <description></description>
-    <td>spark:org.apache.zeppelin.spark.SparkInterpreter,<br />sql:org.apache.zeppelin.spark.SparkSqlInterpreter,<br />md:org.apache.zeppelin.markdown.Markdown,<br />sh:org.apache.zeppelin.shell.ShellInterpreter</td>
+    <td>spark:org.apache.zeppelin.spark.SparkInterpreter,<br />sql:org.apache.zeppelin.spark.SparkSqlInterpreter,<br />md:org.apache.zeppelin.markdown.Markdown,<br />sh:org.apache.zeppelin.shell.ShellInterpreter,<br />hive:org.apache.zeppelin.hive.HiveInterpreter</td>
     <td>Comma separated interpreter configurations [Name]:[Class]. First interpreter become a default</td>
   </tr>
   <tr>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -79,8 +79,8 @@ Configuration can be done by both environment variable(conf/zeppelin-env.sh) and
     <td>ZEPPELIN_INTERPRETERS</td>
     <td>zeppelin.interpreters</td>
   <description></description>
-    <td>spark:org.apache.zeppelin.spark.SparkInterpreter,<br />sql:org.apache.zeppelin.spark.SparkSqlInterpreter,<br />md:org.apache.zeppelin.markdown.Markdown,<br />sh:org.apache.zeppelin.shell.ShellInterpreter,<br />hive:org.apache.zeppelin.hive.HiveInterpreter</td>
-    <td>Comma separated interpreter configurations [Name]:[Class]. First interpreter become a default</td>
+    <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter</td>
+    <td>Comma separated interpreter configurations [Class]. First interpreter become a default</td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ tagline: Less Development, More analysis!
 ### Multiple language backend
 
 Zeppelin interpreter concept allows any language/data-processing-backend to be plugged into Zeppelin.
-Current languages included in the Zeppelin interpreter are: Scala(with Apache Spark), Python(with Apache Spark), SparkSQL, Markdown and Shell.
+Current languages included in the Zeppelin interpreter are: Scala(with Apache Spark), Python(with Apache Spark), SparkSQL, Hive, Markdown and Shell.
 
 <img class="img-responsive" src="assets/themes/zeppelin/img/screenshots/multiple_language_backend.png" />
 

--- a/index.md
+++ b/index.md
@@ -104,7 +104,7 @@ This way, you can easily embed it as an iframe inside of your website.</p>
 <br />
 ### 100% Opensource
 
-Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](https://github.com/NFLabs/zeppelin) and [How to contribute](./docs/development/howtocontribute.html)
+Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](https://github.com/apache/incubator-zeppelin) and [How to contribute](./docs/development/howtocontribute.html)
 
 Zeppelin has a very active development community.
 Join the [Mailing list](./community.html) and report issues on our [Issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN).


### PR DESCRIPTION
- Update git url from https://github.com/nflabs/zeppelin to https://github.com/apache/incubator-zeppelin
- Update package/groupId from `com.nflabs` to `org.apache`
- Add hive as default interpreter
- Remove docs/current file to run jekyll