### PR TITLE
[ZEPPELIN-35] Icons should have tool tips

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -11,7 +11,7 @@
     "angular-animate": "1.3.8",
     "angular-touch": "1.3.8",
     "angular-route": "1.3.8",
-    "angular-bootstrap": "~0.11.0",
+    "angular-bootstrap": "~0.13.0",
     "angular-websocket": "~1.0.13",
     "ace-builds": "1.1.8",
     "angular-ui-ace": "0.1.1",

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -2,24 +2,24 @@
   "name": "zeppelin-web",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.3.8",
+    "angular": "1.2.28",
     "json3": "~3.3.1",
     "es5-shim": "~3.1.0",
     "bootstrap": "~3.2.0",
-    "angular-cookies": "1.3.8",
-    "angular-sanitize": "1.3.8",
-    "angular-animate": "1.3.8",
-    "angular-touch": "1.3.8",
-    "angular-route": "1.3.8",
+    "angular-cookies": "1.2.28",
+    "angular-sanitize": "1.2.28",
+    "angular-animate": "1.2.28",
+    "angular-touch": "1.2.28",
+    "angular-route": "1.2.28",
     "angular-bootstrap": "~0.11.0",
-    "angular-websocket": "~1.0.13",
+    "angular-websocket": "~0.0.5",
     "ace-builds": "1.1.8",
     "angular-ui-ace": "0.1.1",
     "jquery.scrollTo": "~1.4.13",
     "nvd3": "~1.1.15-beta",
     "angular-dragdrop": "~1.0.8",
     "perfect-scrollbar": "~0.5.4",
-    "ng-sortable": "~1.1.9",
+    "ng-sortable": "1.1.6",
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
     "angular-xeditable": "0.1.8",
@@ -28,8 +28,8 @@
     "angular-filter": "~0.5.4"
   },
   "devDependencies": {
-    "angular-mocks": "1.3.8",
-    "angular-scenario": "1.3.8"
+    "angular-mocks": "1.2.28",
+    "angular-scenario": "1.2.28"
   },
   "appPath": "src",
   "resolutions": {

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -2,24 +2,24 @@
   "name": "zeppelin-web",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.2.28",
+    "angular": "1.3.8",
     "json3": "~3.3.1",
     "es5-shim": "~3.1.0",
     "bootstrap": "~3.2.0",
-    "angular-cookies": "1.2.28",
-    "angular-sanitize": "1.2.28",
-    "angular-animate": "1.2.28",
-    "angular-touch": "1.2.28",
-    "angular-route": "1.2.28",
+    "angular-cookies": "1.3.8",
+    "angular-sanitize": "1.3.8",
+    "angular-animate": "1.3.8",
+    "angular-touch": "1.3.8",
+    "angular-route": "1.3.8",
     "angular-bootstrap": "~0.11.0",
-    "angular-websocket": "~0.0.5",
+    "angular-websocket": "~1.0.13",
     "ace-builds": "1.1.8",
     "angular-ui-ace": "0.1.1",
     "jquery.scrollTo": "~1.4.13",
     "nvd3": "~1.1.15-beta",
     "angular-dragdrop": "~1.0.8",
     "perfect-scrollbar": "~0.5.4",
-    "ng-sortable": "1.1.6",
+    "ng-sortable": "~1.1.9",
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
     "angular-xeditable": "0.1.8",
@@ -28,8 +28,8 @@
     "angular-filter": "~0.5.4"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.28",
-    "angular-scenario": "1.2.28"
+    "angular-mocks": "1.3.8",
+    "angular-scenario": "1.3.8"
   },
   "appPath": "src",
   "resolutions": {

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -23,7 +23,7 @@ limitations under the License.
                     class="btn btn-default btn-xs"
                     ng-click="runNote()"
                     ng-if="!isNoteRunning()"
-                    tooltip-placement="top" tooltip="Run all the note">
+                    tooltip-placement="top" tooltip="Run all the notes">
               <i class="icon-control-play"></i>
             </button>
 
@@ -54,7 +54,8 @@ limitations under the License.
               <div class="btn btn-default btn-xs dropdown-toggle"
                    type="button"
                    data-toggle="dropdown"
-                   ng-class="{ 'btn-info' : note.config.cron, 'btn-danger' : note.info.cron, 'btn-default' : !note.config.cron}">
+                   ng-class="{ 'btn-info' : note.config.cron, 'btn-danger' : note.info.cron, 'btn-default' : !note.config.cron}"
+                   tooltip-placement="top" tooltip="Run scheduler">
                 <span class="fa fa-clock-o"></span> {{getCronOptionNameFromValue(note.config.cron)}}
               </div>
               <ul class="dropdown-menu" role="menu" style="width:300px">

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -26,8 +26,8 @@ limitations under the License.
 
     <div class="collapse navbar-collapse" ng-controller="NavCtrl as navbar">
       <ul class="nav navbar-nav">
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle">Notebook <span class="caret"></span></a>
+        <li class="dropdown" dropdown>
+          <a href="#" class="dropdown-toggle" dropdown-toggle>Notebook <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="javascript:void(0);" ng-click="navbar.websocketMsgSrv.createNotebook()"><i class="fa fa-plus"></i> Create new note</a></li>
             <li class="divider"></li>


### PR DESCRIPTION
Fix the issue that tooltip doesn't show by forcing angular version to 1.2.x.
angular-bootstrap doesn't support angular 1.3 for now.
Also downgraded ng-sortable to 1.1.6 since current one requires angular 1.3.
