### PR TITLE
Hive Interpreter: first column name is always prefixed with null

### DIFF
--- a/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
+++ b/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
@@ -120,7 +120,7 @@ public class HiveInterpreter extends Interpreter {
         msg = new StringBuilder();
       }
       else {
-        msg = new StringBuilder("%table " + msg);
+        msg = new StringBuilder("%table ");
       }
       ResultSet res = currentStatement.executeQuery(sql);
       try {


### PR DESCRIPTION
minor bugfix