### PR TITLE
[ZEPPELIN-49] Interpreter.getProperty returns wrong value

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -156,7 +156,7 @@ public abstract class Interpreter {
       }
     }
 
-    return property;
+    return p;
   }
 
   public String getProperty(String key) {


### PR DESCRIPTION
- Fixed to return p, not property