### PR TITLE
ZEPPELIN-54: check for negative ms

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -574,7 +574,7 @@ angular.module('zeppelinWebApp')
   $scope.getExecutionTime = function() {
     var pdata = $scope.paragraph;
     var timeMs = Date.parse(pdata.dateFinished) - Date.parse(pdata.dateStarted);
-    if (isNaN(timeMs)) {
+    if (isNaN(timeMs) || timeMs < 0) {
       return '&nbsp;';
     }
     return 'Took ' + (timeMs/1000) + ' seconds';


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/ZEPPELIN-54 -- check for negative ms, as well as NaN.