### PR TITLE
Fix typo in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -893,7 +893,7 @@
         </configuration>
         <executions>
           <execution>
-            <id>covertura</id>
+            <id>cobertura</id>
             <phase>package</phase>
             <goals>
               <goal>cobertura</goal>


### PR DESCRIPTION
The name of the plugin is "co[b]ertura", not "co[v]ertura"