### PR TITLE
Fixes a typo in conf_dir check

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -29,7 +29,7 @@ function usage() {
 if [[ "$1" == "--config" ]]; then
   shift
   conf_dir="$1"
-  if [[ ! -d "{$conf_dir}" ]]; then
+  if [[ ! -d "${conf_dir}" ]]; then
     echo "ERROR : ${conf_dir} is not a directory"
     echo ${USAGE}
     exit 1


### PR DESCRIPTION
bin/zeppelin.sh checks for conf_dir's existence. There's a typo as {$config_dir}.