### PR TITLE
ZEPPELIN-59 fix interpreter restart

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -79,7 +79,6 @@ public class RemoteInterpreter extends Interpreter {
       String interpreterPath,
       Map<String, String> env) {
     super(property);
-
     this.className = className;
     this.interpreterRunner = interpreterRunner;
     this.interpreterPath = interpreterPath;
@@ -325,16 +324,18 @@ public class RemoteInterpreter extends Interpreter {
     super.setInterpreterGroup(interpreterGroup);
 
     synchronized (interpreterGroupReference) {
-      if (!interpreterGroupReference
+      if (interpreterGroupReference
           .containsKey(getInterpreterGroupKey(interpreterGroup))) {
-        interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
-            new RemoteInterpreterProcess(interpreterRunner,
-                interpreterPath, env, interpreterContextRunnerPool));
-
-        logger.info("setInterpreterGroup = "
-            + getInterpreterGroupKey(interpreterGroup) + " class=" + className
-            + ", path=" + interpreterPath);
+        interpreterGroupReference.remove(getInterpreterGroupKey(interpreterGroup));
       }
+
+      interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
+          new RemoteInterpreterProcess(interpreterRunner,
+              interpreterPath, env, interpreterContextRunnerPool));
+
+      logger.info("setInterpreterGroup = "
+          + getInterpreterGroupKey(interpreterGroup) + " class=" + className
+          + ", path=" + interpreterPath);
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
@@ -118,6 +118,9 @@ public class RemoteScheduler implements Scheduler {
 
   @Override
   public void submit(Job job) {
+    if (terminate) {
+      throw new RuntimeException("Scheduler already terminated");
+    }
     job.setStatus(Status.PENDING);
 
     synchronized (queue) {


### PR DESCRIPTION
From some point, interpreter restart button stops interpreter but does not bringing up again. 
This PR fixes the problem and adds test for it. https://issues.apache.org/jira/browse/ZEPPELIN-59

Ready to merge.