### PR TITLE
Fix process creation behavior

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -324,11 +324,11 @@ public class RemoteInterpreter extends Interpreter {
     super.setInterpreterGroup(interpreterGroup);
 
     synchronized (interpreterGroupReference) {
-      if (!interpreterGroupReference
-          .containsKey(getInterpreterGroupKey(interpreterGroup))
-          || (!interpreterGroupReference.get(
-              getInterpreterGroupKey(interpreterGroup)).isRunning() && interpreterGroupReference
-              .get(getInterpreterGroupKey(interpreterGroup)).getPort() > 0)) {
+      RemoteInterpreterProcess intpProcess = interpreterGroupReference
+          .get(getInterpreterGroupKey(interpreterGroup));
+
+      // when interpreter process is not created or terminated
+      if (intpProcess == null || (!intpProcess.isRunning() && intpProcess.getPort() > 0)) {
         interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
             new RemoteInterpreterProcess(interpreterRunner,
                 interpreterPath, env, interpreterContextRunnerPool));

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -324,18 +324,19 @@ public class RemoteInterpreter extends Interpreter {
     super.setInterpreterGroup(interpreterGroup);
 
     synchronized (interpreterGroupReference) {
-      if (interpreterGroupReference
-          .containsKey(getInterpreterGroupKey(interpreterGroup))) {
-        interpreterGroupReference.remove(getInterpreterGroupKey(interpreterGroup));
+      if (!interpreterGroupReference
+          .containsKey(getInterpreterGroupKey(interpreterGroup))
+          || (!interpreterGroupReference.get(
+              getInterpreterGroupKey(interpreterGroup)).isRunning() && interpreterGroupReference
+              .get(getInterpreterGroupKey(interpreterGroup)).getPort() > 0)) {
+        interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
+            new RemoteInterpreterProcess(interpreterRunner,
+                interpreterPath, env, interpreterContextRunnerPool));
+
+        logger.info("setInterpreterGroup = "
+            + getInterpreterGroupKey(interpreterGroup) + " class=" + className
+            + ", path=" + interpreterPath);
       }
-
-      interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
-          new RemoteInterpreterProcess(interpreterRunner,
-              interpreterPath, env, interpreterContextRunnerPool));
-
-      logger.info("setInterpreterGroup = "
-          + getInterpreterGroupKey(interpreterGroup) + " class=" + className
-          + ", path=" + interpreterPath);
     }
   }
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -457,4 +457,25 @@ public class RemoteInterpreterTest {
 
     intpA.close();
   }
+
+  @Test
+  public void testProcessCreation() {
+    Properties p = new Properties();
+
+    RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpA.setInterpreterGroup(intpGroup);
+    RemoteInterpreterProcess processA = intpA.getInterpreterProcess();
+
+    intpA.setInterpreterGroup(new InterpreterGroup(intpA.getInterpreterGroup().getId()));
+    RemoteInterpreterProcess processB = intpA.getInterpreterProcess();
+
+    assertEquals(processA.hashCode(), processB.hashCode());
+  }
 }


### PR DESCRIPTION
#52 introduces new side effect around creation of interpreter process.
As a result, some functions, such as 'z.run(2)' wouldn't able to run.

This includes fix and unit test.