### PR TITLE
#64 Force opacity 0 in .ace_text-input.ace_composition

### DIFF
--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -222,6 +222,11 @@
   z-index:auto !important;
 }
 
+/** Force opacity:0 to textarea in writing texts **/
+.ace_text-input.ace_composition {
+ opacity: 0 !important;
+}
+
 #main .emacs-mode .ace_cursor {
   background-color:#C0C0C0!important;
   border: none !important;


### PR DESCRIPTION
Force opacity 0 in ace_composition.
This is to prevent the character collapse in writing texts in non-English language using IME.