### PR TITLE
Add Infinite scrollbar for paragraphs

### DIFF
--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -109,6 +109,7 @@ limitations under the License.
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/json3/lib/json3.js"></script>
+    <script src="bower_components/lodash/lodash.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
@@ -136,6 +137,7 @@ limitations under the License.
     <script src="bower_components/angular-elastic-input/dist/angular-elastic-input.min.js"></script>
     <script src="bower_components/angular-xeditable/dist/js/xeditable.js"></script>
     <script src="bower_components/highlightjs/highlight.pack.js"></script>
+    <script src="bower_components/ngInfiniteScroll/build/ng-infinite-scroll.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:js({.tmp,app}) scripts/scripts.js -->

--- a/zeppelin-web/app/scripts/app.js
+++ b/zeppelin-web/app/scripts/app.js
@@ -89,7 +89,8 @@ angular
     'ngDragDrop',
     'monospaced.elastic',
     'puElasticInput',
-    'xeditable'
+    'xeditable',
+    'infinite-scroll'
   ])
   .filter('breakFilter', function() {
     return function (text) {
@@ -122,5 +123,12 @@ angular
       });
   });
 
+  angular.isUndefinedOrNull = function (val) {
+    return angular.isUndefined(val) || val === null;
+  };
 
+
+  angular.isBlanck = function (val) {
+    return angular.isUndefinedOrNull(val) || val === '';
+  };
 

--- a/zeppelin-web/app/scripts/controllers/notebook.js
+++ b/zeppelin-web/app/scripts/controllers/notebook.js
@@ -25,6 +25,10 @@
  */
 angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $route, $routeParams, $location, $rootScope, $http) {
   $scope.note = null;
+  /** Collection of paragraphs that will be diplayed, will populate paragraphs from note.paragraphs.*/
+  $scope.notebookParagraphs = [];
+  /** Number of paragraphs that will be displayed by default. */
+  var minimumOfParagraphs = 6;
   $scope.showEditor = false;
   $scope.editorToggled = false;
   $scope.tableToggled = false;
@@ -65,6 +69,31 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   };
 
   initNotebook();
+  
+  /** Function to load more paragraphs. */
+  $scope.loadMoreParagraph = function() {
+    var sizeOfCurrentParagraphDisplay = $scope.notebookParagraphs.length;
+    var sizeOfParagraphtoDisplay = sizeOfCurrentParagraphDisplay + 6;
+
+    if (angular.isUndefinedOrNull($scope.note) || angular.isUndefinedOrNull($scope.note.paragraphs)) {
+      return;
+    }
+
+    if (sizeOfParagraphtoDisplay >= $scope.note.paragraphs.length) {
+      sizeOfParagraphtoDisplay = $scope.note.paragraphs.length;
+    }
+
+    if(sizeOfCurrentParagraphDisplay >= sizeOfParagraphtoDisplay) {
+      return;
+    }
+
+    while (sizeOfCurrentParagraphDisplay <= sizeOfParagraphtoDisplay) {
+      if (!angular.isUndefinedOrNull($scope.note.paragraphs[sizeOfCurrentParagraphDisplay])) {
+        $scope.notebookParagraphs.push($scope.note.paragraphs[sizeOfCurrentParagraphDisplay]);
+      }
+      sizeOfCurrentParagraphDisplay++;
+    }
+  };
 
   /** Remove the note and go back tot he main page */
   /** TODO(anthony): In the nearly future, go back to the main page and telle to the dude that the note have been remove */
@@ -167,6 +196,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
     if ($scope.note === null) {
       $scope.note = note;
+      $scope.notebookParagraphs = _.take($scope.note.paragraphs, minimumOfParagraphs);
     } else {
       updateNote(note);
     }

--- a/zeppelin-web/app/views/notebooks.html
+++ b/zeppelin-web/app/views/notebooks.html
@@ -154,17 +154,19 @@ limitations under the License.
   <div class="note-jump"></div>
 
   <!-- Include the paragraphs according to the note -->
-  <div id="{{currentParagraph.id}}_paragraphColumn_main"
-       ng-repeat="currentParagraph in note.paragraphs"
-       ng-controller="ParagraphCtrl"
-       ng-Init="init(currentParagraph)"
-       ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       class="paragraph-col">
-    <div id="{{currentParagraph.id}}_paragraphColumn"
-         ng-include src="'views/paragraph.html'"
-         ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused}"
-         ng-hide="currentParagraph.config.tableHide && viewOnly">
+  <div infinite-scroll='loadMoreParagraph()' infinite-scroll-distance='0'>
+    <div id="{{currentParagraph.id}}_paragraphColumn_main"
+         ng-repeat="currentParagraph in notebookParagraphs track by currentParagraph.id"
+         ng-controller="ParagraphCtrl"
+         ng-Init="init(currentParagraph)"
+         ng-class="columnWidthClass(currentParagraph.config.colWidth)"
+         class="paragraph-col">
+      <div id="{{currentParagraph.id}}_paragraphColumn"
+           ng-include src="'views/paragraph.html'"
+           ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused}"
+           ng-hide="currentParagraph.config.tableHide && viewOnly">
+      </div>
     </div>
+    <div style="clear:both"></div>
   </div>
-  <div style="clear:both;height:10px"></div>
 </div>

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -23,7 +23,8 @@
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
     "angular-xeditable" : "0.1.8",
-    "highlightjs": "~8.4.0"
+    "highlightjs": "~8.4.0",
+    "ngInfiniteScroll": "1.0.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "angular": "1.3.8",
     "json3": "~3.3.1",
+    "lodash": "3.3.1",
     "es5-shim": "~3.1.0",
     "bootstrap": "~3.2.0",
     "angular-cookies": "1.3.8",


### PR DESCRIPTION
Hi,

When you have a lot of paragraphs in your notebook, it will take a while to load, because we are rendering (via ng-repeat) every paragraphs. This is annoying and ressources consuming.

This PR is about adding a infinitescrollbar that will load paragraphs progressively so the notebook will render faster and add elements (paragraphs) when the user will scroll.

By default, 12 paragraphs will be loaded and then they 6 by 6 (this can be change).