### PR TITLE
Fixed pyspark indentation issue - take 2

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -85,9 +85,7 @@ while True :
   try:
     stmts = req.statements().split("\n")
     jobGroup = req.jobGroup()
-    single = None
-    incomplete = None
-    compiledCode = None
+    final_code = None
 
     for s in stmts:
       if s == None or len(s.strip()) == 0:
@@ -97,38 +95,13 @@ while True :
       if s.strip().startswith("#"):
         continue
 
-      if s[0] != " " and s[0] != "\t":
-        if incomplete != None:
-          raise incomplete
-
-        if compiledCode != None:
-          sc.setJobGroup(jobGroup, "Zeppelin")
-          eval(compiledCode)
-          compiledCode = None
-          single = None
-          incomplete = None
-
-      if single == None:
-        single = s
+      if final_code:
+        final_code += "\n" + s
       else:
-        single += "\n" + s
+        final_code = s
 
-      try :
-        compiledCode = compile(single, "<string>", "single")
-        incomplete = None
-      except SyntaxError as e:
-        if str(e).startswith("unexpected EOF while parsing") :
-          # incomplete expression
-          incomplete = e
-          continue
-        else :
-          # actual error
-          raise e
-
-    if incomplete != None:
-      raise incomplete
-
-    if compiledCode != None:
+    if final_code:
+      compiledCode = compile(final_code, "<string>", "exec")
       sc.setJobGroup(jobGroup, "Zeppelin")
       eval(compiledCode)
 
@@ -137,4 +110,3 @@ while True :
     intp.setStatementsFinished(str(sys.exc_info()), True)
 
   output.reset()
-    


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/ZEPPELIN-34, should allow:
```
%pyspark
if True:
    print "one"
else:
    print "two"
    
def test_func(text):
    for i in range(1, 10):
        print text + '-' + str(i)
test_func('fixed')
```