### PR TITLE
ZEPPELIN-69 frontend webapp built once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -888,7 +888,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <formats>
             <format>html</format>
@@ -1098,15 +1097,18 @@
             </execution>
           </executions>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>2.13</version>
         </plugin>
+
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>2.8</version>
         </plugin>
+
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
@@ -1122,14 +1124,22 @@
             </excludes> <includes> <include>**/itest/**</include> </includes> </configuration>
             </execution> </executions> -->
         </plugin>
+
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.4</version>
         </plugin>
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>1.2.1</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>2.7</version>
         </plugin>
 
         <plugin>
@@ -1145,7 +1155,6 @@
             </filesets>
           </configuration>
         </plugin>
-
 
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -74,6 +74,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>0.0.23</version>
         <executions>
+
           <execution>
             <id>install node and npm</id>
             <goals>
@@ -90,10 +91,6 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <arguments>install</arguments>
-            </configuration>
           </execution>
           
           <execution>
@@ -101,7 +98,6 @@
             <goals>
               <goal>bower</goal>
             </goals>
-            <phase>generate-resources</phase>
             <configuration>
               <arguments>--allow-root install</arguments>
             </configuration>
@@ -112,15 +108,33 @@
             <goals>
               <goal>grunt</goal>
             </goals>
-            <phase>generate-resources</phase>
+
             <configuration>
               <!-- TODO(anthonycorbacho): remove force once all JSHint are fixed! -->
               <arguments>--no-color --force</arguments>
             </configuration>
           </execution>
-          
         </executions>
       </plugin>
+
+      <!--
+          Disabling test report generation as it forks the lifecycle
+          and results in https://issues.apache.org/jira/browse/ZEPPELIN-69
+
+          There is no better way to do it, as per
+          http://jira.codehaus.org/browse/MCOBERTURA-154
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>cobertura</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-69

Disabling test report generation for ```zeppelin-web``` using [cobertura plugin](http://mojo.codehaus.org/cobertura-maven-plugin/check-mojo.html) as it forks the lifecycle and makes everything run twice

