### PR TITLE
[ZEPPELIN-73][HOTFIX-1]: Fix various Maven warnings in the poms

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -30,9 +30,6 @@
     "angular-scenario": "1.3.8"
   },
   "appPath": "app",
-  "resolutions": {
-    "perfect-scrollbar": "~0.5.4"
-  },
   "overrides": {
     "ace-builds": {
         "main": ["src-noconflict/ace.js",

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -33,5 +33,9 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:apache/incubator-zeppelin.git"
   }
 }


### PR DESCRIPTION
Updated the `zeppelin-web/pom.xml` file to further remove various warnings as noted [here](https://issues.apache.org/jira/browse/ZEPPELIN-73?focusedCommentId=14537058&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14537058).