### PR TITLE
[ZEPPELIN-23] Set version of default spark interpreter build profile from 1.1 to 1.3

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -21,6 +21,7 @@ log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n
 
+log4j.appender.dailyfile.DatePattern=.yyyy-MM-dd
 log4j.appender.dailyfile.Threshold = INFO
 log4j.appender.dailyfile = org.apache.log4j.DailyRollingFileAppender
 log4j.appender.dailyfile.File = ${zeppelin.log.file}

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
   </modules>
 
   <properties>
-    <spark.version>1.3.0</spark.version>
+    <spark.version>1.1.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
     <scala.macros.version>2.0.1</scala.macros.version>
@@ -1308,11 +1308,14 @@
 
     <profile>
       <id>spark-1.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
       </dependencies>
       <properties>
         <akka.version>2.3.4-spark</akka.version>
-        <spark.version>1.3.0</spark.version>
+        <spark.version>1.3.1</spark.version>
         <mesos.version>0.21.0</mesos.version>
         <hbase.version>0.98.7</hbase.version>
         <hbase.artifact>hbase</hbase.artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
   </modules>
 
   <properties>
-    <spark.version>1.1.1</spark.version>
+    <spark.version>1.3.0</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
     <scala.macros.version>2.0.1</scala.macros.version>

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -45,6 +45,21 @@ public class SparkInterpreterTest {
   private InterpreterContext context;
   private File tmpDir;
 
+
+  /**
+   * Get spark version number as a numerical value.
+   * eg. 1.1.x => 11, 1.2.x => 12, 1.3.x => 13 ...
+   */
+  public static int getSparkVersionNumber() {
+    if (repl == null) {
+      return 0;
+    }
+
+    String[] split = repl.getSparkContext().version().split(".");
+    int version = Integer.parseInt(split[0]) + Integer.parseInt(split[1]);
+    return version;
+  }
+
   @Before
   public void setUp() throws Exception {
     tmpDir = new File(System.getProperty("java.io.tmpdir") + "/ZeppelinLTest_" + System.currentTimeMillis());
@@ -52,18 +67,19 @@ public class SparkInterpreterTest {
 
     tmpDir.mkdirs();
 
-	  if (repl == null) {
-		  Properties p = new Properties();
+    if (repl == null) {
+      Properties p = new Properties();
 
-	    repl = new SparkInterpreter(p);
-  	  repl.open();
-	  }
+      repl = new SparkInterpreter(p);
+      repl.open();
+    }
 
-	  InterpreterGroup intpGroup = new InterpreterGroup();
-    context = new InterpreterContext("id", "title", "text", new HashMap<String, Object>(), new GUI(),
-        new AngularObjectRegistry(intpGroup.getId(), null),
+    InterpreterGroup intpGroup = new InterpreterGroup();
+    context = new InterpreterContext("id", "title", "text",
+        new HashMap<String, Object>(), new GUI(), new AngularObjectRegistry(
+            intpGroup.getId(), null),
         new LinkedList<InterpreterContextRunner>());
-	}
+  }
 
   @After
   public void tearDown() throws Exception {
@@ -83,52 +99,55 @@ public class SparkInterpreterTest {
     }
   }
 
-	@Test
-	public void testBasicIntp() {
-		assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("val a = 1\nval b = 2", context).code());
+  @Test
+  public void testBasicIntp() {
+    assertEquals(InterpreterResult.Code.SUCCESS,
+        repl.interpret("val a = 1\nval b = 2", context).code());
 
-		// when interpret incomplete expression
-		InterpreterResult incomplete = repl.interpret("val a = \"\"\"", context);
-		assertEquals(InterpreterResult.Code.INCOMPLETE, incomplete.code());
-		assertTrue(incomplete.message().length()>0); // expecting some error message
-		/*
-		assertEquals(1, repl.getValue("a"));
-		assertEquals(2, repl.getValue("b"));
-		repl.interpret("val ver = sc.version");
-		assertNotNull(repl.getValue("ver"));
-		assertEquals("HELLO\n", repl.interpret("println(\"HELLO\")").message());
-		*/
-	}
+    // when interpret incomplete expression
+    InterpreterResult incomplete = repl.interpret("val a = \"\"\"", context);
+    assertEquals(InterpreterResult.Code.INCOMPLETE, incomplete.code());
+    assertTrue(incomplete.message().length() > 0); // expecting some error
+                                                   // message
+    /*
+     * assertEquals(1, repl.getValue("a")); assertEquals(2, repl.getValue("b"));
+     * repl.interpret("val ver = sc.version");
+     * assertNotNull(repl.getValue("ver")); assertEquals("HELLO\n",
+     * repl.interpret("println(\"HELLO\")").message());
+     */
+  }
 
-	@Test
-	public void testEndWithComment() {
-		assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("val c=1\n//comment", context).code());
-	}
+  @Test
+  public void testEndWithComment() {
+    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("val c=1\n//comment", context).code());
+  }
 
-	@Test
-	public void testSparkSql(){
-		repl.interpret("case class Person(name:String, age:Int)\n", context);
-		repl.interpret("val people = sc.parallelize(Seq(Person(\"moon\", 33), Person(\"jobs\", 51), Person(\"gates\", 51), Person(\"park\", 34)))\n", context);
-		assertEquals(Code.SUCCESS, repl.interpret("people.take(3)", context).code());
+  @Test
+  public void testSparkSql(){
+    repl.interpret("case class Person(name:String, age:Int)\n", context);
+    repl.interpret("val people = sc.parallelize(Seq(Person(\"moon\", 33), Person(\"jobs\", 51), Person(\"gates\", 51), Person(\"park\", 34)))\n", context);
+    assertEquals(Code.SUCCESS, repl.interpret("people.take(3)", context).code());
 
-		// create new interpreter
-		Properties p = new Properties();
-		SparkInterpreter repl2 = new SparkInterpreter(p);
-		repl2.open();
 
-		repl.interpret("case class Man(name:String, age:Int)", context);
-		repl.interpret("val man = sc.parallelize(Seq(Man(\"moon\", 33), Man(\"jobs\", 51), Man(\"gates\", 51), Man(\"park\", 34)))", context);
-		assertEquals(Code.SUCCESS, repl.interpret("man.take(3)", context).code());
-		repl2.getSparkContext().stop();
-	}
+    if (getSparkVersionNumber() <= 11) { // spark 1.2 or later does not allow create multiple SparkContext in the same jvm by default.
+    // create new interpreter
+    Properties p = new Properties();
+    SparkInterpreter repl2 = new SparkInterpreter(p);
+    repl2.open();
 
-	@Test
-	public void testReferencingUndefinedVal(){
-		InterpreterResult result = repl.interpret("def category(min: Int) = {" +
-				       "    if (0 <= value) \"error\"" +
-                       "}", context);
-		assertEquals(Code.ERROR, result.code());
-	}
+    repl.interpret("case class Man(name:String, age:Int)", context);
+    repl.interpret("val man = sc.parallelize(Seq(Man(\"moon\", 33), Man(\"jobs\", 51), Man(\"gates\", 51), Man(\"park\", 34)))", context);
+    assertEquals(Code.SUCCESS, repl.interpret("man.take(3)", context).code());
+    repl2.getSparkContext().stop();
+    }
+  }
+
+  @Test
+  public void testReferencingUndefinedVal() {
+    InterpreterResult result = repl.interpret("def category(min: Int) = {"
+        + "    if (0 <= value) \"error\"" + "}", context);
+    assertEquals(Code.ERROR, result.code());
+  }
 
   @Test
   public void testZContextDependencyLoading() {

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -36,81 +36,115 @@ import org.junit.Test;
 
 public class SparkSqlInterpreterTest {
 
-	private SparkSqlInterpreter sql;
+  private SparkSqlInterpreter sql;
   private SparkInterpreter repl;
   private InterpreterContext context;
   private InterpreterGroup intpGroup;
 
-	@Before
-	public void setUp() throws Exception {
-		Properties p = new Properties();
+  @Before
+  public void setUp() throws Exception {
+    Properties p = new Properties();
 
-		if (repl == null) {
+    if (repl == null) {
 
-		  if (SparkInterpreterTest.repl == null) {
-		    repl = new SparkInterpreter(p);
-		    repl.open();
-		    SparkInterpreterTest.repl = repl;
-		  } else {
-		    repl = SparkInterpreterTest.repl;
-		  }
+      if (SparkInterpreterTest.repl == null) {
+        repl = new SparkInterpreter(p);
+        repl.open();
+        SparkInterpreterTest.repl = repl;
+      } else {
+        repl = SparkInterpreterTest.repl;
+      }
 
-  		sql = new SparkSqlInterpreter(p);
+    sql = new SparkSqlInterpreter(p);
 
-  		intpGroup = new InterpreterGroup();
-		  intpGroup.add(repl);
-		  intpGroup.add(sql);
-		  sql.setInterpreterGroup(intpGroup);
-		  sql.open();
-		}
-		context = new InterpreterContext("id", "title", "text", new HashMap<String, Object>(), new GUI(),
-		    new AngularObjectRegistry(intpGroup.getId(), null),
-		    new LinkedList<InterpreterContextRunner>());
-	}
+    intpGroup = new InterpreterGroup();
+      intpGroup.add(repl);
+      intpGroup.add(sql);
+      sql.setInterpreterGroup(intpGroup);
+      sql.open();
+    }
+    context = new InterpreterContext("id", "title", "text", new HashMap<String, Object>(), new GUI(),
+        new AngularObjectRegistry(intpGroup.getId(), null),
+        new LinkedList<InterpreterContextRunner>());
+  }
 
-	@After
-	public void tearDown() throws Exception {
-	}
+  @After
+  public void tearDown() throws Exception {
+  }
 
-	@Test
-	public void test() {
-		repl.interpret("case class Test(name:String, age:Int)", context);
-		repl.interpret("val test = sc.parallelize(Seq(Test(\"moon\", 33), Test(\"jobs\", 51), Test(\"gates\", 51), Test(\"park\", 34)))", context);
-		repl.interpret("test.registerAsTable(\"test\")", context);
+  boolean isDataFrameSupported() {
+    return SparkInterpreterTest.getSparkVersionNumber() >= 13;
+  }
 
-		InterpreterResult ret = sql.interpret("select name, age from test where age < 40", context);
-		assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
-		assertEquals(Type.TABLE, ret.type());
-		assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
+  @Test
+  public void test() {
+    repl.interpret("case class Test(name:String, age:Int)", context);
+    repl.interpret("val test = sc.parallelize(Seq(Test(\"moon\", 33), Test(\"jobs\", 51), Test(\"gates\", 51), Test(\"park\", 34)))", context);
+    if (isDataFrameSupported()) {
+      repl.interpret("test.toDF.registerTempTable(\"test\")", context);
+    } else {
+      repl.interpret("test.registerTempTable(\"test\")", context);
+    }
 
-	  assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select wrong syntax", context).code());
-		assertEquals(InterpreterResult.Code.SUCCESS, sql.interpret("select case when name==\"aa\" then name else name end from people", context).code());
-	}
+    InterpreterResult ret = sql.interpret("select name, age from test where age < 40", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(Type.TABLE, ret.type());
+    assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
 
-	@Test
-	public void testStruct(){
-		repl.interpret("case class Person(name:String, age:Int)", context);
-		repl.interpret("case class People(group:String, person:Person)", context);
-		repl.interpret("val gr = sc.parallelize(Seq(People(\"g1\", Person(\"moon\",33)), People(\"g2\", Person(\"sun\",11))))", context);
-		repl.interpret("gr.registerAsTable(\"gr\")", context);
-		InterpreterResult ret = sql.interpret("select * from gr", context);
-		assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
-	}
+    assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select wrong syntax", context).code());
+    assertEquals(InterpreterResult.Code.SUCCESS, sql.interpret("select case when name==\"aa\" then name else name end from test", context).code());
+  }
 
-	@Test
-	public void test_null_value_in_row() {
-		repl.interpret("import org.apache.spark.sql._", context);
-		repl.interpret("def toInt(s:String): Any = {try { s.trim().toInt} catch {case e:Exception => null}}", context);
-		repl.interpret("val schema = StructType(Seq(StructField(\"name\", StringType, false),StructField(\"age\" , IntegerType, true),StructField(\"other\" , StringType, false)))", context);
-		repl.interpret("val csv = sc.parallelize(Seq((\"jobs, 51, apple\"), (\"gates, , microsoft\")))", context);
-		repl.interpret("val raw = csv.map(_.split(\",\")).map(p => Row(p(0),toInt(p(1)),p(2)))", context);
-		repl.interpret("val people = z.sqlContext.applySchema(raw, schema)", context);
-		repl.interpret("people.registerTempTable(\"people\")", context);
+  @Test
+  public void testStruct() {
+    repl.interpret("case class Person(name:String, age:Int)", context);
+    repl.interpret("case class People(group:String, person:Person)", context);
+    repl.interpret(
+        "val gr = sc.parallelize(Seq(People(\"g1\", Person(\"moon\",33)), People(\"g2\", Person(\"sun\",11))))",
+        context);
+    if (isDataFrameSupported()) {
+      repl.interpret("gr.toDF.registerTempTable(\"gr\")", context);
+    } else {
+      repl.interpret("gr.registerTempTable(\"gr\")", context);
+    }
 
-		InterpreterResult ret = sql.interpret("select name, age from people where name = 'gates'", context);
-		System.err.println("RET=" + ret.message());
-		assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
-		assertEquals(Type.TABLE, ret.type());
-		assertEquals("name\tage\ngates\tnull\n", ret.message());
-	}
+    InterpreterResult ret = sql.interpret("select * from gr", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+  }
+
+  @Test
+  public void test_null_value_in_row() {
+    repl.interpret("import org.apache.spark.sql._", context);
+    if (isDataFrameSupported()) {
+      repl.interpret(
+          "import org.apache.spark.sql.types.{StructType,StructField,StringType,IntegerType}",
+          context);
+    }
+    repl.interpret(
+        "def toInt(s:String): Any = {try { s.trim().toInt} catch {case e:Exception => null}}",
+        context);
+    repl.interpret(
+        "val schema = StructType(Seq(StructField(\"name\", StringType, false),StructField(\"age\" , IntegerType, true),StructField(\"other\" , StringType, false)))",
+        context);
+    repl.interpret(
+        "val csv = sc.parallelize(Seq((\"jobs, 51, apple\"), (\"gates, , microsoft\")))",
+        context);
+    repl.interpret(
+        "val raw = csv.map(_.split(\",\")).map(p => Row(p(0),toInt(p(1)),p(2)))",
+        context);
+    repl.interpret("val people = z.sqlContext.applySchema(raw, schema)",
+        context);
+    if (isDataFrameSupported()) {
+      repl.interpret("people.toDF.registerTempTable(\"people\")", context);
+    } else {
+      repl.interpret("people.registerTempTable(\"people\")", context);
+    }
+
+    InterpreterResult ret = sql.interpret(
+        "select name, age from people where name = 'gates'", context);
+    System.err.println("RET=" + ret.message());
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(Type.TABLE, ret.type());
+    assertEquals("name\tage\ngates\tnull\n", ret.message());
+  }
 }


### PR DESCRIPTION
I updated the version of spark used by default throughout the dependency listing to be 1.3.0 (to match the version used in the 1.3 profile).