### PR TITLE
Tajo jdbc thrift interpreters

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -66,7 +66,7 @@
 
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.jdbc.TajoInterpreter</value>
   <description>Comma separated interpreter configurations. First interpreter become a default</description>
 </property>
 

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -66,7 +66,7 @@
 
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.jdbc.TajoInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.jdbc.TajoInterpreter,org.apache.zeppelin.tajo.thrift.TajoInterpreter</value>
   <description>Comma separated interpreter configurations. First interpreter become a default</description>
 </property>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <module>angular</module>
     <module>shell</module>
     <module>hive</module>
-    <module>tajo</module>
+    <module>tajo-jdbc</module>
     <module>zeppelin-web</module>
     <module>zeppelin-server</module>
     <module>zeppelin-distribution</module>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>shell</module>
     <module>hive</module>
     <module>tajo-jdbc</module>
+    <module>tajo-thrift</module>
     <module>zeppelin-web</module>
     <module>zeppelin-server</module>
     <module>zeppelin-distribution</module>

--- a/tajo-jdbc/pom.xml
+++ b/tajo-jdbc/pom.xml
@@ -25,10 +25,10 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-tajo</artifactId>
+  <artifactId>zeppelin-tajo-jdbc</artifactId>
   <packaging>jar</packaging>
   <version>0.5.0-incubating-SNAPSHOT</version>
-  <name>Zeppelin: Tajo interpreter</name>
+  <name>Zeppelin: Tajo JDBC interpreter</name>
   <url>http://www.apache.org</url>
 
   <properties>
@@ -100,7 +100,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/../../interpreter/tajo</outputDirectory>
+              <outputDirectory>${project.build.directory}/../../interpreter/tajo-jdbc</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
               <overWriteIfNewer>true</overWriteIfNewer>
@@ -114,7 +114,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/../../interpreter/tajo</outputDirectory>
+              <outputDirectory>${project.build.directory}/../../interpreter/tajo-jdbc</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>false</overWriteSnapshots>
               <overWriteIfNewer>true</overWriteIfNewer>

--- a/tajo-jdbc/src/main/java/org/apache/zeppelin/tajo/jdbc/TajoInterpreter.java
+++ b/tajo-jdbc/src/main/java/org/apache/zeppelin/tajo/jdbc/TajoInterpreter.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import java.sql.*;
 import java.util.List;
@@ -45,8 +45,8 @@ public class TajoInterpreter extends Interpreter {
 
   static {
     Interpreter.register(
-      "tajo",
-      "tajo",
+      "tsqlj",
+      "tajo-jdbc",
       TajoInterpreter.class.getName(),
       new InterpreterPropertyBuilder()
         .add(TAJO_JDBC_URI, "jdbc:tajo://localhost:26002/default", "The URL for TajoServer.")

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TajoInterpreterTest.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TajoInterpreterTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import com.google.gson.JsonParseException;
 import org.apache.tajo.jdbc.TajoDriver;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterConnection.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterConnection.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 
 import java.sql.*;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterDatabaseMetaData.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterDatabaseMetaData.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterResultSet.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterResultSet.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import java.math.BigDecimal;
 import java.sql.*;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterResultSetMetaData.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterResultSetMetaData.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterStatement.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterStatement.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 
 import java.sql.*;

--- a/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterTajoInterpreter.java
+++ b/tajo-jdbc/src/test/java/org/apache/zeppelin/tajo/jdbc/TesterTajoInterpreter.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.tajo;
+package org.apache.zeppelin.tajo.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/tajo-thrift/README.md
+++ b/tajo-thrift/README.md
@@ -1,0 +1,10 @@
+# Tajo interpreter (thrift version)
+
+This is Tajo interpreter that is using thrift interface
+
+To build this branch, build Tajo thriftserver version https://github.com/jerryjung/tajo/tree/thriftserver first and install artifact into local maven repository (mvn install)
+And then you can build Zeppelin.
+
+Tajo thrift driver keyword is %tsql
+
+

--- a/tajo-thrift/pom.xml
+++ b/tajo-thrift/pom.xml
@@ -31,6 +31,10 @@
   <name>Zeppelin: Tajo Thrift interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 
+  <properties>
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/tajo-thrift/pom.xml
+++ b/tajo-thrift/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zeppelin</artifactId>
+    <groupId>org.apache.zeppelin</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.apache.zeppelin</groupId>
+  <artifactId>zeppelin-tajo-thrift</artifactId>
+  <packaging>jar</packaging>
+  <version>0.5.0-SNAPSHOT</version>
+  <name>Zeppelin: Tajo Thrift interpreter</name>
+  <url>http://zeppelin.incubator.apache.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-interpreter</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tajo</groupId>
+      <artifactId>tajo-thrift-server</artifactId>
+      <version>0.11.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>            
+        <executions> 
+          <execution> 
+            <id>enforce</id> 
+            <phase>none</phase> 
+          </execution>
+        </executions>
+      </plugin>
+
+    <plugin>
+    <groupId>org.apache.rat</groupId>
+    <artifactId>apache-rat-plugin</artifactId>
+    <executions>
+        <execution>
+            <phase>none</phase>
+        </execution>
+    </executions>
+    </plugin>
+    
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/tajo-thrift</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/tajo-thrift</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                  <type>${project.packaging}</type>
+                </artifactItem>
+              </artifactItems>              
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tajo-thrift/pom.xml
+++ b/tajo-thrift/pom.xml
@@ -21,13 +21,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.0-incubating-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-tajo-thrift</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.0-SNAPSHOT</version>
+  <version>0.5.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Tajo Thrift interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/tajo-thrift/pom.xml
+++ b/tajo-thrift/pom.xml
@@ -68,6 +68,20 @@
     </dependency>
   </dependencies>
 
+ <repositories>
+    <!-- For unpublished tajo-thrift-server snapshot -->
+    <repository>
+      <id>nflabs public repository</id>
+      <url>https://raw.github.com/NFLabs/mvn-repo/master/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>

--- a/tajo-thrift/src/main/java/org/apache/zeppelin/tajo/thrift/TajoInterpreter.java
+++ b/tajo-thrift/src/main/java/org/apache/zeppelin/tajo/thrift/TajoInterpreter.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.tajo.thrift;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.tajo.conf.TajoConf;
+import org.apache.tajo.thrift.ThriftServerConstants;
+import org.apache.tajo.thrift.client.TajoThriftClient;
+import org.apache.tajo.thrift.generated.TBriefQueryInfo;
+import org.apache.tajo.thrift.generated.TColumn;
+import org.apache.tajo.thrift.generated.TGetQueryStatusResponse;
+import org.apache.tajo.thrift.generated.TSchema;
+import org.apache.tajo.thrift.generated.TTableDesc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.ServiceException;
+
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+
+/**
+ * Tajo interpreter implementation. with thrift protocol support
+ * https://github.com/jerryjung/tajo/tree/thriftserver
+ */
+public class TajoInterpreter extends Interpreter {
+  static {
+    Interpreter.register(
+        "tsqlt",
+        "tajo-thrift",
+        TajoInterpreter.class.getName(),
+        new InterpreterPropertyBuilder()
+          .add("tajo.thrift.server",
+               "localhost:" + ThriftServerConstants.DEFAULT_LISTEN_PORT,
+               "Tajo thrift server address, host:port")
+          .add("tajo.maxResult",
+              "1000",
+               "Maximum number of result to retreive")
+          .build());
+  }
+
+  Logger logger = LoggerFactory.getLogger(TajoInterpreter.class);
+  private TajoThriftClient tajoClient;
+
+
+  public TajoInterpreter(Properties property) {
+    super(property);
+  }
+
+  @Override
+  public void open() {
+    TajoConf conf = new TajoConf();
+    try {
+      tajoClient = new TajoThriftClient(conf, getProperty("tajo.thrift.server"), null);
+    } catch (IOException e) {
+      throw new InterpreterException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    tajoClient.close();
+  }
+
+  private int getMaxResult() {
+    return Integer.parseInt(getProperty("tajo.maxResult"));
+  }
+
+  private String getHelpMessage() {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append("General\n");
+    builder.append("  \\version\t\tshow Tajo version\n");
+    builder.append("  \\?\t\tshow help\n");
+    builder.append("  \\help\t\talias of \\?\n");
+    builder.append("\n");
+    builder.append("Informational\n");
+    builder.append("  \\l\t\tlist databases\n");
+    builder.append("  \\c\t\tshow current database\n");
+    builder.append("  \\c [DBNAME]\t\tconnect to new database\n");
+    builder.append("  \\d\t\tlist tables\n");
+    builder.append("  \\d [TBNAME]\t\tdescribe tables\n");
+
+    return builder.toString();
+  }
+
+  private String listToOutput(List<String> list) {
+    return listToOutput(list, "");
+  }
+
+  private String listToOutput(List<String> list, String defaultValue) {
+    String out = "";
+    if (list == null || list.size() == 0) return defaultValue;
+    for (String l : list) {
+      out += l + "\n";
+    }
+    return out;
+  }
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+    ResultSet result;
+
+    logger.info("interpret function");
+    if (st != null && st.trim().startsWith("\\")) {
+      String tcmd = st.trim();
+      try {
+        if (tcmd.equals("\\l")) {       // list database
+          return new InterpreterResult(
+              Code.SUCCESS,
+              listToOutput(tajoClient.getAllDatabaseNames()));
+        } else if (tcmd.equals("\\c")) {  // show current database
+          return new InterpreterResult(
+              Code.SUCCESS,
+              tajoClient.getCurrentDatabase());
+        } else if (tcmd.startsWith("\\c")) {
+          String dbName = tcmd.split(" ")[1];
+          return new InterpreterResult(
+              Code.SUCCESS,
+              (tajoClient.selectDatabase(dbName) ?
+                  "connected to database " + dbName :
+                  "failed"));
+        } else if (tcmd.equals("\\d")) {  // list tables
+          return new InterpreterResult(
+              Code.SUCCESS,
+              listToOutput(
+                  tajoClient.getTableList(tajoClient.getCurrentDatabase()),
+                  "No Relation Found"));
+        } else if (tcmd.startsWith("\\d")) { // describe tables
+          String tableName = tcmd.split(" ")[1];
+          TTableDesc tdesc = tajoClient.getTableDesc(tableName);
+
+          if (tdesc == null) {
+            return new InterpreterResult(
+                Code.SUCCESS,
+                "no such a table:" + tableName);
+          }
+
+          String out = "";
+          out += "table name: " + tdesc.getTableName() + "\n";
+          out += "table path: " + tdesc.getPath() + "\n";
+          out += "store type: " + tdesc.getStoreType() + "\n";
+          out += "number of rows: " + tdesc.getStats().getNumRows() + "\n";
+          out += "volumne: " + tdesc.getStats().getNumBytes() + " B\n";
+          out += "Options:\n";
+          Map<String, String> meta = tdesc.getTableMeta();
+          if (meta != null) {
+            for (String k : meta.keySet()) {
+              out += k + "\t" + meta.get(k) + "\n";
+            }
+          }
+
+          out += "\n";
+          out += "schema:\n";
+          TSchema schema = tdesc.getSchema();
+          for (TColumn col : schema.getColumns()) {
+            out += col.getSimpleName() + "\t" + col.getDataTypeName() + "\n";
+          }
+          return new InterpreterResult(
+              Code.SUCCESS,
+              out);
+        } else if (tcmd.startsWith("\\set")) {
+          String[] set = tcmd.split(" ");
+          if (set.length != 3) {
+            return new InterpreterResult(
+                Code.SUCCESS,
+                "usage: \\set [[NAME] VALUE]");
+          }
+
+          String name = set[1];
+          String value = set[2];
+
+          if (tajoClient.updateSessionVariable(name, value)) {
+            return new InterpreterResult(
+                Code.SUCCESS,
+                name + " = " + value);
+          } else {
+            return new InterpreterResult(
+                Code.ERROR,
+                "Error");
+          }
+        } else if (tcmd.startsWith("\\unset")) {
+          String[] set = tcmd.split(" ");
+          if (set.length != 2) {
+            return new InterpreterResult(
+                Code.SUCCESS,
+                "usage: \\unset NAME");
+          }
+
+          String name = set[1];
+
+          if (tajoClient.unsetSessionVariable(name)) {
+            return new InterpreterResult(
+                Code.SUCCESS,
+                "unset " + name);
+          } else {
+            return new InterpreterResult(
+                Code.ERROR,
+                "Error");
+          }
+        } else {
+          return new InterpreterResult(
+              Code.SUCCESS,
+              getHelpMessage());
+        }
+      } catch (Exception e) {
+        throw new InterpreterException(e);
+      }
+    }
+
+    try {
+      result = tajoClient.executeQueryAndGetResult(st);
+      // empty result
+      if (result == null) {
+        return new InterpreterResult(Code.SUCCESS, "");
+      }
+
+      String m = "";
+
+      // extract column info
+      ResultSetMetaData md = result.getMetaData();
+      int numColumns = md.getColumnCount();
+
+      if (numColumns == 0) {
+        return new InterpreterResult(Code.SUCCESS, "");
+      }
+
+      for (int i = 1; i <= numColumns; i++) {
+        if (i != 1) {
+          m += "\t";
+        }
+        m += md.getColumnName(i);
+      }
+      m += "\n";
+
+      int maxResult = getMaxResult();
+      int currentRow = 0;
+      String extraMessage = "";
+
+      while (result.next()) {
+
+        if (currentRow == maxResult) {
+          extraMessage = "\n<font color=red>Results are limited by " + maxResult + ".</font>";
+          break;
+        }
+        currentRow++;
+
+        for (int i = 1; i <= numColumns; i++) {
+          if (i != 1) {
+            m += "\t";
+          }
+
+          Object col = result.getObject(i);
+          if (col == null) {
+            m += "\t";
+          } else {
+            m += col.toString();
+          }
+        }
+
+        m += "\n";
+      }
+
+      return new InterpreterResult(Code.SUCCESS, "%table " + m + extraMessage);
+
+    } catch (ServiceException | IOException | SQLException e) {
+      logger.error("Error", e);
+      return new InterpreterResult(Code.ERROR, e.getMessage());
+    }
+
+
+  }
+
+  @Override
+  public void cancel(InterpreterContext context) {
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+
+    return 0;
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    return new LinkedList<String>();
+  }
+
+}

--- a/tajo-thrift/src/main/java/org/apache/zeppelin/tajo/thrift/TajoInterpreter.java
+++ b/tajo-thrift/src/main/java/org/apache/zeppelin/tajo/thrift/TajoInterpreter.java
@@ -311,7 +311,25 @@ public class TajoInterpreter extends Interpreter {
   @Override
   public int getProgress(InterpreterContext context) {
 
-    return 0;
+    int result = 0;
+    logger.info("Getting progress information...");
+    try {
+      List<TBriefQueryInfo> queryList = tajoClient.getQueryList();
+
+      logger.info("\t " + queryList.size() + " queries");
+      if (queryList.isEmpty()) {
+        return result;
+      }
+
+      String queryId = queryList.get(queryList.size() - 1).queryId;
+      TGetQueryStatusResponse query = tajoClient.getQueryStatus(queryId);
+      logger.info("Done! " + query);
+      result = (int) query.progress * 100;
+
+    } catch (Exception e) {
+      logger.error("getProgress failed ", e);
+    }
+    return result;
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -389,7 +389,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         + "org.apache.zeppelin.angular.AngularInterpreter,"
         + "org.apache.zeppelin.shell.ShellInterpreter,"
         + "org.apache.zeppelin.hive.HiveInterpreter,"
-        + "org.apache.zeppelin.tajo.TajoInterpreter"),
+        + "org.apache.zeppelin.tajo.jdbc.TajoInterpreter"),
         ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "interpreter"),
         ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
         ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -389,7 +389,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         + "org.apache.zeppelin.angular.AngularInterpreter,"
         + "org.apache.zeppelin.shell.ShellInterpreter,"
         + "org.apache.zeppelin.hive.HiveInterpreter,"
-        + "org.apache.zeppelin.tajo.jdbc.TajoInterpreter"),
+        + "org.apache.zeppelin.tajo.jdbc.TajoInterpreter,"
+        + "org.apache.zeppelin.tajo.thrift.TajoInterpreter"),
         ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "interpreter"),
         ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
         ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),


### PR DESCRIPTION
This is for decoupling Tajo-jdbc and Tajo-thrift interpreters. 

TODO
- [x] Rename Tajo interpreter explicitly into tajo-jdbc
- [x] Add tajo-thrift interpreter
- [x] Implement **getProgress()** for tajo-thrift interpreter, by @bzz 
- [x] Learning Zeppelin architecture and handling unexpected problems 
- [ ] Implement **cancel()**
