### PR TITLE
Fix 'Scheduler already terminated error' exception after restart interpreter

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -319,6 +319,7 @@ public class RemoteInterpreter extends Interpreter {
         maxConcurrency);
   }
 
+
   @Override
   public void setInterpreterGroup(InterpreterGroup interpreterGroup) {
     super.setInterpreterGroup(interpreterGroup);
@@ -328,7 +329,8 @@ public class RemoteInterpreter extends Interpreter {
           .get(getInterpreterGroupKey(interpreterGroup));
 
       // when interpreter process is not created or terminated
-      if (intpProcess == null || (!intpProcess.isRunning() && intpProcess.getPort() > 0)) {
+      if (intpProcess == null || (!intpProcess.isRunning() && intpProcess.getPort() > 0)
+          || (!intpProcess.isRunning() && intpProcess.getPort() == -1)) {
         interpreterGroupReference.put(getInterpreterGroupKey(interpreterGroup),
             new RemoteInterpreterProcess(interpreterRunner,
                 interpreterPath, env, interpreterContextRunnerPool));

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.interpreter.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -459,7 +460,7 @@ public class RemoteInterpreterTest {
   }
 
   @Test
-  public void testProcessCreation() {
+  public void testInterpreterGroupResetBeforeProcessStarts() {
     Properties p = new Properties();
 
     RemoteInterpreter intpA = new RemoteInterpreter(
@@ -476,6 +477,55 @@ public class RemoteInterpreterTest {
     intpA.setInterpreterGroup(new InterpreterGroup(intpA.getInterpreterGroup().getId()));
     RemoteInterpreterProcess processB = intpA.getInterpreterProcess();
 
+    assertNotSame(processA.hashCode(), processB.hashCode());
+  }
+
+  @Test
+  public void testInterpreterGroupResetAfterProcessFinished() {
+    Properties p = new Properties();
+
+    RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpA.setInterpreterGroup(intpGroup);
+    RemoteInterpreterProcess processA = intpA.getInterpreterProcess();
+    intpA.open();
+
+    processA.dereference();    // intpA.close();
+
+    intpA.setInterpreterGroup(new InterpreterGroup(intpA.getInterpreterGroup().getId()));
+    RemoteInterpreterProcess processB = intpA.getInterpreterProcess();
+
+    assertNotSame(processA.hashCode(), processB.hashCode());
+  }
+
+  @Test
+  public void testInterpreterGroupResetDuringProcessRunning() {
+    Properties p = new Properties();
+
+    RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env
+        );
+
+    intpA.setInterpreterGroup(intpGroup);
+    RemoteInterpreterProcess processA = intpA.getInterpreterProcess();
+    intpA.open();
+
+    intpA.setInterpreterGroup(new InterpreterGroup(intpA.getInterpreterGroup().getId()));
+    RemoteInterpreterProcess processB = intpA.getInterpreterProcess();
+
     assertEquals(processA.hashCode(), processB.hashCode());
+
+    processA.dereference();     // intpA.close();
+
   }
 }


### PR DESCRIPTION
In certain condition, interpreter restart cause 'Scheduler already terminated' exception.
This PR fixes the bug.

Related issue https://issues.apache.org/jira/browse/ZEPPELIN-85
