### PR TITLE
[ZEPPELIN-63] add interpreter for Apache Ignite

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -66,7 +66,7 @@
 
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter</value>
   <description>Comma separated interpreter configurations. First interpreter become a default</description>
 </property>
 

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+  
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zeppelin</artifactId>
+    <groupId>org.apache.zeppelin</groupId>
+    <version>0.5.0-incubating-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.apache.zeppelin</groupId>
+  <artifactId>zeppelin-ignite</artifactId>
+  <packaging>jar</packaging>
+  <version>0.5.0-incubating-SNAPSHOT</version>
+  <name>Zeppelin: Apache Ignite interpreter</name>
+  <url>http://zeppelin.incubator.apache.org</url>
+
+  <properties>
+    <ignite.version>1.0.0</ignite.version>
+    <ignite.scala.binary.version>2.10</ignite.scala.binary.version>
+    <ignite.scala.version>2.10.4</ignite.scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-interpreter</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency> 
+
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-core</artifactId>
+      <version>${ignite.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-spring</artifactId>
+      <version>${ignite.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-indexing</artifactId>
+      <version>${ignite.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${ignite.scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+      <version>${ignite.scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-reflect</artifactId>
+      <version>${ignite.scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>            
+        <executions> 
+          <execution> 
+            <id>enforce</id> 
+            <phase>none</phase> 
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/ignite</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/ignite</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                  <type>${project.packaging}</type>
+                </artifactItem>
+              </artifactItems>              
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
@@ -39,7 +39,7 @@ public class IgniteInterpreter extends Interpreter {
         "ignite",
         IgniteInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
-            .add("ignite.clientMode", "true", "Client mode. true or false")
+            .add("ignite.clientMode", "false", "Client mode. true or false")
             .build());
   }
 
@@ -62,8 +62,8 @@ public class IgniteInterpreter extends Interpreter {
   }
 
 
-  public boolean isLocalMode() {
-    return Boolean.parseBoolean(getProperty("ignite.localMode"));
+  public boolean isClientMode() {
+    return Boolean.parseBoolean(getProperty("ignite.clientMode"));
   }
 
 
@@ -71,7 +71,7 @@ public class IgniteInterpreter extends Interpreter {
     synchronized (this) {
       if (ignite == null) {
         IgniteConfiguration conf = new IgniteConfiguration();
-        conf.setClientMode(!isLocalMode());
+        conf.setClientMode(isClientMode());
         ignite = Ignition.start(conf);
       }
       return ignite;

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
@@ -16,8 +16,14 @@
  */
 package org.apache.zeppelin.ignite;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.ignite.Ignite;
@@ -25,14 +31,27 @@ import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
-import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.InterpreterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Console;
+import scala.None;
+import scala.Some;
+import scala.tools.nsc.Settings;
+import scala.tools.nsc.interpreter.IMain;
+import scala.tools.nsc.settings.MutableSettings.BooleanSetting;
+import scala.tools.nsc.settings.MutableSettings.PathSetting;
 
 /**
  * Interpreter for Apache Ignite (http://ignite.incubator.apache.org/)
  */
 public class IgniteInterpreter extends Interpreter {
+  Logger logger = LoggerFactory.getLogger(IgniteInterpreter.class);
+
   static {
     Interpreter.register(
         "ignite",
@@ -44,6 +63,10 @@ public class IgniteInterpreter extends Interpreter {
   }
 
   private Ignite ignite;
+  private Settings settings;
+  private ByteArrayOutputStream out;
+  private IMain imain;
+  private Map<String, Object> binder;
 
   public IgniteInterpreter(Properties property) {
     super(property);
@@ -51,21 +74,82 @@ public class IgniteInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    getIgnite();
+    URL[] urls = getClassloaderUrls();
+    this.settings = new Settings();
+
+    // set classpath
+    PathSetting pathSettings = settings.classpath();
+    String classpath = "";
+    List<File> paths = currentClassPath();
+    for (File f : paths) {
+      if (classpath.length() > 0) {
+        classpath += File.pathSeparator;
+      }
+      classpath += f.getAbsolutePath();
+    }
+
+    if (urls != null) {
+      for (URL u : urls) {
+        if (classpath.length() > 0) {
+          classpath += File.pathSeparator;
+        }
+        classpath += u.getFile();
+      }
+    }
+
+    pathSettings.v_$eq(classpath);
+    settings.scala$tools$nsc$settings$ScalaSettings$_setter_$classpath_$eq(pathSettings);
+    settings.explicitParentLoader_$eq(new Some<ClassLoader>(Thread.currentThread()
+        .getContextClassLoader()));
+    BooleanSetting b = (BooleanSetting) settings.usejavacp();
+    b.v_$eq(true);
+    settings.scala$tools$nsc$settings$StandardScalaSettings$_setter_$usejavacp_$eq(b);
+
+    out = new ByteArrayOutputStream();
+    imain = new IMain(settings, new PrintWriter(out));
+
+    initializeIgnite();
   }
 
-  @Override
-  public void close() {
-    synchronized (this) {
-      ignite.close();
+  private List<File> currentClassPath() {
+    List<File> paths = classPath(Thread.currentThread().getContextClassLoader());
+    String[] cps = System.getProperty("java.class.path").split(File.pathSeparator);
+    if (cps != null) {
+      for (String cp : cps) {
+        paths.add(new File(cp));
+      }
+    }
+    return paths;
+  }
+
+  private List<File> classPath(ClassLoader cl) {
+    List<File> paths = new LinkedList<File>();
+    if (cl == null) {
+      return paths;
+    }
+
+    if (cl instanceof URLClassLoader) {
+      URLClassLoader ucl = (URLClassLoader) cl;
+      URL[] urls = ucl.getURLs();
+      if (urls != null) {
+        for (URL url : urls) {
+          paths.add(new File(url.getFile()));
+        }
+      }
+    }
+    return paths;
+  }
+
+  public Object getValue(String name) {
+    Object ret = imain.valueOfTerm(name);
+    if (ret instanceof None) {
+      return null;
+    } else if (ret instanceof Some) {
+      return ((Some) ret).get();
+    } else {
+      return ret;
     }
   }
-
-
-  public boolean isClientMode() {
-    return Boolean.parseBoolean(getProperty("ignite.clientMode"));
-  }
-
 
   public Ignite getIgnite() {
     synchronized (this) {
@@ -78,14 +162,97 @@ public class IgniteInterpreter extends Interpreter {
     }
   }
 
+  private void initializeIgnite() {
+    imain.interpret("@transient var _binder = new java.util.HashMap[String, Object]()");
+    binder = (Map<String, Object>) getValue("_binder");
+
+    getIgnite();
+
+    binder.put("ignite", ignite);
+
+    imain.interpret("@transient val ignite = "
+        + "_binder.get(\"ignite\")"
+        + ".asInstanceOf[org.apache.ignite.Ignite]");
+  }
+
+
   @Override
-  public InterpreterResult interpret(String st, InterpreterContext context) {
-    throw new InterpreterException("Not implemented yet");
+  public void close() {
+    synchronized (this) {
+      ignite.close();
+      imain.close();
+    }
+  }
+
+
+  public boolean isClientMode() {
+    return Boolean.parseBoolean(getProperty("ignite.clientMode"));
+  }
+
+
+
+  @Override
+  public InterpreterResult interpret(String line, InterpreterContext context) {
+    if (line == null || line.trim().length() == 0) {
+      return new InterpreterResult(Code.SUCCESS);
+    }
+
+    InterpreterResult result = interpret(line.split("\n"), context);
+    return result;
   }
 
   @Override
   public void cancel(InterpreterContext context) {
 
+  }
+
+  public InterpreterResult interpret(String[] lines, InterpreterContext context) {
+    String[] linesToRun = new String[lines.length + 1];
+    for (int i = 0; i < lines.length; i++) {
+      linesToRun[i] = lines[i];
+    }
+    linesToRun[lines.length] = "print(\"\")";
+
+    Console.setOut(out);
+    out.reset();
+    Code r = null;
+
+    String incomplete = "";
+    for (String s : linesToRun) {
+      scala.tools.nsc.interpreter.Results.Result res = null;
+      try {
+        res = imain.interpret(incomplete + s);
+      } catch (Exception e) {
+        logger.info("Interpreter exception", e);
+        return new InterpreterResult(Code.ERROR, InterpreterUtils.getMostRelevantMessage(e));
+      }
+
+      r = getResultCode(res);
+
+      if (r == Code.ERROR) {
+        return new InterpreterResult(r, out.toString());
+      } else if (r == Code.INCOMPLETE) {
+        incomplete += s + "\n";
+      } else {
+        incomplete = "";
+      }
+    }
+
+    if (r == Code.INCOMPLETE) {
+      return new InterpreterResult(r, "Incomplete expression");
+    } else {
+      return new InterpreterResult(r, out.toString());
+    }
+  }
+
+  private Code getResultCode(scala.tools.nsc.interpreter.Results.Result r) {
+    if (r instanceof scala.tools.nsc.interpreter.Results.Success$) {
+      return Code.SUCCESS;
+    } else if (r instanceof scala.tools.nsc.interpreter.Results.Incomplete$) {
+      return Code.INCOMPLETE;
+    } else {
+      return Code.ERROR;
+    }
   }
 
   @Override

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.ignite;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+
+/**
+ * Interpreter for Apache Ignite (http://ignite.incubator.apache.org/)
+ */
+public class IgniteInterpreter extends Interpreter {
+  static {
+    Interpreter.register(
+        "ignite",
+        "ignite",
+        IgniteInterpreter.class.getName(),
+        new InterpreterPropertyBuilder()
+            .add("ignite.clientMode", "true", "Client mode. true or false")
+            .build());
+  }
+
+  private Ignite ignite;
+
+  public IgniteInterpreter(Properties property) {
+    super(property);
+  }
+
+  @Override
+  public void open() {
+    getIgnite();
+  }
+
+  @Override
+  public void close() {
+    synchronized (this) {
+      ignite.close();
+    }
+  }
+
+
+  public boolean isLocalMode() {
+    return Boolean.parseBoolean(getProperty("ignite.localMode"));
+  }
+
+
+  public Ignite getIgnite() {
+    synchronized (this) {
+      if (ignite == null) {
+        IgniteConfiguration conf = new IgniteConfiguration();
+        conf.setClientMode(!isLocalMode());
+        ignite = Ignition.start(conf);
+      }
+      return ignite;
+    }
+  }
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+    throw new InterpreterException("Not implemented yet");
+  }
+
+  @Override
+  public void cancel(InterpreterContext context) {
+
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.NATIVE;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return 0;
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    return new LinkedList<String>();
+  }
+
+}

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
@@ -42,8 +42,8 @@ import org.slf4j.LoggerFactory;
 public class IgniteSqlInterpreter extends Interpreter {
   static {
     Interpreter.register(
-        "ignite",
         "ignitesql",
+        "ignite",
         IgniteSqlInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
             .add("url", "localhost:11211/", "url for jdbc driver")

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.ignite;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.ignite.IgniteJdbcDriver;
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
+import org.apache.zeppelin.interpreter.WrappedInterpreter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ */
+public class IgniteSqlInterpreter extends Interpreter {
+  static {
+    Interpreter.register(
+        "ignite",
+        "ignitesql",
+        IgniteSqlInterpreter.class.getName(),
+        new InterpreterPropertyBuilder()
+            .add("url", "localhost:11211/", "url for jdbc driver")
+            .build());
+  }
+
+  Logger logger = LoggerFactory.getLogger(IgniteSqlInterpreter.class);
+  private Connection conn;
+
+  public IgniteSqlInterpreter(Properties property) {
+    super(property);
+  }
+
+  @Override
+  public void open() {
+    IgniteJdbcDriver jdbcDriver = new IgniteJdbcDriver();
+    try {
+      logger.info("connect to jdbc:ignite://" + getProperty("url"));
+      conn = jdbcDriver.connect("jdbc:ignite://" + getProperty("url"), getProperty());
+    } catch (SQLException e) {
+      throw new InterpreterException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (conn != null) {
+      try {
+        conn.close();
+      } catch (SQLException e) {
+        throw new InterpreterException(e);
+      }
+    }
+  }
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+    StringBuilder msg = new StringBuilder("%table ");
+
+    try {
+      Statement stmt = conn.createStatement();
+      ResultSet res = stmt.executeQuery(st);
+
+      ResultSetMetaData md = res.getMetaData();
+      try {
+        for (int i = 1; i < md.getColumnCount() + 1; i++) {
+          if (i == 1) {
+            msg.append(md.getColumnName(i));
+          } else {
+            msg.append("\t" + md.getColumnName(i));
+          }
+        }
+        msg.append("\n");
+        while (res.next()) {
+          for (int i = 1; i < md.getColumnCount() + 1; i++) {
+            msg.append(res.getString(i) + "\t");
+          }
+          msg.append("\n");
+        }
+      } finally {
+        try {
+          res.close();
+          stmt.close();
+        } finally {
+          stmt = null;
+        }
+      }
+    } catch (SQLException e) {
+      throw new InterpreterException(e);
+    }
+
+    return new InterpreterResult(Code.SUCCESS, msg.toString());
+  }
+
+
+
+  @Override
+  public void cancel(InterpreterContext context) {
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return 0;
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    return new LinkedList<String>();
+  }
+
+  private IgniteInterpreter getIgniteInterpreter() {
+    for (Interpreter intp : getInterpreterGroup()) {
+      if (intp.getClassName().equals(IgniteInterpreter.class.getName())) {
+        Interpreter p = intp;
+        while (p instanceof WrappedInterpreter) {
+          if (p instanceof LazyOpenInterpreter) {
+            p.open();
+          }
+          p = ((WrappedInterpreter) p).getInnerInterpreter();
+        }
+        return (IgniteInterpreter) p;
+      }
+    }
+    return null;
+  }
+
+}

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
@@ -99,7 +99,10 @@ public class IgniteSqlInterpreter extends Interpreter {
         msg.append("\n");
         while (res.next()) {
           for (int i = 1; i < md.getColumnCount() + 1; i++) {
-            msg.append(res.getString(i) + "\t");
+            msg.append(res.getString(i));
+            if (i != md.getColumnCount()) {
+              msg.append("\t");
+            }
           }
           msg.append("\n");
         }

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.ignite;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IgniteInterpreterTest {
+
+  private IgniteInterpreter ignite;
+
+  @Before
+  public void setUp() {
+    Properties p = new Properties();
+    ignite = new IgniteInterpreter(p);
+    ignite.open();
+  }
+
+  @After
+  public void tearDown() {
+    ignite.close();
+  }
+
+  @Test
+  public void testStartStop() {
+    ignite.getIgnite();
+  }
+
+}

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
@@ -38,8 +38,8 @@ public class IgniteSqlInterpreterTest {
   @Before
   public void setUp() {
     Properties p = new Properties();
-    p.setProperty("url", "localhost:11211");
-    p.setProperty("ignite.clientMode", "true");
+    p.setProperty("url", "localhost:11211/person");
+    p.setProperty("ignite.clientMode", "false");
     ignite = new IgniteInterpreter(p);
     ignite.open();
 
@@ -58,9 +58,11 @@ public class IgniteSqlInterpreterTest {
   @Test
   public void testSql() {
     CacheConfiguration<Integer, Person> cacheConf = new CacheConfiguration<Integer, Person>();
-    cacheConf.setName(null); // use default cache
+    cacheConf.setIndexedTypes(Integer.class, Person.class);
+    cacheConf.setName("person");
 
-    IgniteCache<Integer, Person> cache = ignite.getIgnite().cache("query");
+    IgniteCache<Integer, Person> cache = ignite.getIgnite().createCache(cacheConf);
+    //IgniteCache<Integer, Person> cache = ignite.getIgnite().cache("person");
     cache.put(1, new Person("sun", 100));
     cache.put(2, new Person("moon", 50));
     InterpreterResult result = sql.interpret("select name, age from Person where age > 10", context);

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
@@ -25,6 +25,7 @@ import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,6 @@ public class IgniteSqlInterpreterTest {
     ignite.open();
 
     sql = new IgniteSqlInterpreter(p);
-    sql.open();
 
     context = new InterpreterContext(null, null, null, null, null, null, null);
   }
@@ -65,8 +65,13 @@ public class IgniteSqlInterpreterTest {
     //IgniteCache<Integer, Person> cache = ignite.getIgnite().cache("person");
     cache.put(1, new Person("sun", 100));
     cache.put(2, new Person("moon", 50));
-    InterpreterResult result = sql.interpret("select name, age from Person where age > 10", context);
+    assertEquals("moon", cache.get(2).getName());
+
+    sql.open();
+    InterpreterResult result = sql.interpret("select name, age from person where age > 10", context);
     assertEquals(Code.SUCCESS, result.code());
+    assertEquals(Type.TABLE, result.type());
+    assertEquals("NAME\tAGE\nsun\t100\nmoon\t50\n", result.message());
   }
 
 }

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteSqlInterpreterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.ignite;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IgniteSqlInterpreterTest {
+
+  private IgniteInterpreter ignite;
+  private IgniteSqlInterpreter sql;
+  private InterpreterContext context;
+
+  @Before
+  public void setUp() {
+    Properties p = new Properties();
+    p.setProperty("url", "localhost:11211");
+    p.setProperty("ignite.clientMode", "true");
+    ignite = new IgniteInterpreter(p);
+    ignite.open();
+
+    sql = new IgniteSqlInterpreter(p);
+    sql.open();
+
+    context = new InterpreterContext(null, null, null, null, null, null, null);
+  }
+
+  @After
+  public void tearDown() {
+    sql.close();
+    ignite.close();
+  }
+
+  @Test
+  public void testSql() {
+    CacheConfiguration<Integer, Person> cacheConf = new CacheConfiguration<Integer, Person>();
+    cacheConf.setName(null); // use default cache
+
+    IgniteCache<Integer, Person> cache = ignite.getIgnite().cache("query");
+    cache.put(1, new Person("sun", 100));
+    cache.put(2, new Person("moon", 50));
+    InterpreterResult result = sql.interpret("select name, age from Person where age > 10", context);
+    assertEquals(Code.SUCCESS, result.code());
+  }
+
+}

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/Person.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/Person.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.ignite;
+
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+
+public class Person {
+  @QuerySqlField
+  private String name;
+
+  @QuerySqlField
+  private int age;
+
+  public Person(String name, int age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+
+}

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/Person.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/Person.java
@@ -16,9 +16,11 @@
  */
 package org.apache.zeppelin.ignite;
 
+import java.io.Serializable;
+
 import org.apache.ignite.cache.query.annotations.QuerySqlField;
 
-public class Person {
+public class Person implements Serializable {
   @QuerySqlField
   private String name;
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>shell</module>
     <module>hive</module>
     <module>tajo</module>
+    <module>ignite</module>
     <module>zeppelin-web</module>
     <module>zeppelin-server</module>
     <module>zeppelin-distribution</module>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -389,7 +389,9 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         + "org.apache.zeppelin.angular.AngularInterpreter,"
         + "org.apache.zeppelin.shell.ShellInterpreter,"
         + "org.apache.zeppelin.hive.HiveInterpreter,"
-        + "org.apache.zeppelin.tajo.TajoInterpreter"),
+        + "org.apache.zeppelin.tajo.TajoInterpreter,"
+        + "org.apache.zeppelin.ignite.IgniteInterpreter,"
+        + "org.apache.zeppelin.ignite.IgniteSqlInterpreter"),
         ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "interpreter"),
         ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
         ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),


### PR DESCRIPTION
Currently it is very early stage of implementation. 
My idea is implementing 2 interpreter for ignite,

   * [ ] IgniteInterpreter - Let user use ignite API (scala) by embedding scala compiler.
   * [x] IgniteSqlInterpreter - use JDBC driver to make sql query

While IgniteSqlInterpreter can be simply implemented using JDBC driver, i'd like to work on IgniteSqlInterpreter first and than work on IgniteInterpreter.

Work in progress ..