### PR TITLE
Fix abnormal height of chart in IE

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -912,11 +912,11 @@ angular.module('zeppelinWebApp')
 
       var chartEl = d3.select('#p'+$scope.paragraph.id+'_'+type+' svg')
           .attr('height', $scope.paragraph.config.graph.height)
+          .style('height', height + 'px')
           .datum(d3g)
           .transition()
           .duration(animationDuration)
           .call($scope.chart[type]);
-      d3.select('#p'+$scope.paragraph.id+'_'+type+' svg').style.height = height+'px';
       nv.utils.windowResize($scope.chart[type].update);
     };
 


### PR DESCRIPTION
I fixed https://issues.apache.org/jira/browse/ZEPPELIN-91 issue.

This issue is related to abnormal height of chart in IE. Please refer to the link below for more details.
https://github.com/NFLabs/zeppelin/issues/417