### PR TITLE
Fix test. parsing version number

### DIFF
--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -55,8 +55,8 @@ public class SparkInterpreterTest {
       return 0;
     }
 
-    String[] split = repl.getSparkContext().version().split(".");
-    int version = Integer.parseInt(split[0]) + Integer.parseInt(split[1]);
+    String[] split = repl.getSparkContext().version().split("\\.");
+    int version = Integer.parseInt(split[0]) * 10 + Integer.parseInt(split[1]);
     return version;
   }
 


### PR DESCRIPTION
#71  has change to run unittest for all spark versions. But there was mistake when parsing spark version number and that causes test failure.