### PR TITLE
Fixing YARN build for CDH

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,6 +43,13 @@
     <yarn.version>${hadoop.version}</yarn.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-94

"mvn clean package -Pspark-1.3 -Dspark.version=1.3.1 -Phadoop-2.2 -Dhadoop.version=2.0.0-cdh4.7.1 -Pyarn -DskipTests"

resulted in 

```
[INFO] Reactor Summary:
[INFO]
[INFO] Zeppelin .......................................... SUCCESS [4.219s]
[INFO] Zeppelin: Interpreter ............................. SUCCESS [16.483s]
[INFO] Zeppelin: Zengine ................................. SUCCESS [5.951s]
[INFO] Zeppelin: Spark ................................... FAILURE [4.358s]
[INFO] Zeppelin: Markdown interpreter .................... SKIPPED
[INFO] Zeppelin: Angular interpreter ..................... SKIPPED
[INFO] Zeppelin: Shell interpreter ....................... SKIPPED
[INFO] Zeppelin: Hive interpreter ........................ SKIPPED
[INFO] Zeppelin: Tajo interpreter ........................ SKIPPED
[INFO] Zeppelin: web Application ......................... SKIPPED
[INFO] Zeppelin: Server .................................. SKIPPED
[INFO] Zeppelin: Packaging distribution .................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31.394s
[INFO] Finished at: Mon Jun 08 23:24:12 KST 2015
[INFO] Final Memory: 55M/744M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project zeppelin-spark: Could not resolve dependencies for project org.apache.zeppelin:zeppelin-spark:jar:0.5.0-incubating-SNAPSHOT: The following artifacts could not be resolved: org.apache.hadoop:hadoop-client:jar:2.0.0-cdh4.7.1, org.apache.hadoop:hadoop-yarn-api:jar:2.0.0-cdh4.7.1: Could not find artifact org.apache.hadoop:hadoop-client:jar:2.0.0-cdh4.7.1 in central (http://repo.maven.apache.org/maven2) -> [Help 1]
```