### PR TITLE
ZEPPELIN-104 Spark-1.4 as default Zeppelin's build profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,23 +32,24 @@ script:
   - mvn package -Pbuild-distr -Phadoop-2.3 -B
   - ./testing/startSparkCluster.sh 1.4.1 2.3
   - SPARK_HOME=./spark-1.4.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Phadoop-2.3 -B
+  - ./testing/stopSparkCluster.sh 1.4.1 2.3
  # spark 1.3
-  - mvn clean package -DskipTests -Pspark-1.3 -Phadoop-2.3 -B -pl '!zeppelin-web,!zeppelin-distribution'
+  - mvn clean package -DskipTests -Pspark-1.3 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - mvn package -Pbuild-distr -Pspark-1.3 -Phadoop-2.3 -B
   - ./testing/startSparkCluster.sh 1.3.1 2.3
-  - SPARK_HOME=./spark-1.3.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Pspark-1.3 -Phadoop-2.3 -B
+  - SPARK_HOME=./spark-1.3.1-bin-hadoop2.3 mvn verify -Pspark-1.3 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - ./testing/stopSparkCluster.sh 1.3.1 2.3
 # spark 1.2
-  - mvn clean package -DskipTests -Pspark-1.2 -Phadoop-2.3 -B -pl '!zeppelin-web,!zeppelin-distribution'
+  - mvn clean package -DskipTests -Pspark-1.2 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - mvn package -Pbuild-distr -Pspark-1.2 -Phadoop-2.3 -B
   - ./testing/startSparkCluster.sh 1.2.1 2.3
-  - SPARK_HOME=./spark-1.2.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Pspark-1.2 -Phadoop-2.3 -B
+  - SPARK_HOME=./spark-1.2.1-bin-hadoop2.3 mvn verify -Pspark-1.2 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - ./testing/stopSparkCluster.sh 1.2.1 2.3
 # spark 1.1
-  - mvn clean package -DskipTests -Pspark-1.1 -Phadoop-2.3 -B -pl '!zeppelin-web,!zeppelin-distribution'
+  - mvn clean package -DskipTests -Pspark-1.1 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - mvn package -Pbuild-distr -Pspark-1.1 -Phadoop-2.3 -B
   - ./testing/startSparkCluster.sh 1.1.1 2.3
-  - SPARK_HOME=./spark-1.1.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Pspark-1.1 -Phadoop-2.3 -B
+  - SPARK_HOME=./spark-1.1.1-bin-hadoop2.3 mvn verify -Pspark-1.1 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - ./testing/stopSparkCluster.sh 1.1.1 2.3
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,15 @@ before_script:
   -
 
 script:
-# spark 1.3
+# spark 1.4
   - mvn package -Pbuild-distr -Phadoop-2.3 -B
+  - ./testing/startSparkCluster.sh 1.4.1 2.3
+  - SPARK_HOME=./spark-1.4.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Phadoop-2.3 -B
+ # spark 1.3
+  - mvn clean package -DskipTests -Pspark-1.3 -Phadoop-2.3 -B -pl '!zeppelin-web,!zeppelin-distribution'
+  - mvn package -Pbuild-distr -Pspark-1.3 -Phadoop-2.3 -B
   - ./testing/startSparkCluster.sh 1.3.1 2.3
-  - SPARK_HOME=./spark-1.3.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Phadoop-2.3 -B
+  - SPARK_HOME=./spark-1.3.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Pspark-1.3 -Phadoop-2.3 -B
   - ./testing/stopSparkCluster.sh 1.3.1 2.3
 # spark 1.2
   - mvn clean package -DskipTests -Pspark-1.2 -Phadoop-2.3 -B -pl '!zeppelin-web,!zeppelin-distribution'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_script:
 script:
 # spark 1.4
   - mvn package -Pbuild-distr -Phadoop-2.3 -B
-  - ./testing/startSparkCluster.sh 1.4.1 2.3
+  - ./testing/startSparkCluster.sh 1.4.0 2.3
   - SPARK_HOME=./spark-1.4.1-bin-hadoop2.3 mvn verify -Pusing-packaged-distr -Phadoop-2.3 -B
-  - ./testing/stopSparkCluster.sh 1.4.1 2.3
+  - ./testing/stopSparkCluster.sh 1.4.0 2.3
  # spark 1.3
   - mvn clean package -DskipTests -Pspark-1.3 -Phadoop-2.3 -B -pl 'zeppelin-interpreter,spark'
   - mvn package -Pbuild-distr -Pspark-1.3 -Phadoop-2.3 -B

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -35,7 +35,7 @@
   
 
   <properties>
-    <spark.version>1.3.1</spark.version>
+    <spark.version>1.4.0</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
 

--- a/testing/startSparkCluster.sh
+++ b/testing/startSparkCluster.sh
@@ -45,4 +45,10 @@ export SPARK_MASTER_PORT=7071
 export SPARK_MASTER_WEBUI_PORT=7072
 export SPARK_WORKER_WEBUI_PORT=8082
 ${SPARK_HOME}/sbin/start-master.sh
-${SPARK_HOME}/sbin/start-slave.sh 1 `hostname`:${SPARK_MASTER_PORT}
+
+echo ${SPARK_VERSION} | grep "^1.4" > /dev/null
+if [ $? -ne 0 ]; then   # spark 1.3 or prior
+    ${SPARK_HOME}/sbin/start-slave.sh 1 `hostname`:${SPARK_MASTER_PORT}
+else
+    ${SPARK_HOME}/sbin/start-slave.sh spark://`hostname`:7071
+fi


### PR DESCRIPTION
This PR makes Spark-1.4 as default Zeppelin's build profile. https://issues.apache.org/jira/browse/ZEPPELIN-104

And Enabling CI test Zeppelin with spark version 1.4