### PR TITLE
ZEPPELIN-105 Speedup default build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,10 +248,9 @@
         </configuration>
         <executions>
           <execution>
-            <id>checkstyle</id>
+            <id>checkstyle-fail-build</id>
             <phase>validate</phase>
             <goals>
-              <goal>checkstyle</goal>
               <goal>check</goal>
             </goals>
             <configuration>
@@ -259,6 +258,17 @@
               <excludes>org/apache/zeppelin/interpreter/thrift/*</excludes>
             </configuration>
           </execution>
+          <execution>
+            <id>checkstyle-gen-html-report</id>
+            <phase>install</phase>
+            <goals>
+              <goal>checkstyle-aggregate</goal>
+            </goals>
+            <configuration>
+              <excludes>org/apache/zeppelin/interpreter/thrift/*</excludes>
+            </configuration>
+          </execution>
+
         </executions>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <executions>
           <execution>
             <id>cobertura</id>
-            <phase>package</phase>
+            <phase>install</phase>
             <goals>
               <goal>cobertura</goal>
             </goals>


### PR DESCRIPTION
Details in [ZEPPELIN-105](https://issues.apache.org/jira/browse/ZEPPELIN-105)

This PR cuts default Java projects build time ~2 times. 