### PR TITLE
ZEPPELIN-127 DisplayUtils breaks some spark code working

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -442,6 +442,8 @@ public class SparkInterpreter extends Interpreter {
       intp.interpret("import org.apache.spark.sql.functions._");
     }
 
+    /* Temporary disabling DisplayUtils. see https://issues.apache.org/jira/browse/ZEPPELIN-127
+     *
     // Utility functions for display
     intp.interpret("import org.apache.zeppelin.spark.utils.DisplayUtils._");
 
@@ -449,6 +451,7 @@ public class SparkInterpreter extends Interpreter {
     intp.interpret("import org.apache.zeppelin.spark.utils.SparkMaxResult");
     intp.interpret("implicit val sparkMaxResult = new SparkMaxResult(" +
             Integer.parseInt(getProperty("zeppelin.spark.maxResult")) + ")");
+     */
 
     try {
       if (sc.version().startsWith("1.1") || sc.version().startsWith("1.2")) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-127
This PR disables autoloading of DisplayUtil due to breaking some basic spark codes.

