### PR TITLE
ZEPPELIN-131 Inherit the Apache pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
   <url>http://zeppelin.incubator.apache.org/</url>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>17</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
To publish maven artifact, Zeppelin need inherit apache pom. described http://www.apache.org/dev/publishing-maven-artifacts.html#signing-up