### PR TITLE
ZEPPELIN-132 Skip deploy zeppelin-web artifact in maven-deploy-plugin

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -135,6 +135,14 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-132 Skip deploy zeppelin-web artifact in maven-deploy-plugin. Which does not make sense to be published.