### PR TITLE
[ZEPPELIN-146] Force IE to use "edge" compatible mode

### DIFF
--- a/zeppelin-web/app/404.html
+++ b/zeppelin-web/app/404.html
@@ -15,6 +15,7 @@ limitations under the License.
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title>Page Not Found :(</title>
     <style>

--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -14,6 +14,7 @@ limitations under the License.
 <!doctype html>
 <html ng-app="zeppelinWebApp" ng-controller="MainCtrl" class="no-js">
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title></title>
     <!-- disable caches for all browser -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-146

In Microsoft internal deployment, compatible level of IE will be set to "5" for interant sites, due to group policy set by admin.
Then, some JavaScript will be broken, and home page of Zeppelin cannot be rendered.
We need to set X-UA-Compatible tag for IE to "edge" to force it use the latest IE version.