### PR TITLE
ZEPPELIN-79 Zeppelin does not kill some interpreters when server is stopped

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -101,19 +101,27 @@ function wait_for_zeppelin_to_die() {
   local pid
   local count
   pid=$1
+  timeout=$2
   count=0
-  while [[ "${count}" -lt 10 ]]; do
+  timeoutTime=$(date "+%s")
+  let "timeoutTime+=$timeout"
+  currentTime=$(date "+%s")
+  forceKill=1
+
+  while [[ $currentTime -lt $timeoutTime ]]; do
     $(kill ${pid} > /dev/null 2> /dev/null)
     if kill -0 ${pid} > /dev/null 2>&1; then
       sleep 3
-      let "count+=1"
     else
+      forceKill=0
       break
     fi
-  if [[ "${count}" == "5" ]]; then
+    currentTime=$(date "+%s")
+  done
+
+  if [[ forceKill -ne 0 ]]; then
     $(kill -9 ${pid} > /dev/null 2> /dev/null)
   fi
-  done
 }
 
 function wait_zeppelin_is_up_for_ci() {
@@ -187,7 +195,7 @@ function stop() {
     if [[ -z "${pid}" ]]; then
       echo "${ZEPPELIN_NAME} is not running"
     else
-      wait_for_zeppelin_to_die $pid
+      wait_for_zeppelin_to_die $pid 40
       $(rm -f ${ZEPPELIN_PID})
       action_msg "${ZEPPELIN_NAME} stop" "${SET_OK}"
     fi
@@ -200,7 +208,7 @@ function stop() {
     fi
 
     pid=$(cat ${f})
-    wait_for_zeppelin_to_die $pid
+    wait_for_zeppelin_to_die $pid 20
     $(rm -f ${f})
   done
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -18,9 +18,11 @@
 package org.apache.zeppelin.interpreter;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 
+import org.apache.log4j.Logger;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 
 /**
@@ -71,14 +73,50 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
   }
 
   public void close() {
-    for (Interpreter intp : this) {
-      intp.close();
+    List<Thread> closeThreads = new LinkedList<Thread>();
+
+    for (final Interpreter intp : this) {
+      Thread t = new Thread() {
+        public void run() {
+          intp.close();
+        }
+      };
+
+      t.start();
+      closeThreads.add(t);
+    }
+
+    for (Thread t : closeThreads) {
+      try {
+        t.join();
+      } catch (InterruptedException e) {
+        Logger logger = Logger.getLogger(InterpreterGroup.class);
+        logger.error("Can't close interpreter", e);
+      }
     }
   }
 
   public void destroy() {
-    for (Interpreter intp : this) {
-      intp.destroy();
+    List<Thread> destroyThreads = new LinkedList<Thread>();
+
+    for (final Interpreter intp : this) {
+      Thread t = new Thread() {
+        public void run() {
+          intp.destroy();
+        }
+      };
+
+      t.start();
+      destroyThreads.add(t);
+    }
+
+    for (Thread t : destroyThreads) {
+      try {
+        t.join();
+      } catch (InterruptedException e) {
+        Logger logger = Logger.getLogger(InterpreterGroup.class);
+        logger.error("Can't close interpreter", e);
+      }
     }
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -163,10 +163,10 @@ public class RemoteInterpreterProcess implements ExecuteResultHandler {
         clientPool.clear();
         clientPool.close();
 
-        // wait for 3 sec and force kill
+        // wait for some time (connectTimeout) and force kill
         // remote process server.serve() loop is not always finishing gracefully
         long startTime = System.currentTimeMillis();
-        while (System.currentTimeMillis() - startTime < 3 * 1000) {
+        while (System.currentTimeMillis() - startTime < connectTimeout) {
           if (this.isRunning()) {
             try {
               Thread.sleep(500);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -546,13 +546,26 @@ public class InterpreterFactory {
 
 
   public void close() {
+    List<Thread> closeThreads = new LinkedList<Thread>();
     synchronized (interpreterSettings) {
-      synchronized (interpreterSettings) {
-        Collection<InterpreterSetting> intpsettings = interpreterSettings.values();
-        for (InterpreterSetting intpsetting : intpsettings) {
-          intpsetting.getInterpreterGroup().close();
-          intpsetting.getInterpreterGroup().destroy();
-        }
+      Collection<InterpreterSetting> intpsettings = interpreterSettings.values();
+      for (final InterpreterSetting intpsetting : intpsettings) {
+        Thread t = new Thread() {
+          public void run() {
+            intpsetting.getInterpreterGroup().close();
+            intpsetting.getInterpreterGroup().destroy();
+          }
+        };
+        t.start();
+        closeThreads.add(t);
+      }
+    }
+
+    for (Thread t : closeThreads) {
+      try {
+        t.join();
+      } catch (InterruptedException e) {
+        logger.error("Can't close interpreterGroup", e);
       }
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-79

Zeppelin sometimes left interpreter process after it is stopped.
This pr solve the problem by increase timeout for graceful shutdown