### PR TITLE
ZEPPELIN-152 Propagate error from interpreter process to the GUI

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -35,6 +35,7 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterUtils;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.WrappedInterpreter;
@@ -128,13 +129,10 @@ public class SparkSqlInterpreter extends Interpreter {
       sc.setLocalProperty("spark.scheduler.pool", null);
     }
 
-    try {
-      Object rdd = sqlc.sql(st);
-      String msg = ZeppelinContext.showRDD(sc, context, rdd, maxResult);
-      return new InterpreterResult(Code.SUCCESS, msg);
-    } catch (Exception e) {
-      return new InterpreterResult(Code.ERROR, e.getMessage());
-    }
+
+    Object rdd = sqlc.sql(st);
+    String msg = ZeppelinContext.showRDD(sc, context, rdd, maxResult);
+    return new InterpreterResult(Code.SUCCESS, msg);
   }
 
   @Override

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.zeppelin.spark;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -91,7 +91,12 @@ public class SparkSqlInterpreterTest {
     assertEquals(Type.TABLE, ret.type());
     assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
 
-    assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select wrong syntax", context).code());
+    try {
+      sql.interpret("select wrong syntax", context);
+      fail("Exception not catched");
+    } catch (Exception e) {
+      // okay
+    }
     assertEquals(InterpreterResult.Code.SUCCESS, sql.interpret("select case when name==\"aa\" then name else name end from test", context).code());
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ClassloaderInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ClassloaderInterpreter.java
@@ -55,8 +55,9 @@ public class ClassloaderInterpreter
     Thread.currentThread().setContextClassLoader(cl);
     try {
       return intp.interpret(st, context);
+    } catch (InterpreterException e) {
+      throw e;
     } catch (Exception e) {
-      e.printStackTrace();
       throw new InterpreterException(e);
     } finally {
       cl = Thread.currentThread().getContextClassLoader();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -30,6 +30,7 @@ import org.apache.zeppelin.interpreter.InterpreterContextRunner;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterContext;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterResult;
@@ -222,7 +223,8 @@ public class RemoteInterpreter extends Interpreter {
         context.getGui().setForms(remoteGui.getForms());
       }
 
-      return convert(remoteResult);
+      InterpreterResult result = convert(remoteResult);
+      return result;
     } catch (TException e) {
       throw new InterpreterException(e);
     } finally {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -42,6 +42,7 @@ import org.apache.zeppelin.interpreter.InterpreterContextRunner;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterContext;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterEvent;
@@ -210,18 +211,15 @@ public class RemoteInterpreterServer
       }
     }
 
+    InterpreterResult result;
     if (job.getStatus() == Status.ERROR) {
-      throw new TException(job.getException());
+      result = new InterpreterResult(Code.ERROR, Job.getStack(job.getException()));
     } else {
-      if (intp.getFormType() == FormType.NATIVE) {
-        // serialize dynamic form
-
-      }
-
-      return convert((InterpreterResult) job.getReturn(),
-          context.getConfig(),
-          context.getGui());
+      result = (InterpreterResult) job.getReturn();
     }
+    return convert(result,
+        context.getConfig(),
+        context.getGui());
   }
 
   class InterpretJobListener implements JobListener {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -21,7 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 
-import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -191,17 +191,13 @@ public abstract class Job {
     }
   }
 
-  public String getStack(Throwable e) {
-    StackTraceElement[] stacks = e.getStackTrace();
-    if (stacks == null) {
+  public static String getStack(Throwable e) {
+    if (e == null) {
       return "";
     }
-    String ss = "";
-    for (StackTraceElement s : stacks) {
-      ss += s.toString() + "\n";
-    }
 
-    return ss;
+    Throwable cause = ExceptionUtils.getRootCause(e);
+    return ExceptionUtils.getFullStackTrace(cause);
   }
 
   public Throwable getException() {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -37,6 +37,8 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterContextRunner;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer.InterpretJob;
 import org.apache.zeppelin.interpreter.remote.mock.MockInterpreterA;
 import org.apache.zeppelin.interpreter.remote.mock.MockInterpreterB;
 import org.apache.zeppelin.scheduler.Job;
@@ -126,6 +128,36 @@ public class RemoteInterpreterTest {
 
     assertFalse(process.isRunning());
 
+  }
+
+  @Test
+  public void testRemoteInterperterErrorStatus() throws TTransportException, IOException {
+    Properties p = new Properties();
+
+    RemoteInterpreter intpA = new RemoteInterpreter(
+        p,
+        MockInterpreterA.class.getName(),
+        new File("../bin/interpreter.sh").getAbsolutePath(),
+        "fake",
+        env,
+        10 * 1000
+        );
+
+    intpGroup.add(intpA);
+    intpA.setInterpreterGroup(intpGroup);
+
+    intpA.open();
+    InterpreterResult ret = intpA.interpret("non numeric value",
+        new InterpreterContext(
+            "id",
+            "title",
+            "text",
+            new HashMap<String, Object>(),
+            new GUI(),
+            new AngularObjectRegistry(intpGroup.getId(), null),
+            new LinkedList<InterpreterContextRunner>()));
+
+    assertEquals(Code.ERROR, ret.code());
   }
 
   @Test

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -568,7 +568,9 @@ public class NotebookServer extends WebSocketServer implements
     @Override
     public void afterStatusChange(Job job, Status before, Status after) {
       if (after == Status.ERROR) {
-        job.getException().printStackTrace();
+        if (job.getException() != null) {
+          LOG.error("Error", job.getException());
+        }
       }
       if (job.isTerminated()) {
         LOG.info("Job {} is finished", job.getId());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-152
Errors from remote process are not propagated correctly. So, before go and check interpreter's log, it's hard to see actual problem.