### PR TITLE
Added Kafka module to spark configuration to support Kafka integration.

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -310,6 +310,12 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming-kafka_2.10</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>


### PR DESCRIPTION
This references issue:
https://github.com/NFLabs/zeppelin/issues/189

on the old Zeppelin GitHub.

This change lets us use Kafka with Spark streaming inside the shell. 