### PR TITLE
Switch ngDelete to ngEscape

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -16,7 +16,7 @@ limitations under the License.
   <div class="noteAction" ng-show="note.id && !paragraphUrl">
     <h3 class="new_h3">
       <input type="text" class="form-control2" placeholder="{{note.name || 'Note ' + note.id}}" style="width:200px;"
-             ng-show="showEditor" ng-model="note.name" ng-enter="sendNewName()" ng-delete="showEditor = false" autofocus/>
+             ng-show="showEditor" ng-model="note.name" ng-enter="sendNewName()" ng-escape="showEditor = false" autofocus/>
         <p class="form-control-static2" ng-click="showEditor = true" ng-show="!showEditor">{{note.name || 'Note ' + note.id}}</p>
           <span class="labelBtn btn-group">
             <button type="button"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -22,7 +22,7 @@ limitations under the License.
            placeholder="Edit title"
            ng-model="paragraph.title"
            ng-show="showTitleEditor"
-           ng-delete="showTitleEditor = false"
+           ng-escape="showTitleEditor = false"
            ng-enter="setTitle(); showTitleEditor = false"/>
     <div ng-click="showTitleEditor = !asIframe && !viewOnly"
          ng-show="!showTitleEditor"

--- a/zeppelin-web/src/components/ngescape/ngescape.directive.js
+++ b/zeppelin-web/src/components/ngescape/ngescape.directive.js
@@ -11,13 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
-angular.module('zeppelinWebApp').directive('ngDelete', function() {
+angular.module('zeppelinWebApp').directive('ngEscape', function() {
   return function(scope, element, attrs) {
     element.bind('keydown keyup', function(event) {
-      if (event.which === 27 || event.which === 46) {
+      if (event.which === 27) {
         scope.$apply(function() {
           scope.$eval(attrs.ngEnter);
         });

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -111,7 +111,7 @@ limitations under the License.
     <script src="app/interpreter/interpreter.controller.js"></script>
     <script src="app/notebook/paragraph/paragraph.controller.js"></script>
     <script src="components/navbar/navbar.controller.js"></script>
-    <script src="components/ngdelete/ngdelete.directive.js"></script>
+    <script src="components/ngescape/ngescape.directive.js"></script>
     <script src="components/popover-html-unsafe/popover-html-unsafe.directive.js"></script>
     <script src="components/ngenter/ngenter.directive.js"></script>
     <script src="components/dropdowninput/dropdowninput.directive.js"></script>


### PR DESCRIPTION
When IBM-compatible keyboards user presses `Delete` key, it updates title of notebook/paragraph instead of forward delete.
This PR fix this bug by removing delete key event.