### PR TITLE
ZEPPELIN-165 Correct PYTHONPATH when SPARK_HOME is defined

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -74,7 +74,7 @@ if [[ ! -d "${ZEPPELIN_LOG_DIR}" ]]; then
 fi
 
 if [[ ! -z "${SPARK_HOME}" ]]; then
-  PYSPARKPATH="${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
+  PYSPARKPATH="${SPARK_HOME}/python:${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
 else
   PYSPARKPATH="${ZEPPELIN_HOME}/interpreter/spark/pyspark/pyspark.zip:${ZEPPELIN_HOME}/interpreter/spark/pyspark/py4j-0.8.2.1-src.zip"
 fi

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -74,7 +74,7 @@ if [[ ! -d "${ZEPPELIN_LOG_DIR}" ]]; then
 fi
 
 if [[ ! -z "${SPARK_HOME}" ]]; then
-  PYSPARKPATH="${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
+  PYSPARKPATH="${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
 else
   PYSPARKPATH="${ZEPPELIN_HOME}/interpreter/spark/pyspark/pyspark.zip:${ZEPPELIN_HOME}/interpreter/spark/pyspark/py4j-0.8.2.1-src.zip"
 fi


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-165

When SPARK_HOME is defined, PYTHONPATH is defined as
```
${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
```
instead of
```
${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.8.2.1-src.zip"
```