### PR TITLE
updates to make your own interpreter

### DIFF
--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -14,13 +14,23 @@ Interpreters in the same InterpreterGroup can reference each other. For example,
 
 <img class="img-responsive" style="width:50%; border: 1px solid #ecf0f1;" height="auto" src="../../assets/themes/zeppelin/img/interpreter.png" />
 
-Interpreter can be launched either using separate classloader or separate JVM process. Sometimes separate classloader causes problem especially when your interpreter uses reflections or trying to grab standard out/err. In this case, separate JVM process is the option you can select. (by checking 'fork' in Interpreter menu, which is default value) When Interpreter is running in separate JVM process, it's communicating with Zeppelin via thrift.
+Interpreter can be launched either using separate JVM process or separate classloader. The default is using separate JVM process (by checking 'fork' in Interpreter menu). When Interpreter is running in separate JVM process, it's communicating with Zeppelin via thrift. The other option is to use separate classloader, note that sometime separate classloader can causes problem especially when your interpreter uses reflections or trying to grab standard out/err.
 
 ### Make your own Interpreter
 
 Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.interpreter](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
 
 You can include org.apache.zeppelin:zeppelin-interpreter:[VERSION] artifact in your build system.
+
+Your interpreter name is derived from the static register method
+
+```
+static {
+    Interpreter.register("MyInterpreterName", MyClassName.class.getName());
+  }
+```
+
+This name will appear later in the interpreter name option box during the interpreter configuration process.
 
 ### Install your interpreter binary
 
@@ -32,17 +42,27 @@ Once you have build your interpreter, you can place your interpreter under direc
 
 ### Configure your interpreter
 
-You can configure zeppelin.interpreters property in conf/zeppelin-site.xml
-Property value is comma separated [INTERPRETER_CLASS_NAME]
+To configure your interpreter you need to follow these steps:
 
-for example, 
+1. create conf/zeppelin-site.xml by copying conf/zeppelin-site.xml.template to conf/zeppelin-site.xml 
 
-```
+2. Add your interpreter class name to the zeppelin.interpreters property in conf/zeppelin-site.xml
+
+  Property value is comma separated [INTERPRETER_CLASS_NAME]
+for example,
+  
+  ```
 <property>
   <name>zeppelin.interpreters</name>
   <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,com.me.MyNewInterpreter</value>
 </property>
 ```
+3. start zeppelin by running ```./bin/zeppelin-deamon start```
+
+4. in the interpreter page, click the +Create button and configure your interpreter properties.
+Now you are done and ready to use your interpreter.
+
+Note that the interpreters shipped with zeppelin have a slightly different configuration process as they are registered by default without the use of the zeppelin-site.xml.
 
 ### Use your interpreter
 
@@ -61,11 +81,11 @@ println(a)
 
 <br />
 #### 0.6.0 and later
-Inside of a noteobok, %[INTERPRETER\_GROUP].[INTERPRETER\_NAME] directive will call your interpreter.
+Inside of a notebook, %[INTERPRETER\_GROUP].[INTERPRETER\_NAME] directive will call your interpreter.
 Note that the first interpreter configuration in zeppelin.interpreters will be the default one.
 
 You can omit either [INTERPRETER\_GROUP] or [INTERPRETER\_NAME]. Omit [INTERPRETER\_NAME] selects first available interpreter in the [INTERPRETER\_GROUP].
-Omit '[INTERPRETER\_GROUP]' will selects [INTERPRETER\_NAME] from defualt interpreter group.
+Omit '[INTERPRETER\_GROUP]' will selects [INTERPRETER\_NAME] from default interpreter group.
 
 
 For example, if you have two interpreter myintp1 and myintp2 in group mygrp,
@@ -86,7 +106,7 @@ and you can call myintp2 like
 codes for myintp2
 ```
 
-If you ommit your interpreter name, it'll selects first available interpreter in the group (myintp1)
+If you omit your interpreter name, it'll selects first available interpreter in the group (myintp1)
 
 ```
 %mygrp
@@ -95,7 +115,7 @@ codes for myintp1
 
 ```
 
-You can only ommit your interpreter group when your interpreter group is selected as a default group.
+You can only omit your interpreter group when your interpreter group is selected as a default group.
 
 ```
 %myintp2

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -14,7 +14,7 @@ Interpreters in the same InterpreterGroup can reference each other. For example,
 
 <img class="img-responsive" style="width:50%; border: 1px solid #ecf0f1;" height="auto" src="../../assets/themes/zeppelin/img/interpreter.png" />
 
-Interpreter can be launched either using separate JVM process or separate classloader. The default is using separate JVM process (by checking 'fork' in Interpreter menu). When Interpreter is running in separate JVM process, it's communicating with Zeppelin via thrift. The other option is to use separate classloader, note that sometime separate classloader can causes problem especially when your interpreter uses reflections or trying to grab standard out/err.
+All Interpreters in the same interpreter group are launched in a single, separate JVM process. The Interpreter communicates with Zeppelin engine via thrift.
 
 ### Make your own Interpreter
 
@@ -30,8 +30,14 @@ static {
   }
 ```
 
-This name will appear later in the interpreter name option box during the interpreter configuration process.
+The name will appear later in the interpreter name option box during the interpreter configuration process.
 
+The name of the interpreter is what you later write to identify a paragraph which should be interpreted using this interpreter.
+
+```
+%MyInterpreterName
+some interpreter spesific code...
+```
 ### Install your interpreter binary
 
 Once you have build your interpreter, you can place your interpreter under directory with all the dependencies.

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -62,7 +62,7 @@ for example,
 4. in the interpreter page, click the +Create button and configure your interpreter properties.
 Now you are done and ready to use your interpreter.
 
-Note that the interpreters shipped with zeppelin have a slightly different configuration process as they are registered by default without the use of the zeppelin-site.xml.
+Note that the interpreters shipped with zeppelin have a [default configuration](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L397) which is used when there is no zeppelin-site.xml.
 
 ### Use your interpreter
 


### PR DESCRIPTION
I have updated the language in the "What is Zeppelin Interpreter" as the separate JVM process is the default.
Also updated the "Make your own Interpreter" and "Configure your interpreter" to better explain the process.