### PR TITLE
add hadoop 2.7 profile in spark/pom.xml

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -668,16 +668,6 @@
     </profile>
 
     <profile>
-      <id>hadoop-2.7</id>
-      <properties>
-        <hadoop.version>2.7.0</hadoop.version>
-        <protobuf.version>2.5.0</protobuf.version>
-        <jets3t.version>0.9.3</jets3t.version>
-        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
-      </properties>
-    </profile>
-
-    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -668,6 +668,16 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.7</id>
+      <properties>
+        <hadoop.version>2.7.0</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.3</jets3t.version>
+        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+      </properties>
+    </profile>
+
+    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
If you build Zeppelin as hadoop 2.7 and use Spark interpreter, a version conflict can occur because protobuf.version is not set.
So it is needed to add hadoop 2.7 profile.