### PR TITLE
Update Lens interpreter pom.xml to use non-snapshot Lens version

### DIFF
--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -33,7 +33,7 @@
   <url>http://www.apache.org</url>
   
   <properties>
-    <lens.version>2.2.0-beta-incubating-SNAPSHOT</lens.version>
+    <lens.version>2.2.0-beta-incubating</lens.version>
     <spring-shell.version>1.1.0.RELEASE</spring-shell.version>
     <hadoop-common.version>2.4.0</hadoop-common.version>
   </properties>


### PR DESCRIPTION
updating lens.version to a non-snapshot version i.e. 2.2.0-beta-incubating