### PR TITLE
README typo, build profile addition and version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.war
 *.ear
 
+# interpreter
+interpreter/
+
 # conf file
 conf/zeppelin-env.sh
 conf/zeppelin-site.xml

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mvn clean package -Pspark-1.1 -Dhadoop.version=2.6.0 -Phadoop-2.6 -Pyarn -DskipT
 ```
 Yarn (Hadoop 2.7.x)
 ```
-mvn clean package -Pspark-1.4 -Dspark.version=1.4.1 -Dhadoop.version=2.7.0 -Phadoop-2.7 -Pyarn -DskipTests
+mvn clean package -Pspark-1.4 -Dspark.version=1.4.1 -Dhadoop.version=2.7.0 -Phadoop-2.6 -Pyarn -DskipTests
 ```
 Ignite (1.1.0-incubating and later)
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mvn clean package -Pspark-1.1 -Dhadoop.version=2.6.0 -Phadoop-2.6 -Pyarn -DskipT
 ```
 Yarn (Hadoop 2.7.x)
 ```
-mvn clean package -Pspark-1.1 -Dhadoop.version=2.7.0 -Phadoop-2.6 -Pyarn -DskipTests
+mvn clean package -Pspark-1.4 -Dspark.version=1.4.1 -Dhadoop.version=2.7.0 -Phadoop-2.7 -Pyarn -DskipTests
 ```
 Ignite (1.1.0-incubating and later)
 ```
@@ -94,7 +94,7 @@ If you wish to configure Zeppelin option (like port number), configure the follo
 ./conf/zeppelin-site.xml
 ```
 (You can copy ```./conf/zeppelin-env.sh.template``` into ```./conf/zeppelin-env.sh```. 
-Same for ```zeppein-site.xml```.)
+Same for ```zeppelin-site.xml```.)
 
 #### External cluster configuration
 Mesos

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -35,7 +35,7 @@
   
 
   <properties>
-    <spark.version>1.4.0</spark.version>
+    <spark.version>1.4.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -668,16 +668,6 @@
     </profile>
 
     <profile>
-      <id>hadoop-2.7</id>
-      <properties>
-        <hadoop.version>2.7.0</hadoop.version>
-        <protobuf.version>2.5.0</protobuf.version>
-        <jets3t.version>0.9.3</jets3t.version>
-        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
-      </properties>
-    </profile>
-
-    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -668,6 +668,16 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.7</id>
+      <properties>
+        <hadoop.version>2.7.0</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.3</jets3t.version>
+        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+      </properties>
+    </profile>
+
+    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
Added interpreter/ folder to .gitignore

README.md
Fixed a typo in README.md
Updated mvn build command for Hadoop 2.7

In spark/pom.xml:
Bumped Spark default version number from 1.4.0 to 1.4.1
Added -PHadoop-2.7 build profile