### PR TITLE
[ZEPPELIN-51] Download link and release note to the first release

### DIFF
--- a/docs/releases/zeppelin-release-0.5.0-incubating.md
+++ b/docs/releases/zeppelin-release-0.5.0-incubating.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "Zeppelin Release 0.5.0-incubating"
+description: ""
+group: release
+---
+{% include JB/setup %}
+
+### Zeppelin Release 0.5.0-incubating
+
+Zeppelin 0.5.0-incubating is the first release under Apache incubation, with contributions from 42 developers and more than 600 commits.
+
+To download Zeppelin 0.5.0-incubating visit the [download](../../download.html) page.
+
+You can visit [issue tracker](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316221&version=12329850) for full list of issues being resolved.
+
+### Contributors
+
+The following developers contributed to this release:
+
+* Akshat Aranya - New features and Improvements in UI.
+* Alexander Bezzubov -Improvements and Bug fixes in Core, UI, Build system. New feature and Improvements in Spark interpreter. Documentation in roadmap.
+* Anthony Corbacho - Improvements in Website. Bug fixes Build system. Improvements and Bug fixes in UI. Documentation in roadmap.
+* Brennon York - Improvements and Bug fixes in Build system.
+* CORNEAU Damien - New feature, Improvements and Bug fixes in UI and Build system.
+* Corey Huang - Improvements in Build system. New feature in Core.
+* Digeratus - Improvements in Tutorials.
+* Dimitrios Liapis - Improvements in Documentation.
+* DuyHai DOAN - New feature in Build system.
+* Emmanuelle Raffenne - Bug fixes in UI.
+* Eran Medan - Improvements in Documentation.
+* Eugene Morozov - Bug fixes in Core.
+* Felix Cheung - Improvements in Spark interpreter. Improvements in Documentation. New features, Improvements and Bug fixes in UI.
+* Hung Lin - Improvements in Core.
+* Hyungu Roh - Bug fixes in UI.
+* Ilya Ganelin - Improvements in Tutorials.
+* JaeHwa Jung - New features in Tajo interpreter.
+* Jakob Homan - Improvements in Website.
+* James Carman - Improvements in Build system.
+* Jongyoul Lee - Improvements in Core, Build system and Spark interpreter. Bug fixes in Spark Interpreter. New features in Build system and Spark interpreter. Improvements in Documentation.
+* Juarez Bochi - Bug fixes in Build system.
+* Julien Buret - Bug fixes in Spark interpreter.
+* Jérémy Subtil - Bug fixes in Build system.
+* Kevin (SangWoo) Kim - New features in Core, Tutorials. Improvements in Documentation. New features, Improvements and Bug fixes in UI.
+* Kyoung-chan Lee - Improvements in Documentation.
+* Lee moon soo - Improvements in Tutorials. New features, Improvements and Bug fixes in Core, UI, Build system and Spark interpreter. New features in Flink interpreter. Improvments in Documentation.
+* Mina Lee - Improvements and Bug fixes in UI. New features in UI. Improvements in Core, Website.
+* Rajat Gupta - Bug fixes in Spark interpreter.
+* Ram Venkatesh - Improvements in Core, Build system, Spark interpreter and Markdown interpreter. New features and Bug fixes in Hive interpreter.
+* Sebastian YEPES - Improvements in Core.
+* Seckin Savasci - Improvements in Build system.
+* Timothy Shelton - Bug fixes in UI.
+* Vincent Botta - New features in UI.
+* Young boom - Improvements in UI.
+* bobbych - Improvements in Spark interpreter.
+* debugger87 - Bug fixes in Core.
+* dobachi - Improvements in UI.
+* epahomov - Improvements in Core and Spark interpreter.
+* kevindai0126 - Improvements in Core.
+* rahul agarwal - Bug fixes in Core.
+* whisperstream - Improvements in Spark interpreter.
+* yundai - Improvements in Core.
+
+Thanks to everyone who made this release possible!

--- a/download.md
+++ b/download.md
@@ -6,16 +6,16 @@ group: nav-right
 ---
 {% include JB/setup %}
 
-### Build from source
+### Download Zeppelin
+
+The latest release of Apache Zeppelin (incubating) is 0.5.0-incubating. Released on July 23, 2015 ([release notes](./docs/releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
+
+[Download](http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.0-incubating)
+
+
+### Build from source, installation
 
 Check [install](./docs/install/install.html).
-
-
-### Current binary release
-
-We will provide binary release pretty soon. Until then, please build your own. It's not that difficult.
-
-For install and configure, check [install](./docs/install/install.html).
 
 
 <!-- 


### PR DESCRIPTION
Vote for 0.5.0-incubating release has passed in general@ incubator mailing list ([here](http://mail-archives.apache.org/mod_mbox/incubator-general/201507.mbox/%3CCALf24sZkjGv9s5%3DMU1U97%3Dj-WdsQsH4VkznUA31xsQ2wFDMqRA%40mail.gmail.com%3E)'s vote result).
This PR trying to update download page and add release note on website before the release announcement.

I have listed contributors since 0.4.0 (it was out side of Apache incubation) in release note. Please let me know if there're contributions i missed.