### PR TITLE
change runNote from event to function call

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -71,7 +71,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   $scope.runNote = function() {
     var result = confirm('Run all paragraphs?');
     if (result) {
-      $scope.$broadcast('runParagraph');
+      _.forEach($scope.note.paragraphs, function(n, key) {
+        angular.element('#' + n.id + '_paragraphColumn_main').scope().runParagraph(n.text);
+      });
     }
   };
 


### PR DESCRIPTION
When using events, we can't guarantee that the paragraphs will be executed in order, so we need to loop through the paragraphs and make them run.

The back-end is already taking care of execution of query in parallel or in order of call, this allows us to send the front-end calls to backend in order.