### PR TITLE
ZEPPELIN-188 Display of line numbers

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -196,6 +196,7 @@ angular.module('zeppelinWebApp')
       $scope.paragraph.errorMessage = data.paragraph.errorMessage;
       $scope.paragraph.jobName = data.paragraph.jobName;
       $scope.paragraph.title = data.paragraph.title;
+      $scope.paragraph.lineNumbers = data.paragraph.lineNumbers;
       $scope.paragraph.status = data.paragraph.status;
       $scope.paragraph.result = data.paragraph.result;
       $scope.paragraph.settings = data.paragraph.settings;
@@ -339,6 +340,24 @@ angular.module('zeppelinWebApp')
     commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };
 
+  $scope.showLineNumbers = function () {
+    var newParams = angular.copy($scope.paragraph.settings.params);
+    var newConfig = angular.copy($scope.paragraph.config);
+    newConfig.lineNumbers = true;
+    $scope.editor.renderer.setShowGutter(true);
+
+    commitParagraph($scope.paragraph.lineNumbers, $scope.paragraph.text, newConfig, newParams);
+  };
+
+  $scope.hideLineNumbers = function () {
+    var newParams = angular.copy($scope.paragraph.settings.params);
+    var newConfig = angular.copy($scope.paragraph.config);
+    newConfig.lineNumbers = false;
+    $scope.editor.renderer.setShowGutter(false);
+
+    commitParagraph($scope.paragraph.lineNumbers, $scope.paragraph.text, newConfig, newParams);
+  };
+
   $scope.columnWidthClass = function(n) {
     if ($scope.asIframe) {
       return 'col-md-12';
@@ -399,8 +418,10 @@ angular.module('zeppelinWebApp')
 
     $scope.editor = _editor;
     if (_editor.container.id !== '{{paragraph.id}}_editor') {
-      $scope.editor.renderer.setShowGutter(false);
+      $scope.editor.renderer.setShowGutter($scope.paragraph.config.lineNumbers);
+      $scope.editor.setShowFoldWidgets(false);
       $scope.editor.setHighlightActiveLine(false);
+      $scope.editor.setHighlightGutterLine(false);
       $scope.editor.setTheme('ace/theme/github');
       $scope.editor.focus();
       var hight = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -435,6 +435,14 @@ limitations under the License.
              ng-click="showTitle()"
              ng-show="!paragraph.config.title"> Show title</a>
         </li>
+        <li>
+          <a class="fa fa-list-ol" style="cursor:pointer"
+             ng-click="hideLineNumbers()"
+             ng-show="paragraph.config.lineNumbers"> Hide line numbers</a>
+          <a class="fa fa-list-ol" style="cursor:pointer"
+             ng-click="showLineNumbers()"
+             ng-show="!paragraph.config.lineNumbers"> Show line numbers</a>
+        </li>
 
         <li><a class="icon-share-alt" style="cursor:pointer"
                ng-click="goToSingleParagraph()"> Link this paragraph</a>


### PR DESCRIPTION
Partial check-in with reference to : ZEPPELIN-188.
- Add an option under the paragraph settings to show/hide line numbers in ace editor

Since Ace editor is already integrated, with minor changes, this patch will get us line numbers. Based on comments, would like to work on improving - syntax highlighting & auto-complete. 

Thanks!