### PR TITLE
[ZEPPELIN-185] ZeppelinContext methods like z.show are not working with DataFrame in pyspark

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -131,7 +131,7 @@ public class SparkSqlInterpreter extends Interpreter {
 
 
     Object rdd = sqlc.sql(st);
-    String msg = ZeppelinContext.showRDD(sc, context, rdd, maxResult);
+    String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
     return new InterpreterResult(Code.SUCCESS, msg);
   }
 

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -31,6 +31,58 @@ from pyspark.serializers import MarshalSerializer, PickleSerializer
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, SchemaRDD, Row
 
+class Logger(object):
+  def __init__(self):
+    self.out = ""
+
+  def write(self, message):
+    self.out = self.out + message
+
+  def get(self):
+    return self.out
+
+  def reset(self):
+    self.out = ""
+
+
+class PyZeppelinContext(dict):
+  from pyspark.sql import DataFrame
+  def __init__(self, zc):
+    self.z = zc
+
+  def show(self, obj):
+    if isinstance(obj, DataFrame):
+      print gateway.jvm.org.apache.zeppelin.spark.ZeppelinContext.showDF(self.z, obj._jdf)
+    else:
+      print str(obj)
+
+  # By implementing special methods it makes operating on it more Pythonic
+  def __setitem__(self, key, item):
+    self.z.put(key, item)
+
+  def __getitem__(self, key):
+    return self.z.get(key)
+
+  def __delitem__(self, key):
+    del self.z.remove(key)
+
+  def __contains__(self, item):
+    return self.z.containsKey(item)
+
+  def add(self, key, value):
+    self.__setitem__(key, value)
+
+  def put(self, key, value):
+    self.__setitem__(key, value)
+
+  def get(self, key):
+    self.__getitem__(key)
+
+
+output = Logger()
+sys.stdout = output
+sys.stderr = output
+
 client = GatewayClient(port=int(sys.argv[1]))
 sparkVersion = sys.argv[2]
 
@@ -71,24 +123,7 @@ sc = SparkContext(jsc=jsc, gateway=gateway, conf=conf)
 sqlc = SQLContext(sc, intp.getSQLContext())
 sqlContext = sqlc
 
-z = intp.getZeppelinContext()
-
-class Logger(object):
-  def __init__(self):
-    self.out = ""
-
-  def write(self, message):
-    self.out = self.out + message
-
-  def get(self):
-    return self.out
-
-  def reset(self):
-    self.out = ""
-
-output = Logger()
-sys.stdout = output
-sys.stderr = output
+z = PyZeppelinContext(intp.getZeppelinContext())
 
 while True :
   req = intp.getStatements()
@@ -98,11 +133,12 @@ while True :
     final_code = None
 
     for s in stmts:
-      if s == None or len(s.strip()) == 0:
+      if s == None:
         continue
 
       # skip comment
-      if s.strip().startswith("#"):
+      s_stripped = s.strip()
+      if len(s_stripped) == 0 or s_stripped.startswith("#"):
         continue
 
       if final_code:

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -46,11 +46,11 @@ class Logger(object):
 
 
 class PyZeppelinContext(dict):
-  from pyspark.sql import DataFrame
   def __init__(self, zc):
     self.z = zc
 
   def show(self, obj):
+    from pyspark.sql import DataFrame
     if isinstance(obj, DataFrame):
       print gateway.jvm.org.apache.zeppelin.spark.ZeppelinContext.showDF(self.z, obj._jdf)
     else:
@@ -64,7 +64,7 @@ class PyZeppelinContext(dict):
     return self.z.get(key)
 
   def __delitem__(self, key):
-    del self.z.remove(key)
+    self.z.remove(key)
 
   def __contains__(self, item):
     return self.z.containsKey(item)
@@ -76,7 +76,7 @@ class PyZeppelinContext(dict):
     self.__setitem__(key, value)
 
   def get(self, key):
-    self.__getitem__(key)
+    return self.__getitem__(key)
 
 
 output = Logger()


### PR DESCRIPTION
(opening a new PR to have a start history)

z.show() doesn’t seem to work properly in Python – I see the same error below: “AttributeError: 'DataFrame' object has no attribute '_get_object_id'"
#Python/PySpark – doesn’t work
rdd = sc.parallelize(["1","2","3"])
Data = Row('first')
df = sqlContext.createDataFrame(rdd.map(lambda d: Data(d)))
print df
print df.collect()
z.show(df)
AttributeError: 'DataFrame' object has no attribute ‘_get_object_id'

More generally, ZeppelinContext methods are not working with Python objects since Py4J would need to know how to serialize it

It turns out the error is caused by Py4J trying to auto convert the DataFrame, which fails since it can only do that for simple types.
Instead of getting conversion to work, the better approach is to pass along the inner java object instead. To do that we intercept the call on the python side with a wrapper object instead of letting Py4J handle it.
As per comment, adding container/dictionary methods to allow for string passing using ZeppelinContext