### PR TITLE
ZEPPELIN-196: fix the auto-completion issue

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -426,15 +426,9 @@ angular.module('zeppelinWebApp')
 
               var pos = session.getTextRange(new Range(0, 0, pos.row, pos.column)).length;
               var buf = session.getValue();
-              $rootScope.$emit('sendNewEvent', {
-                  op : 'COMPLETION',
-                  data : {
-                      id : $scope.paragraph.id,
-                      buf : buf,
-                      cursor : pos
-                  }
-              });
-
+              
+              websocketMsgSrv.completion($scope.paragraph.id, buf, pos);
+              
               $scope.$on('completionList', function(event, data) {
                   if (data.completions) {
                       var completions = [];


### PR DESCRIPTION
The existing code  ($rootScope.$emit('sendNewEvent',...)) emits events to the  "sendNewEvent" channel but apparently there are no listener listening to it! 

The websocketMsgSrv service exposes a completion() method that is not used. The WS communication goes through this webscket service so it seemed natural to use it for the completion method as well. 

This change fixes the event flow problem. You can trace that COMPLETION events go down to the Interceptor's compete method and back to the completers $scope.$on('completionList') handler. 

It seems though that the SparkInteprteer's completer doesn't work. It never returns completion suggestions. But this is would be a different issue. 
