### PR TITLE
ZEPPELIN-173: Zeppelin websocket server is vulnerable to Cross-Site WebSocket Hijacking

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -71,7 +71,7 @@ public class NotebookServer extends WebSocketServlet implements
   @Override
   public void onOpen(NotebookSocket conn) {
     LOG.info("New connection from {} : {}", conn.getRequest().getRemoteAddr(),
-            conn.getRequest().getRemotePort());
+        conn.getRequest().getRemotePort());
     synchronized (connectedSockets) {
       synchronized (seenOrigins) {
         seenOrigins.add(getOrigin(conn));
@@ -87,51 +87,51 @@ public class NotebookServer extends WebSocketServlet implements
       LOG.info("RECEIVE << " + messagereceived.op);
       /** Lets be elegant here */
       switch (messagereceived.op) {
-        case LIST_NOTES:
-          broadcastNoteList();
-          break;
-        case GET_NOTE:
-          sendNote(conn, notebook, messagereceived);
-          break;
-        case NEW_NOTE:
-          createNote(conn, notebook);
-          break;
-        case DEL_NOTE:
-          removeNote(conn, notebook, messagereceived);
-          break;
-        case COMMIT_PARAGRAPH:
-          updateParagraph(conn, notebook, messagereceived);
-          break;
-        case RUN_PARAGRAPH:
-          runParagraph(conn, notebook, messagereceived);
-          break;
-        case CANCEL_PARAGRAPH:
-          cancelParagraph(conn, notebook, messagereceived);
-          break;
-        case MOVE_PARAGRAPH:
-          moveParagraph(conn, notebook, messagereceived);
-          break;
-        case INSERT_PARAGRAPH:
-          insertParagraph(conn, notebook, messagereceived);
-          break;
-        case PARAGRAPH_REMOVE:
-          removeParagraph(conn, notebook, messagereceived);
-          break;
-        case NOTE_UPDATE:
-          updateNote(conn, notebook, messagereceived);
-          break;
-        case COMPLETION:
-          completion(conn, notebook, messagereceived);
-          break;
-        case PING:
-          pong();
-          break;
-        case ANGULAR_OBJECT_UPDATED:
-          angularObjectUpdated(conn, notebook, messagereceived);
-          break;
-        default:
-          broadcastNoteList();
-          break;
+          case LIST_NOTES:
+            broadcastNoteList();
+            break;
+          case GET_NOTE:
+            sendNote(conn, notebook, messagereceived);
+            break;
+          case NEW_NOTE:
+            createNote(conn, notebook);
+            break;
+          case DEL_NOTE:
+            removeNote(conn, notebook, messagereceived);
+            break;
+          case COMMIT_PARAGRAPH:
+            updateParagraph(conn, notebook, messagereceived);
+            break;
+          case RUN_PARAGRAPH:
+            runParagraph(conn, notebook, messagereceived);
+            break;
+          case CANCEL_PARAGRAPH:
+            cancelParagraph(conn, notebook, messagereceived);
+            break;
+          case MOVE_PARAGRAPH:
+            moveParagraph(conn, notebook, messagereceived);
+            break;
+          case INSERT_PARAGRAPH:
+            insertParagraph(conn, notebook, messagereceived);
+            break;
+          case PARAGRAPH_REMOVE:
+            removeParagraph(conn, notebook, messagereceived);
+            break;
+          case NOTE_UPDATE:
+            updateNote(conn, notebook, messagereceived);
+            break;
+          case COMPLETION:
+            completion(conn, notebook, messagereceived);
+            break;
+          case PING:
+            pong();
+            break;
+          case ANGULAR_OBJECT_UPDATED:
+            angularObjectUpdated(conn, notebook, messagereceived);
+            break;
+          default:
+            broadcastNoteList();
+            break;
       }
     } catch (Exception e) {
       LOG.error("Can't handle message", e);
@@ -140,7 +140,7 @@ public class NotebookServer extends WebSocketServlet implements
   @Override
   public void onClose(NotebookSocket conn, int code, String reason) {
     LOG.info("Closed connection to {} : {}. ({}) {}", conn.getRequest()
-            .getRemoteAddr(), conn.getRequest().getRemotePort(), code, reason);
+        .getRemoteAddr(), conn.getRequest().getRemotePort(), code, reason);
     removeConnectionFromAllNote(conn);
     synchronized (connectedSockets) {
       synchronized (seenOrigins) {
@@ -204,7 +204,7 @@ public class NotebookServer extends WebSocketServlet implements
     return id;
   }
   private void broadcastToNoteBindedInterpreter(String interpreterGroupId,
-                                                Message m) {
+      Message m) {
     Notebook notebook = notebook();
     List<Note> notes = notebook.getAllNotes();
     for (Note note : notes) {
@@ -259,7 +259,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastAll(new Message(OP.NOTES_INFO).put("notes", notesInfo));
   }
   private void sendNote(NotebookSocket conn, Notebook notebook,
-                        Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("id");
     if (noteId == null) {
       return;
@@ -272,11 +272,11 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private void updateNote(WebSocket conn, Notebook notebook, Message fromMessage)
-          throws SchedulerException, IOException {
+      throws SchedulerException, IOException {
     String noteId = (String) fromMessage.get("id");
     String name = (String) fromMessage.get("name");
     Map<String, Object> config = (Map<String, Object>) fromMessage
-            .get("config");
+        .get("config");
     if (noteId == null) {
       return;
     }
@@ -297,10 +297,10 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private boolean isCronUpdated(Map<String, Object> configA,
-                                Map<String, Object> configB) {
+      Map<String, Object> configB) {
     boolean cronUpdated = false;
     if (configA.get("cron") != null && configB.get("cron") != null
-            && configA.get("cron").equals(configB.get("cron"))) {
+        && configA.get("cron").equals(configB.get("cron"))) {
       cronUpdated = true;
     } else if (configA.get("cron") == null && configB.get("cron") == null) {
       cronUpdated = false;
@@ -317,7 +317,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastNoteList();
   }
   private void removeNote(WebSocket conn, Notebook notebook, Message fromMessage)
-          throws IOException {
+      throws IOException {
     String noteId = (String) fromMessage.get("id");
     if (noteId == null) {
       return;
@@ -328,15 +328,15 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastNoteList();
   }
   private void updateParagraph(NotebookSocket conn, Notebook notebook,
-                               Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
     }
     Map<String, Object> params = (Map<String, Object>) fromMessage
-            .get("params");
+        .get("params");
     Map<String, Object> config = (Map<String, Object>) fromMessage
-            .get("config");
+        .get("config");
     final Note note = notebook.getNote(getOpenNoteId(conn));
     Paragraph p = note.getParagraph(paragraphId);
     p.settings.setParams(params);
@@ -347,7 +347,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcast(note.id(), new Message(OP.PARAGRAPH).put("paragraph", p));
   }
   private void removeParagraph(NotebookSocket conn, Notebook notebook,
-                               Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -361,7 +361,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private void completion(NotebookSocket conn, Notebook notebook,
-                          Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     String paragraphId = (String) fromMessage.get("id");
     String buffer = (String) fromMessage.get("buf");
     int cursor = (int) Double.parseDouble(fromMessage.get("cursor").toString());
@@ -383,7 +383,7 @@ public class NotebookServer extends WebSocketServlet implements
    * @param fromMessage the message.
    */
   private void angularObjectUpdated(WebSocket conn, Notebook notebook,
-                                    Message fromMessage) {
+      Message fromMessage) {
     String noteId = (String) fromMessage.get("noteId");
     String interpreterGroupId = (String) fromMessage.get("interpreterGroupId");
     String varName = (String) fromMessage.get("name");
@@ -394,14 +394,14 @@ public class NotebookServer extends WebSocketServlet implements
     Note note = notebook.getNote(noteId);
     if (note != null) {
       List<InterpreterSetting> settings = note.getNoteReplLoader()
-              .getInterpreterSettings();
+          .getInterpreterSettings();
       for (InterpreterSetting setting : settings) {
         if (setting.getInterpreterGroup() == null) {
           continue;
         }
         if (interpreterGroupId.equals(setting.getInterpreterGroup().getId())) {
           AngularObjectRegistry angularObjectRegistry = setting
-                  .getInterpreterGroup().getAngularObjectRegistry();
+              .getInterpreterGroup().getAngularObjectRegistry();
           // first trying to get local registry
           ao = angularObjectRegistry.get(varName, noteId);
           if (ao == null) {
@@ -427,54 +427,54 @@ public class NotebookServer extends WebSocketServlet implements
       // interpreter.
       for (Note n : notebook.getAllNotes()) {
         List<InterpreterSetting> settings = note.getNoteReplLoader()
-                .getInterpreterSettings();
+            .getInterpreterSettings();
         for (InterpreterSetting setting : settings) {
           if (setting.getInterpreterGroup() == null) {
             continue;
           }
           if (interpreterGroupId.equals(setting.getInterpreterGroup().getId())) {
             AngularObjectRegistry angularObjectRegistry = setting
-                    .getInterpreterGroup().getAngularObjectRegistry();
+                .getInterpreterGroup().getAngularObjectRegistry();
             this.broadcast(
-                    n.id(),
-                    new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
-                            .put("interpreterGroupId", interpreterGroupId)
-                            .put("noteId", n.id()));
+                n.id(),
+                new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
+                    .put("interpreterGroupId", interpreterGroupId)
+                    .put("noteId", n.id()));
           }
         }
       }
     } else { // broadcast to all web session for the note
       this.broadcast(
-              note.id(),
-              new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
-                      .put("interpreterGroupId", interpreterGroupId)
-                      .put("noteId", note.id()));
+          note.id(),
+          new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
+              .put("interpreterGroupId", interpreterGroupId)
+              .put("noteId", note.id()));
     }
   }
   private void moveParagraph(NotebookSocket conn, Notebook notebook,
-                             Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
     }
     final int newIndex = (int) Double.parseDouble(fromMessage.get("index")
-            .toString());
+        .toString());
     final Note note = notebook.getNote(getOpenNoteId(conn));
     note.moveParagraph(paragraphId, newIndex);
     note.persist();
     broadcastNote(note);
   }
   private void insertParagraph(NotebookSocket conn, Notebook notebook,
-                               Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     final int index = (int) Double.parseDouble(fromMessage.get("index")
-            .toString());
+        .toString());
     final Note note = notebook.getNote(getOpenNoteId(conn));
     note.insertParagraph(index);
     note.persist();
     broadcastNote(note);
   }
   private void cancelParagraph(NotebookSocket conn, Notebook notebook,
-                               Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -484,7 +484,7 @@ public class NotebookServer extends WebSocketServlet implements
     p.abort();
   }
   private void runParagraph(NotebookSocket conn, Notebook notebook,
-                            Message fromMessage) throws IOException {
+      Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -495,14 +495,14 @@ public class NotebookServer extends WebSocketServlet implements
     p.setText(text);
     p.setTitle((String) fromMessage.get("title"));
     Map<String, Object> params = (Map<String, Object>) fromMessage
-            .get("params");
+       .get("params");
     p.settings.setParams(params);
     Map<String, Object> config = (Map<String, Object>) fromMessage
-            .get("config");
+       .get("config");
     p.setConfig(config);
     // if it's the last paragraph, let's add a new one
     boolean isTheLastParagraph = note.getLastParagraph().getId()
-            .equals(p.getId());
+        .equals(p.getId());
     if (!Strings.isNullOrEmpty(text) && isTheLastParagraph) {
       note.addParagraph();
     }
@@ -514,8 +514,8 @@ public class NotebookServer extends WebSocketServlet implements
       LOG.error("Exception from run", ex);
       if (p != null) {
         p.setReturn(
-                new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()),
-                ex);
+            new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()),
+            ex);
         p.setStatus(Status.ERROR);
       }
     }
@@ -534,9 +534,9 @@ public class NotebookServer extends WebSocketServlet implements
     @Override
     public void onProgressUpdate(Job job, int progress) {
       notebookServer.broadcast(
-              note.id(),
-              new Message(OP.PROGRESS).put("id", job.getId()).put("progress",
-                      job.progress()));
+          note.id(),
+          new Message(OP.PROGRESS).put("id", job.getId()).put("progress",
+              job.progress()));
     }
     @Override
     public void beforeStatusChange(Job job, Status before, Status after) {
@@ -567,20 +567,20 @@ public class NotebookServer extends WebSocketServlet implements
   }
   private void sendAllAngularObjects(Note note, NotebookSocket conn) throws IOException {
     List<InterpreterSetting> settings = note.getNoteReplLoader()
-            .getInterpreterSettings();
+        .getInterpreterSettings();
     if (settings == null || settings.size() == 0) {
       return;
     }
     for (InterpreterSetting intpSetting : settings) {
       AngularObjectRegistry registry = intpSetting.getInterpreterGroup()
-              .getAngularObjectRegistry();
+          .getAngularObjectRegistry();
       List<AngularObject> objects = registry.getAllWithGlobal(note.id());
       for (AngularObject object : objects) {
         conn.send(serializeMessage(new Message(OP.ANGULAR_OBJECT_UPDATE)
-                .put("angularObject", object)
-                .put("interpreterGroupId",
-                        intpSetting.getInterpreterGroup().getId())
-                .put("noteId", note.id())));
+            .put("angularObject", object)
+            .put("interpreterGroupId",
+                intpSetting.getInterpreterGroup().getId())
+            .put("noteId", note.id())));
       }
     }
   }
@@ -600,17 +600,17 @@ public class NotebookServer extends WebSocketServlet implements
         continue;
       }
       List<InterpreterSetting> intpSettings = note.getNoteReplLoader()
-              .getInterpreterSettings();
+          .getInterpreterSettings();
       if (intpSettings.isEmpty())
         continue;
       for (InterpreterSetting setting : intpSettings) {
         if (setting.getInterpreterGroup().getId().equals(interpreterGroupId)) {
           broadcast(
-                  note.id(),
-                  new Message(OP.ANGULAR_OBJECT_UPDATE)
-                          .put("angularObject", object)
-                          .put("interpreterGroupId", interpreterGroupId)
-                          .put("noteId", note.id()));
+              note.id(),
+              new Message(OP.ANGULAR_OBJECT_UPDATE)
+                  .put("angularObject", object)
+                  .put("interpreterGroupId", interpreterGroupId)
+                  .put("noteId", note.id()));
         }
       }
     }
@@ -627,9 +627,9 @@ public class NotebookServer extends WebSocketServlet implements
       for (String id : ids) {
         if (id.equals(interpreterGroupId)) {
           broadcast(
-                  note.id(),
-                  new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
-                          "noteId", noteId));
+              note.id(),
+              new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
+                  "noteId", noteId));
         }
       }
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -50,7 +50,7 @@ import com.google.gson.Gson;
  * @author anthonycorbacho
  */
 public class NotebookServer extends WebSocketServlet implements
-    NotebookSocketListener, JobListenerFactory, AngularObjectRegistryListener {
+        NotebookSocketListener, JobListenerFactory, AngularObjectRegistryListener {
   private static final Logger LOG = LoggerFactory
           .getLogger(NotebookServer.class);
   Gson gson = new Gson();
@@ -71,7 +71,7 @@ public class NotebookServer extends WebSocketServlet implements
   @Override
   public void onOpen(NotebookSocket conn) {
     LOG.info("New connection from {} : {}", conn.getRequest().getRemoteAddr(),
-        conn.getRequest().getRemotePort());
+            conn.getRequest().getRemotePort());
     synchronized (connectedSockets) {
       synchronized (seenOrigins) {
         seenOrigins.add(getOrigin(conn));
@@ -87,51 +87,51 @@ public class NotebookServer extends WebSocketServlet implements
       LOG.info("RECEIVE << " + messagereceived.op);
       /** Lets be elegant here */
       switch (messagereceived.op) {
-          case LIST_NOTES:
-            broadcastNoteList();
-            break;
-          case GET_NOTE:
-            sendNote(conn, notebook, messagereceived);
-            break;
-          case NEW_NOTE:
-            createNote(conn, notebook);
-            break;
-          case DEL_NOTE:
-            removeNote(conn, notebook, messagereceived);
-            break;
-          case COMMIT_PARAGRAPH:
-            updateParagraph(conn, notebook, messagereceived);
-            break;
-          case RUN_PARAGRAPH:
-            runParagraph(conn, notebook, messagereceived);
-            break;
-          case CANCEL_PARAGRAPH:
-            cancelParagraph(conn, notebook, messagereceived);
-            break;
-          case MOVE_PARAGRAPH:
-            moveParagraph(conn, notebook, messagereceived);
-            break;
-          case INSERT_PARAGRAPH:
-            insertParagraph(conn, notebook, messagereceived);
-            break;
-          case PARAGRAPH_REMOVE:
-            removeParagraph(conn, notebook, messagereceived);
-            break;
-          case NOTE_UPDATE:
-            updateNote(conn, notebook, messagereceived);
-            break;
-          case COMPLETION:
-            completion(conn, notebook, messagereceived);
-            break;
-          case PING:
-            pong();
-            break;
-          case ANGULAR_OBJECT_UPDATED:
-            angularObjectUpdated(conn, notebook, messagereceived);
-            break;
-          default:
-            broadcastNoteList();
-            break;
+        case LIST_NOTES:
+          broadcastNoteList();
+          break;
+        case GET_NOTE:
+          sendNote(conn, notebook, messagereceived);
+          break;
+        case NEW_NOTE:
+          createNote(conn, notebook);
+          break;
+        case DEL_NOTE:
+          removeNote(conn, notebook, messagereceived);
+          break;
+        case COMMIT_PARAGRAPH:
+          updateParagraph(conn, notebook, messagereceived);
+          break;
+        case RUN_PARAGRAPH:
+          runParagraph(conn, notebook, messagereceived);
+          break;
+        case CANCEL_PARAGRAPH:
+          cancelParagraph(conn, notebook, messagereceived);
+          break;
+        case MOVE_PARAGRAPH:
+          moveParagraph(conn, notebook, messagereceived);
+          break;
+        case INSERT_PARAGRAPH:
+          insertParagraph(conn, notebook, messagereceived);
+          break;
+        case PARAGRAPH_REMOVE:
+          removeParagraph(conn, notebook, messagereceived);
+          break;
+        case NOTE_UPDATE:
+          updateNote(conn, notebook, messagereceived);
+          break;
+        case COMPLETION:
+          completion(conn, notebook, messagereceived);
+          break;
+        case PING:
+          pong();
+          break;
+        case ANGULAR_OBJECT_UPDATED:
+          angularObjectUpdated(conn, notebook, messagereceived);
+          break;
+        default:
+          broadcastNoteList();
+          break;
       }
     } catch (Exception e) {
       LOG.error("Can't handle message", e);
@@ -140,7 +140,7 @@ public class NotebookServer extends WebSocketServlet implements
   @Override
   public void onClose(NotebookSocket conn, int code, String reason) {
     LOG.info("Closed connection to {} : {}. ({}) {}", conn.getRequest()
-        .getRemoteAddr(), conn.getRequest().getRemotePort(), code, reason);
+            .getRemoteAddr(), conn.getRequest().getRemotePort(), code, reason);
     removeConnectionFromAllNote(conn);
     synchronized (connectedSockets) {
       synchronized (seenOrigins) {
@@ -158,7 +158,7 @@ public class NotebookServer extends WebSocketServlet implements
   private void addConnectionToNote(String noteId, NotebookSocket socket) {
     synchronized (noteSocketMap) {
       removeConnectionFromAllNote(socket); // make sure a socket relates only a
-                                           // single note.
+      // single note.
       List<NotebookSocket> socketList = noteSocketMap.get(noteId);
       if (socketList == null) {
         socketList = new LinkedList<>();
@@ -204,7 +204,7 @@ public class NotebookServer extends WebSocketServlet implements
     return id;
   }
   private void broadcastToNoteBindedInterpreter(String interpreterGroupId,
-      Message m) {
+                                                Message m) {
     Notebook notebook = notebook();
     List<Note> notes = notebook.getAllNotes();
     for (Note note : notes) {
@@ -259,7 +259,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastAll(new Message(OP.NOTES_INFO).put("notes", notesInfo));
   }
   private void sendNote(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                        Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("id");
     if (noteId == null) {
       return;
@@ -272,11 +272,11 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private void updateNote(WebSocket conn, Notebook notebook, Message fromMessage)
-      throws SchedulerException, IOException {
+          throws SchedulerException, IOException {
     String noteId = (String) fromMessage.get("id");
     String name = (String) fromMessage.get("name");
     Map<String, Object> config = (Map<String, Object>) fromMessage
-        .get("config");
+            .get("config");
     if (noteId == null) {
       return;
     }
@@ -297,10 +297,10 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private boolean isCronUpdated(Map<String, Object> configA,
-      Map<String, Object> configB) {
+                                Map<String, Object> configB) {
     boolean cronUpdated = false;
     if (configA.get("cron") != null && configB.get("cron") != null
-        && configA.get("cron").equals(configB.get("cron"))) {
+            && configA.get("cron").equals(configB.get("cron"))) {
       cronUpdated = true;
     } else if (configA.get("cron") == null && configB.get("cron") == null) {
       cronUpdated = false;
@@ -317,7 +317,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastNoteList();
   }
   private void removeNote(WebSocket conn, Notebook notebook, Message fromMessage)
-      throws IOException {
+          throws IOException {
     String noteId = (String) fromMessage.get("id");
     if (noteId == null) {
       return;
@@ -328,15 +328,15 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastNoteList();
   }
   private void updateParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                               Message fromMessage) throws IOException {
     String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
     }
     Map<String, Object> params = (Map<String, Object>) fromMessage
-        .get("params");
+            .get("params");
     Map<String, Object> config = (Map<String, Object>) fromMessage
-        .get("config");
+            .get("config");
     final Note note = notebook.getNote(getOpenNoteId(conn));
     Paragraph p = note.getParagraph(paragraphId);
     p.settings.setParams(params);
@@ -347,7 +347,7 @@ public class NotebookServer extends WebSocketServlet implements
     broadcast(note.id(), new Message(OP.PARAGRAPH).put("paragraph", p));
   }
   private void removeParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                               Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -361,7 +361,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
   private void completion(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                          Message fromMessage) throws IOException {
     String paragraphId = (String) fromMessage.get("id");
     String buffer = (String) fromMessage.get("buf");
     int cursor = (int) Double.parseDouble(fromMessage.get("cursor").toString());
@@ -377,13 +377,13 @@ public class NotebookServer extends WebSocketServlet implements
   }
   /**
    * When angular object updated from client
-   * 
+   *
    * @param conn the web socket.
    * @param notebook the notebook.
    * @param fromMessage the message.
    */
   private void angularObjectUpdated(WebSocket conn, Notebook notebook,
-      Message fromMessage) {
+                                    Message fromMessage) {
     String noteId = (String) fromMessage.get("noteId");
     String interpreterGroupId = (String) fromMessage.get("interpreterGroupId");
     String varName = (String) fromMessage.get("name");
@@ -394,14 +394,14 @@ public class NotebookServer extends WebSocketServlet implements
     Note note = notebook.getNote(noteId);
     if (note != null) {
       List<InterpreterSetting> settings = note.getNoteReplLoader()
-          .getInterpreterSettings();
+              .getInterpreterSettings();
       for (InterpreterSetting setting : settings) {
         if (setting.getInterpreterGroup() == null) {
           continue;
         }
         if (interpreterGroupId.equals(setting.getInterpreterGroup().getId())) {
           AngularObjectRegistry angularObjectRegistry = setting
-              .getInterpreterGroup().getAngularObjectRegistry();
+                  .getInterpreterGroup().getAngularObjectRegistry();
           // first trying to get local registry
           ao = angularObjectRegistry.get(varName, noteId);
           if (ao == null) {
@@ -424,57 +424,57 @@ public class NotebookServer extends WebSocketServlet implements
       }
     }
     if (global) { // broadcast change to all web session that uses related
-                  // interpreter.
+      // interpreter.
       for (Note n : notebook.getAllNotes()) {
         List<InterpreterSetting> settings = note.getNoteReplLoader()
-            .getInterpreterSettings();
+                .getInterpreterSettings();
         for (InterpreterSetting setting : settings) {
           if (setting.getInterpreterGroup() == null) {
             continue;
           }
           if (interpreterGroupId.equals(setting.getInterpreterGroup().getId())) {
             AngularObjectRegistry angularObjectRegistry = setting
-                .getInterpreterGroup().getAngularObjectRegistry();
+                    .getInterpreterGroup().getAngularObjectRegistry();
             this.broadcast(
-                n.id(),
-                new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
-                    .put("interpreterGroupId", interpreterGroupId)
-                    .put("noteId", n.id()));
+                    n.id(),
+                    new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
+                            .put("interpreterGroupId", interpreterGroupId)
+                            .put("noteId", n.id()));
           }
         }
       }
     } else { // broadcast to all web session for the note
       this.broadcast(
-          note.id(),
-          new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
-              .put("interpreterGroupId", interpreterGroupId)
-              .put("noteId", note.id()));
+              note.id(),
+              new Message(OP.ANGULAR_OBJECT_UPDATE).put("angularObject", ao)
+                      .put("interpreterGroupId", interpreterGroupId)
+                      .put("noteId", note.id()));
     }
   }
   private void moveParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                             Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
     }
     final int newIndex = (int) Double.parseDouble(fromMessage.get("index")
-        .toString());
+            .toString());
     final Note note = notebook.getNote(getOpenNoteId(conn));
     note.moveParagraph(paragraphId, newIndex);
     note.persist();
     broadcastNote(note);
   }
   private void insertParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                               Message fromMessage) throws IOException {
     final int index = (int) Double.parseDouble(fromMessage.get("index")
-        .toString());
+            .toString());
     final Note note = notebook.getNote(getOpenNoteId(conn));
     note.insertParagraph(index);
     note.persist();
     broadcastNote(note);
   }
   private void cancelParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                               Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -484,7 +484,7 @@ public class NotebookServer extends WebSocketServlet implements
     p.abort();
   }
   private void runParagraph(NotebookSocket conn, Notebook notebook,
-      Message fromMessage) throws IOException {
+                            Message fromMessage) throws IOException {
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -495,14 +495,14 @@ public class NotebookServer extends WebSocketServlet implements
     p.setText(text);
     p.setTitle((String) fromMessage.get("title"));
     Map<String, Object> params = (Map<String, Object>) fromMessage
-        .get("params");
+            .get("params");
     p.settings.setParams(params);
     Map<String, Object> config = (Map<String, Object>) fromMessage
-        .get("config");
+            .get("config");
     p.setConfig(config);
     // if it's the last paragraph, let's add a new one
     boolean isTheLastParagraph = note.getLastParagraph().getId()
-        .equals(p.getId());
+            .equals(p.getId());
     if (!Strings.isNullOrEmpty(text) && isTheLastParagraph) {
       note.addParagraph();
     }
@@ -514,8 +514,8 @@ public class NotebookServer extends WebSocketServlet implements
       LOG.error("Exception from run", ex);
       if (p != null) {
         p.setReturn(
-            new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()),
-            ex);
+                new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()),
+                ex);
         p.setStatus(Status.ERROR);
       }
     }
@@ -534,9 +534,9 @@ public class NotebookServer extends WebSocketServlet implements
     @Override
     public void onProgressUpdate(Job job, int progress) {
       notebookServer.broadcast(
-          note.id(),
-          new Message(OP.PROGRESS).put("id", job.getId()).put("progress",
-              job.progress()));
+              note.id(),
+              new Message(OP.PROGRESS).put("id", job.getId()).put("progress",
+                      job.progress()));
     }
     @Override
     public void beforeStatusChange(Job job, Status before, Status after) {
@@ -567,20 +567,20 @@ public class NotebookServer extends WebSocketServlet implements
   }
   private void sendAllAngularObjects(Note note, NotebookSocket conn) throws IOException {
     List<InterpreterSetting> settings = note.getNoteReplLoader()
-        .getInterpreterSettings();
+            .getInterpreterSettings();
     if (settings == null || settings.size() == 0) {
       return;
     }
     for (InterpreterSetting intpSetting : settings) {
       AngularObjectRegistry registry = intpSetting.getInterpreterGroup()
-          .getAngularObjectRegistry();
+              .getAngularObjectRegistry();
       List<AngularObject> objects = registry.getAllWithGlobal(note.id());
       for (AngularObject object : objects) {
         conn.send(serializeMessage(new Message(OP.ANGULAR_OBJECT_UPDATE)
-            .put("angularObject", object)
-            .put("interpreterGroupId",
-                intpSetting.getInterpreterGroup().getId())
-            .put("noteId", note.id())));
+                .put("angularObject", object)
+                .put("interpreterGroupId",
+                        intpSetting.getInterpreterGroup().getId())
+                .put("noteId", note.id())));
       }
     }
   }
@@ -600,17 +600,17 @@ public class NotebookServer extends WebSocketServlet implements
         continue;
       }
       List<InterpreterSetting> intpSettings = note.getNoteReplLoader()
-          .getInterpreterSettings();
+              .getInterpreterSettings();
       if (intpSettings.isEmpty())
         continue;
       for (InterpreterSetting setting : intpSettings) {
         if (setting.getInterpreterGroup().getId().equals(interpreterGroupId)) {
           broadcast(
-              note.id(),
-              new Message(OP.ANGULAR_OBJECT_UPDATE)
-                  .put("angularObject", object)
-                  .put("interpreterGroupId", interpreterGroupId)
-                  .put("noteId", note.id()));
+                  note.id(),
+                  new Message(OP.ANGULAR_OBJECT_UPDATE)
+                          .put("angularObject", object)
+                          .put("interpreterGroupId", interpreterGroupId)
+                          .put("noteId", note.id()));
         }
       }
     }
@@ -627,9 +627,9 @@ public class NotebookServer extends WebSocketServlet implements
       for (String id : ids) {
         if (id.equals(interpreterGroupId)) {
           broadcast(
-              note.id(),
-              new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
-                      "noteId", noteId));
+                  note.id(),
+                  new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
+                          "noteId", noteId));
         }
       }
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -16,8 +16,12 @@
  */
 package org.apache.zeppelin.socket;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.ArrayList;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
@@ -31,7 +31,6 @@ import org.junit.runners.MethodSorters;
  * @author joelz
  *
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
     public class NotebookServerTests {
 
     @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
@@ -1,0 +1,49 @@
+/**
+ * Created by joelz on 8/6/15.
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+        import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+/**
+ * BASIC Zeppelin rest api tests
+ * TODO: Add Post,Put,Delete test and method
+ *
+ * @author joelz
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+        public class NotebookServerTest {
+
+    @Test
+    public void CheckOrigin(){
+        NotebookServer server = new NotebookServer();
+        NotebookSocket socket = new NotebookSocket(new TestHttpServletRequest(), "http", new TestNotebookSocketListener());
+        server.onOpen(socket);
+        Assert.assertEquals(1, server.seenOrigins.size());
+        server.doWebSocketConnect(new TestHttpServletRequest(), "http");
+        Assert.assertTrue(server.checkOrigin(new TestHttpServletRequest(), "http://localhost:8080"));
+        server.onClose(socket, 0, "Shutdown");
+        Assert.assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://localhost:8080"));
+        Assert.assertEquals(0, server.seenOrigins.size());
+    }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
@@ -19,7 +19,7 @@
  */
 package org.apache.zeppelin.socket;
 
-        import org.junit.Assert;
+import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -32,7 +32,7 @@ import org.junit.runners.MethodSorters;
  *
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-        public class NotebookServerTest {
+        public class NotebookServerTests {
 
     @Test
     public void CheckOrigin(){
@@ -44,6 +44,18 @@ import org.junit.runners.MethodSorters;
         Assert.assertTrue(server.checkOrigin(new TestHttpServletRequest(), "http://localhost:8080"));
         server.onClose(socket, 0, "Shutdown");
         Assert.assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://localhost:8080"));
+        Assert.assertEquals(0, server.seenOrigins.size());
+    }
+
+    @Test
+    public void CheckInvalidOrigin(){
+        NotebookServer server = new NotebookServer();
+        NotebookSocket socket = new NotebookSocket(new TestHttpServletRequest(), "http", new TestNotebookSocketListener());
+        server.onOpen(socket);
+        Assert.assertEquals(1, server.seenOrigins.size());
+        server.doWebSocketConnect(new TestHttpServletRequest(), "http");
+        Assert.assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://evillocalhost:8080"));
+        server.onClose(socket, 0, "Shutdown");
         Assert.assertEquals(0, server.seenOrigins.size());
     }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTests.java
@@ -32,7 +32,7 @@ import org.junit.runners.MethodSorters;
  *
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-        public class NotebookServerTests {
+    public class NotebookServerTests {
 
     @Test
     public void CheckOrigin(){

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
@@ -1,7 +1,352 @@
 package org.apache.zeppelin.socket;
 
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * Created by joelz on 8/6/15.
  */
-public class TestHttpServletRequest {
+public class TestHttpServletRequest implements HttpServletRequest {
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return new Cookie[0];
+    }
+
+    @Override
+    public long getDateHeader(String s) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String s) {
+        switch (s) {
+            case "Origin":
+                return "http://localhost:8080";
+        }
+
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String s) {
+        return null;
+    }
+
+    @Override
+    public int getIntHeader(String s) {
+        return 0;
+    }
+
+    @Override
+    public String getMethod() {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public String getPathInfo() {
+        return null;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return null;
+    }
+
+    @Override
+    public String getQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return null;
+    }
+
+    @Override
+    public String getServletPath() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean b) {
+        return null;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isUserInRole(String s) {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String s) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public int getContentLength() {
+        return 0;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return null;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        return null;
+    }
+
+    @Override
+    public String getLocalName() {
+        return null;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public String getParameter(String s) {
+        return null;
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getParameterValues(String s) {
+        return new String[0];
+    }
+
+    @Override
+    public String getProtocol() {
+        return null;
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getRealPath(String s) {
+        return null;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return null;
+    }
+
+    @Override
+    public int getRemotePort() {
+        return 0;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String s) {
+        return null;
+    }
+
+    @Override
+    public String getScheme() {
+        return null;
+    }
+
+    @Override
+    public String getServerName() {
+        return null;
+    }
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public void removeAttribute(String s) {
+
+    }
+
+    @Override
+    public void setAttribute(String s, Object o) {
+
+    }
+
+    @Override
+    public void setCharacterEncoding(String s) throws UnsupportedEncodingException {
+
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        return null;
+    }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
@@ -1,3 +1,22 @@
+/**
+ * Created by joelz on 8/6/15.
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.socket;
 
 import javax.servlet.*;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
@@ -1,0 +1,7 @@
+package org.apache.zeppelin.socket;
+
+/**
+ * Created by joelz on 8/6/15.
+ */
+public class TestHttpServletRequest {
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestHttpServletRequest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 /**
  * Created by joelz on 8/6/15.
+ * Helps mocking a http servlet request
  */
 public class TestHttpServletRequest implements HttpServletRequest {
     @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
@@ -3,5 +3,19 @@ package org.apache.zeppelin.socket;
 /**
  * Created by joelz on 8/6/15.
  */
-public class TestNotebookSocketListener {
+public class TestNotebookSocketListener implements NotebookSocketListener {
+    @Override
+    public void onClose(NotebookSocket socket, int code, String message) {
+
+    }
+
+    @Override
+    public void onOpen(NotebookSocket socket) {
+
+    }
+
+    @Override
+    public void onMessage(NotebookSocket socket, String message) {
+
+    }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
@@ -1,3 +1,22 @@
+/**
+ * Created by joelz on 8/6/15.
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.socket;
 
 /**

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
@@ -2,6 +2,7 @@ package org.apache.zeppelin.socket;
 
 /**
  * Created by joelz on 8/6/15.
+ * This enables mocking a socket listener.
  */
 public class TestNotebookSocketListener implements NotebookSocketListener {
     @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/TestNotebookSocketListener.java
@@ -1,0 +1,7 @@
+package org.apache.zeppelin.socket;
+
+/**
+ * Created by joelz on 8/6/15.
+ */
+public class TestNotebookSocketListener {
+}


### PR DESCRIPTION
Fixing the socket cross-origin vulnerability as described in the Jira. Overwrote the checkOrigin in the WebSocketServlet class implemented by NotebookServer so that a list of all seen socket Get requests are kept and only Upgrade requests from the same origin will be accepted. Otherwise unauthorized will be returned.
Included basic unit tests.