### PR TITLE
ZEPPELIN-219: Paragaph mode auto-detection - initial impl

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -160,7 +160,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   $scope.startSaveTimer = function() {
     $scope.killSaveTimer();
     $scope.isNoteDirty = true;
-    console.log('startSaveTimer called ' + $scope.note.id);
+    //console.log('startSaveTimer called ' + $scope.note.id);
     $scope.saveTimer = $timeout(function(){
       $scope.saveNote();
     }, 10000);

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -29,7 +29,7 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       websocketEvents.sendNewEvent({op: 'DEL_NOTE', data: {id: noteId}});
     },
 
-	cloneNotebook: function(noteIdToClone, newNoteName ) {
+    cloneNotebook: function(noteIdToClone, newNoteName ) {
       websocketEvents.sendNewEvent({op: 'CLONE_NOTE', data: {id: noteIdToClone, name: newNoteName}});
     },
     getNotebookList: function() {


### PR DESCRIPTION
Here are the mode autodetection rules (and optimizations): 
- Evaluates the editor mode on each `aceChange` event.
- (Optimization 1) Evaluates the mode only if the cursor is within the first 30 characters of the buffer. 
- (Optimization 2) Sets the mode (e.g. `session.setMode(new mode)` ) only if the new mode differs from the previous one. 

Also the mode tag detection structure is refactored to bring together the interpreter tag test and the mode reference. The convention looks like this:
```javascript
  var editorModes = [
     [<Your Mode 1 Reg Expression Test>, <ACE Mode 1>],
     ......
     [<Your Mode N Reg Expression Test>, <ACE Mode N>]
  ];
```
For example:
```javascript
  var editorModes = [
     [/^%spark/, 'ace/mode/scala'],
     [/^%(\w*\.)?\wql/, 'ace/mode/sql'],
     [/^%md/, 'ace/mode/markdown'],
     [/^%sh/, 'ace/mode/sh']
  ];
```
