### PR TITLE
Show line number overide the paragraph title

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -356,7 +356,7 @@ angular.module('zeppelinWebApp')
     newConfig.lineNumbers = true;
     $scope.editor.renderer.setShowGutter(true);
 
-    commitParagraph($scope.paragraph.lineNumbers, $scope.paragraph.text, newConfig, newParams);
+    commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };
 
   $scope.hideLineNumbers = function () {
@@ -365,7 +365,7 @@ angular.module('zeppelinWebApp')
     newConfig.lineNumbers = false;
     $scope.editor.renderer.setShowGutter(false);
 
-    commitParagraph($scope.paragraph.lineNumbers, $scope.paragraph.text, newConfig, newParams);
+    commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };
 
   $scope.columnWidthClass = function(n) {


### PR DESCRIPTION
Show line number was calling ```commitParagraph``` with the wrong parameter as title which result in losing the title when hide\show numbers
![selection_014](https://cloud.githubusercontent.com/assets/2227083/9260817/d0aa99be-4212-11e5-9970-8d9995e15fbc.png)
Showing the numbers delete the title
![selection_015](https://cloud.githubusercontent.com/assets/2227083/9260818/d3131244-4212-11e5-981f-2726a22e313c.png)

