### PR TITLE
ZEPPELIN-227 Allow nextline invoke in SparkInterpreter

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -245,7 +245,17 @@ public class FlinkInterpreter extends Interpreter {
     Code r = null;
 
     String incomplete = "";
-    for (String s : linesToRun) {
+    for (int l = 0; l < linesToRun.length; l++) {
+      String s = linesToRun[l];      
+      // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
+      if (l + 1 < linesToRun.length) {
+        String nextLine = linesToRun[l + 1].trim();
+        if (nextLine.startsWith(".") && !nextLine.startsWith("..") && !nextLine.startsWith("./")) {
+          incomplete += s + "\n";
+          continue;
+        }
+      }
+
       scala.tools.nsc.interpreter.Results.Result res = null;
       try {
         res = imain.interpret(incomplete + s);

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
@@ -54,6 +54,11 @@ public class FlinkInterpreterTest {
     assertEquals("1", result.message());
   }
 
+  @Test
+  public void testNextlineInvoke() {
+    InterpreterResult result = flink.interpret("\"123\"\n  .toInt", context);
+    assertEquals("res0: Int = 123\n", result.message());    
+  }
 
   @Test
   public void testWordCount() {

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
@@ -286,7 +286,17 @@ public class IgniteInterpreter extends Interpreter {
     Code code = null;
 
     String incomplete = "";
-    for (String s : linesToRun) {
+    for (int l = 0; l < linesToRun.length; l++) {
+      String s = linesToRun[l];      
+      // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
+      if (l + 1 < linesToRun.length) {
+        String nextLine = linesToRun[l + 1].trim();
+        if (nextLine.startsWith(".") && !nextLine.startsWith("..") && !nextLine.startsWith("./")) {
+          incomplete += s + "\n";
+          continue;
+        }
+      }
+
       try {
         code = getResultCode(imain.interpret(incomplete + s));
       } catch (Exception e) {

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
@@ -84,6 +84,9 @@ public class IgniteInterpreterTest {
 
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertTrue(result.message().contains(sizeVal + ": Int = " + ignite.cluster().nodes().size()));
+
+    result = intp.interpret("\"123\"\n  .toInt", INTP_CONTEXT);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
   }
 
   @Test
@@ -92,10 +95,5 @@ public class IgniteInterpreterTest {
 
     assertEquals(InterpreterResult.Code.ERROR, result.code());
   }
-  
-  @Test
-  public void testNextlineInvoke() {
-    InterpreterResult result = intp.interpret("\"123\"\n  .toInt", INTP_CONTEXT);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-  }
+
 }

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
@@ -92,4 +92,10 @@ public class IgniteInterpreterTest {
 
     assertEquals(InterpreterResult.Code.ERROR, result.code());
   }
+  
+  @Test
+  public void testNextlineInvoke() {
+    InterpreterResult result = intp.interpret("\"123\"\n  .toInt", INTP_CONTEXT);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+  }
 }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -604,7 +604,18 @@ public class SparkInterpreter extends Interpreter {
     out.reset();
     Code r = null;
     String incomplete = "";
-    for (String s : linesToRun) {
+
+    for (int l = 0; l < linesToRun.length; l++) {
+      String s = linesToRun[l];      
+      // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
+      if (l + 1 < linesToRun.length) {
+        String nextLine = linesToRun[l + 1].trim();
+        if (nextLine.startsWith(".") && !nextLine.startsWith("..") && !nextLine.startsWith("./")) {
+          incomplete += s + "\n";
+          continue;
+        }
+      }
+
       scala.tools.nsc.interpreter.Results.Result res = null;
       try {
         res = intp.interpret(incomplete + s);

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -118,6 +118,11 @@ public class SparkInterpreterTest {
   }
 
   @Test
+  public void testNextLineInvocation() {
+    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("\"123\"\n.toInt", context).code());    
+  }
+
+  @Test
   public void testEndWithComment() {
     assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("val c=1\n//comment", context).code());
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-227

This patch allows invoke methods in nextline. To support such case

```scala
"123"
   .toInt
```