### PR TITLE
feat: use ZEPPELIN_HOSTNAME to specify hostname

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -23,6 +23,7 @@
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default = ZEPPELIN_MEM
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options. Default = ZEPPELIN_JAVA_OPTS
 
+# export ZEPPELIN_HOSTNAME          # hostname used to check web socket request origin. Defaults to java.net.InetAddress.getLocalHost().getHostName() or "localhost"
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. /tmp by default.
 # export ZEPPELIN_NOTEBOOK_DIR   		# Where notebook saved

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.UnknownHostException;
 
 /**
@@ -36,18 +37,33 @@ import java.net.UnknownHostException;
  * @author joelz
  *
  */
-    public class NotebookServerTests {
+public class NotebookServerTest {
+
+    private static String invokeHostName(NotebookServer server) {
+        String hostname = null;
+        try {
+            Method method = server.getClass().getDeclaredMethod("hostName");
+            method.setAccessible(true);
+            hostname =  method.invoke(server).toString();
+        }
+        catch (Exception e) {
+            Assert.fail("private hostName method missing");
+        }
+        return hostname;
+    }
 
     @Test
-    public void CheckOrigin() throws UnknownHostException {
+    public void CheckValidOrigin() throws UnknownHostException {
         NotebookServer server = new NotebookServer();
-         Assert.assertTrue(server.checkOrigin(new TestHttpServletRequest(),
+        Assert.assertTrue(server.checkOrigin(new TestHttpServletRequest(),
                  "http://" + java.net.InetAddress.getLocalHost().getHostName() + ":8080"));
+        Assert.assertEquals(invokeHostName(server), java.net.InetAddress.getLocalHost().getHostName());
     }
 
     @Test
     public void CheckInvalidOrigin(){
         NotebookServer server = new NotebookServer();
         Assert.assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://evillocalhost:8080"));
+        Assert.assertNotEquals(invokeHostName(server), "evillocalhost:8080");
     }
 }


### PR DESCRIPTION
ZEPPELIN_HOSTNAME supports running Zeppelin in environments where the
hostname of the server does not match the hostname delivered to the
browser. If ZEPPELIN_HOSTNAME is not set, java.net.InetAddress.
getLocalHost().getHostName() is still used to lookup the server's
current hostname.

NotebookServerTests was renamed to NotebookServerTest to permit the
test cases to run using Maven's test goal.

Fixes https://issues.apache.org/jira/browse/ZEPPELIN-231