### PR TITLE
Option to choose default interpreter for a group

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -106,6 +106,8 @@ public class SparkInterpreter extends Interpreter {
                 getSystemDefault("ZEPPELIN_SPARK_USEHIVECONTEXT",
                     "zeppelin.spark.useHiveContext", "true"),
                 "Use HiveContext instead of SQLContext if it is true.")
+            .add("zeppelin.default.interpreter", "spark",
+                "Default interpreter used for the spark group")
             .add("zeppelin.spark.maxResult",
                 getSystemDefault("ZEPPELIN_SPARK_MAXRESULT", "zeppelin.spark.maxResult", "1000"),
                 "Max number of SparkSQL result to display.")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -121,20 +121,25 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
     }
   }
 
+  public Interpreter getInterpreterByName(String interpreterName) {
+    Interpreter interpreter = null;
+    for (Interpreter intp : this) {
+      RegisteredInterpreter regIntp = Interpreter
+          .findRegisteredInterpreterByClassName(intp.getClassName());
+      if (regIntp.getName().equals(interpreterName)) {
+        interpreter = intp;
+        break;
+      }
+    }
+    return interpreter;
+  }
+
   public void bringDefaultToFront() {
     String defaultInterpreterName = getProperty().getProperty("zeppelin.default.interpreter");
     Logger logger = Logger.getLogger(InterpreterGroup.class);
     logger.info("Default interpreter name is " + defaultInterpreterName);
     if (defaultInterpreterName != null && defaultInterpreterName.trim().length() > 0) {
-      Interpreter defaultInterpreter = null;
-      for (Interpreter intp : this) {
-        RegisteredInterpreter regIntp = Interpreter
-            .findRegisteredInterpreterByClassName(intp.getClassName());
-        if (regIntp.getName().equals(defaultInterpreterName)) {
-          defaultInterpreter = intp;
-          break;
-        }
-      }
+      Interpreter defaultInterpreter = getInterpreterByName(defaultInterpreterName);
       //if there is a default interpreter, remove it and insert it at the head
       if (defaultInterpreter != null && defaultInterpreter != getFirst()) {
         logger.info("Default interpreter found. Moving to front of list");

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -24,6 +24,7 @@ import java.util.Random;
 
 import org.apache.log4j.Logger;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.interpreter.Interpreter.RegisteredInterpreter;
 
 /**
  * InterpreterGroup is list of interpreters in the same group.
@@ -116,6 +117,29 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
       } catch (InterruptedException e) {
         Logger logger = Logger.getLogger(InterpreterGroup.class);
         logger.error("Can't close interpreter", e);
+      }
+    }
+  }
+
+  public void bringDefaultToFront() {
+    String defaultInterpreterName = getProperty().getProperty("zeppelin.default.interpreter");
+    Logger logger = Logger.getLogger(InterpreterGroup.class);
+    logger.info("Default interpreter name is " + defaultInterpreterName);
+    if (defaultInterpreterName != null && defaultInterpreterName.trim().length() > 0) {
+      Interpreter defaultInterpreter = null;
+      for (Interpreter intp : this) {
+        RegisteredInterpreter regIntp = Interpreter
+            .findRegisteredInterpreterByClassName(intp.getClassName());
+        if (regIntp.getName().equals(defaultInterpreterName)) {
+          defaultInterpreter = intp;
+          break;
+        }
+      }
+      //if there is a default interpreter, remove it and insert it at the head
+      if (defaultInterpreter != null && defaultInterpreter != getFirst()) {
+        logger.info("Default interpreter found. Moving to front of list");
+        remove(defaultInterpreter);
+        addFirst(defaultInterpreter);
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -397,6 +397,7 @@ public class InterpreterFactory {
         }
       }
     }
+    interpreterGroup.bringDefaultToFront();
     return interpreterGroup;
   }
 


### PR DESCRIPTION
Allow the user to select a default interpreter from the interpreter settings, by setting 'zeppelin.default.Interpreter'. This interpreter, if present in the group, will be moved to the front of the group (i.e it becomes the first element in the linked list) when `createInterpreterGroup()` is called.

This interpreter now acts as the default. It is used whenever `interpreterGroup.get(0)` is called.