### PR TITLE
Fix NotebookList Ordering

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -381,9 +381,10 @@ public class NotebookServer extends WebSocketServlet implements
     note.addParagraph(); // it's an empty note. so add one paragraph
     if (message != null) {
       String noteName = (String) message.get("name");
-      if (noteName != null && !noteName.isEmpty()){
-        note.setName(noteName);
+      if (noteName == null || noteName.isEmpty()){
+        noteName = "Note " + note.id;
       }
+      note.setName(noteName);
     }
 
     note.persist();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -382,7 +382,7 @@ public class NotebookServer extends WebSocketServlet implements
     if (message != null) {
       String noteName = (String) message.get("name");
       if (noteName == null || noteName.isEmpty()){
-        noteName = "Note " + note.id;
+        noteName = "Note " + note.getId();
       }
       note.setName(noteName);
     }

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -13,11 +13,12 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, notebookListDataFactory, websocketMsgSrv, $rootScope) {
+angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, notebookListDataFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv) {
   
   var vm = this;
   vm.notes = notebookListDataFactory;
   vm.websocketMsgSrv = websocketMsgSrv;
+  vm.arrayOrderingSrv = arrayOrderingSrv;
 
   $scope.notebookHome = false;
   $scope.staticHome = false;

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -30,7 +30,7 @@ limitations under the License.
            <h5><a href="" data-toggle="modal" data-target="#noteNameModal" style="text-decoration: none;">
               <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
           <ul style="list-style-type: none;">
-            <li ng-repeat="note in home.notes.list track by $index"><i style="font-size: 10px;" class="icon-doc"></i>
+            <li ng-repeat="note in home.notes.list | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index"><i style="font-size: 10px;" class="icon-doc"></i>
               <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{note.name || 'Note ' + note.id}}</a>
             </li>
           </ul>

--- a/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
+++ b/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('zeppelinWebApp').service('arrayOrderingSrv', function() {
+
+  this.notebookListOrdering = function(note) {
+    return (note.name ? note.name : 'Note ' + note.id);
+  };
+
+});

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -15,16 +15,17 @@
 
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootScope, $routeParams, notebookListDataFactory, websocketMsgSrv) {
+angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootScope, $routeParams, notebookListDataFactory, websocketMsgSrv, arrayOrderingSrv) {
   /** Current list of notes (ids) */
 
   var vm = this;
   vm.notes = notebookListDataFactory;
   vm.connected = websocketMsgSrv.isConnected();
   vm.websocketMsgSrv = websocketMsgSrv;
-
-  $('#notebook-list').perfectScrollbar({suppressScrollX : true});
-
+  vm.arrayOrderingSrv = arrayOrderingSrv;
+  
+  $('#notebook-list').perfectScrollbar({suppressScrollX: true});
+  
   $scope.$on('setNoteMenu', function(event, notes) {
     notebookListDataFactory.setNotes(notes);
   });

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -32,7 +32,8 @@ limitations under the License.
             <li><a href="" data-toggle="modal" data-target="#noteNameModal"><i class="fa fa-plus"></i> Create new note</a></li>
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container">
-              <li ng-repeat="note in navbar.notes.list track by $index" ng-class="{'active' : navbar.isActive(note.id)}">
+              <li ng-repeat="note in navbar.notes.list | orderBy:navbar.arrayOrderingSrv.notebookListOrdering track by $index"
+                  ng-class="{'active' : navbar.isActive(note.id)}">
                 <a href="#/notebook/{{note.id}}">{{note.name || 'Note ' + note.id}} </a>
               </li>
             </div>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -124,6 +124,7 @@ limitations under the License.
     <script src="app/notebook/notebook.controller.js"></script>
     <script src="app/interpreter/interpreter.controller.js"></script>
     <script src="app/notebook/paragraph/paragraph.controller.js"></script>
+    <script src="components/arrayOrderingSrv/arrayOrdering.service.js"></script>
     <script src="components/navbar/navbar.controller.js"></script>
     <script src="components/ngescape/ngescape.directive.js"></script>
     <script src="components/noteName-create/notename.controller.js"></script>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -89,6 +89,10 @@ public class Note implements Serializable, JobListener {
   public String id() {
     return id;
   }
+  
+  public String getId() {
+    return id;
+  }
 
   public String getName() {
     return name;


### PR DESCRIPTION
In the notebook list, the notebooks that have been created without name (empty name) and prefixed with 'Note' are not ordered correctly with the others.

The reason behind it, is that when notebook doesn't have a name, we use the notebook id and prefix it by 'Note'. At that time the list was already ordered and therefore the Name shown doesn't match the position in the list.

Before:
![screen shot 2015-08-22 at 2 48 56 pm](https://cloud.githubusercontent.com/assets/710411/9422740/f9d7a496-48dc-11e5-9326-bfddd16dd66d.png)

After:
![screen shot 2015-08-22 at 2 30 26 pm](https://cloud.githubusercontent.com/assets/710411/9422688/6fdc69f4-48da-11e5-8f39-5752369942ab.png)

The Fix I have is to have an ordering function at the place we prefix the 'Note' on the front side.
Another solution could be to just to have by default the notebook name as 'Note ' + note.id when we create a note. The second option could probably be better performance wise, however it wouldn't be backward compatible.