### PR TITLE
Fix CI failing in master branch

### DIFF
--- a/zeppelin-server/src/test/resources/zeppelin-site-star.xml
+++ b/zeppelin-server/src/test/resources/zeppelin-site-star.xml
@@ -84,12 +84,6 @@
 </property>
 
 <property>
-  <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter</value>
-  <description>Comma separated interpreter configurations. First interpreter become a default</description>
-</property>
-
-<property>
   <name>zeppelin.interpreter.connect.timeout</name>
   <value>30000</value>
   <description>Interpreter process connect timeout in msec.</description>

--- a/zeppelin-server/src/test/resources/zeppelin-site.xml
+++ b/zeppelin-server/src/test/resources/zeppelin-site.xml
@@ -84,12 +84,6 @@
 </property>
 
 <property>
-  <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter</value>
-  <description>Comma separated interpreter configurations. First interpreter become a default</description>
-</property>
-
-<property>
   <name>zeppelin.interpreter.connect.timeout</name>
   <value>30000</value>
   <description>Interpreter process connect timeout in msec.</description>

--- a/zeppelin-zengine/src/test/resources/test-zeppelin-site1.xml
+++ b/zeppelin-zengine/src/test/resources/test-zeppelin-site1.xml
@@ -83,11 +83,6 @@
   <description>Interpreter implementation base directory</description>
 </property>
 
-<property>
-  <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter</value>
-  <description>Comma separated interpreter configurations. First interpreter become a default</description>
-</property>
 
 <property>
   <name>zeppelin.interpreter.connect.timeout</name>

--- a/zeppelin-zengine/src/test/resources/test-zeppelin-site2.xml
+++ b/zeppelin-zengine/src/test/resources/test-zeppelin-site2.xml
@@ -84,12 +84,6 @@
 </property>
 
 <property>
-  <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter</value>
-  <description>Comma separated interpreter configurations. First interpreter become a default</description>
-</property>
-
-<property>
   <name>zeppelin.interpreter.connect.timeout</name>
   <value>30000</value>
   <description>Interpreter process connect timeout in msec.</description>

--- a/zeppelin-zengine/src/test/resources/zeppelin-site.xml
+++ b/zeppelin-zengine/src/test/resources/zeppelin-site.xml
@@ -84,12 +84,6 @@
 </property>
 
 <property>
-  <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter</value>
-  <description>Comma separated interpreter configurations. First interpreter become a default</description>
-</property>
-
-<property>
   <name>zeppelin.interpreter.connect.timeout</name>
   <value>30000</value>
   <description>Interpreter process connect timeout in msec.</description>


### PR DESCRIPTION
This is fix for CI failing in master branch.
By removing zeppelin.interpreters property from test resources, let test perform with default values defined in ZeppelinConfiguration.