### PR TITLE
ZEPPELIN_PORT=10008 removed

### DIFF
--- a/docs/install/yarn_install.md
+++ b/docs/install/yarn_install.md
@@ -157,7 +157,6 @@ Set the following properties
 ```bash
 export JAVA_HOME=/home/zeppelin/prerequisites/jdk1.7.0_79
 export HADOOP_CONF_DIR=/etc/hadoop/conf
-export ZEPPELIN_PORT=10008
 export ZEPPELIN_JAVA_OPTS="-Dhdp.version=2.3.1.0-2574"
 ```
 


### PR DESCRIPTION
Port changed but afterwards it is specified the default 8080. No reason to change port. Besides, if it is really necessary, one should change it in the zeppelin-site.xml configuration file.