### PR TITLE
Update documentation: Set information about version of maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Test coverage report location are in `${submodule}/target/site/cobertura/index.h
 
 To build the code, install
  * Oracle Java 7
- * Apache Maven
+ * Apache Maven 3.3.x
 
 ## Getting the source code
 First of all, you need the Zeppelin source code. The official location for Zeppelin is [https://github.com/apache/incubator-zeppelin](https://github.com/apache/incubator-zeppelin)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To know more about Zeppelin, visit our web site [http://zeppelin.incubator.apach
 ## Requirements
  * Java 1.7
  * Tested on Mac OSX, Ubuntu 14.X, CentOS 6.X
- * Maven (if you want to build from the source code)
+ * Maven **3.3.x** (if you want to build from the source code)
  * Node.js Package Manager
 
 ## Getting Started


### PR DESCRIPTION
If you want to build from source, you need to have maven 3.3.x installed.
But this information is missing from the doc and contributing.
