### PR TITLE
Zeppelin-272: Remove option part from REST API

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -33,10 +33,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.zeppelin.interpreter.Interpreter;
-import org.apache.zeppelin.interpreter.InterpreterException;
-import org.apache.zeppelin.interpreter.InterpreterFactory;
-import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.Interpreter.RegisteredInterpreter;
 import org.apache.zeppelin.rest.message.NewInterpreterSettingRequest;
 import org.apache.zeppelin.rest.message.UpdateInterpreterSettingRequest;
@@ -102,7 +99,8 @@ public class InterpreterRestApi {
         NewInterpreterSettingRequest.class);
     Properties p = new Properties();
     p.putAll(request.getProperties());
-    interpreterFactory.add(request.getName(), request.getGroup(), request.getOption(), p);
+    // Option is deprecated from API, always use remote = true
+    interpreterFactory.add(request.getName(), request.getGroup(), new InterpreterOption(true), p);
     return new JsonResponse(Status.CREATED, "").build();
   }
 
@@ -114,7 +112,9 @@ public class InterpreterRestApi {
     try {
       UpdateInterpreterSettingRequest p = gson.fromJson(message,
           UpdateInterpreterSettingRequest.class);
-      interpreterFactory.setPropertyAndRestart(settingId, p.getOption(), p.getProperties());
+      // Option is deprecated from API, always use remote = true
+      interpreterFactory.setPropertyAndRestart(settingId,
+          new InterpreterOption(true), p.getProperties());
     } catch (InterpreterException e) {
       return new JsonResponse(
           Status.NOT_FOUND, e.getMessage(), ExceptionUtils.getStackTrace(e)).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -100,8 +100,11 @@ public class InterpreterRestApi {
     Properties p = new Properties();
     p.putAll(request.getProperties());
     // Option is deprecated from API, always use remote = true
-    interpreterFactory.add(request.getName(), request.getGroup(), new InterpreterOption(true), p);
-    return new JsonResponse(Status.CREATED, "").build();
+    InterpreterGroup interpreterGroup = interpreterFactory.add(request.getName(),
+        request.getGroup(), new InterpreterOption(true), p);
+    InterpreterSetting setting = interpreterFactory.get(interpreterGroup.getId());
+    logger.info("new setting created with " + setting.id());
+    return new JsonResponse(Status.CREATED, "", setting ).build();
   }
 
   @PUT

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewInterpreterSettingRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewInterpreterSettingRequest.java
@@ -28,7 +28,7 @@ import org.apache.zeppelin.interpreter.InterpreterOption;
 public class NewInterpreterSettingRequest {
   String name;
   String group;
-  InterpreterOption option;
+  // option was deprecated
   Map<String, String> properties;
 
   public NewInterpreterSettingRequest() {
@@ -47,7 +47,4 @@ public class NewInterpreterSettingRequest {
     return properties;
   }
 
-  public InterpreterOption getOption() {
-    return option;
-  }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/UpdateInterpreterSettingRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/UpdateInterpreterSettingRequest.java
@@ -25,18 +25,16 @@ import org.apache.zeppelin.interpreter.InterpreterOption;
  *
  */
 public class UpdateInterpreterSettingRequest {
-  InterpreterOption option;
+
+  // option was deprecated
   Properties properties;
 
   public UpdateInterpreterSettingRequest(InterpreterOption option,
       Properties properties) {
     super();
-    this.option = option;
     this.properties = properties;
   }
-  public InterpreterOption getOption() {
-    return option;
-  }
+
   public Properties getProperties() {
     return properties;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
@@ -1,0 +1,22 @@
+package org.apache.zeppelin.server;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+
+/**
+ * Created by eranw on 8/30/15.
+ * Omit InterpreterOption from serialization
+ */
+public class JsonExclusionStrategy implements ExclusionStrategy {
+
+  public boolean shouldSkipClass(Class<?> arg0) {
+    //exclude only InterpreterOption
+    return InterpreterOption.class.equals(arg0);
+  }
+
+  public boolean shouldSkipField(FieldAttributes f) {
+
+    return false;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.server;
 
 import com.google.gson.ExclusionStrategy;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonResponse.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonResponse.java
@@ -105,6 +105,7 @@ public class JsonResponse<T> {
     if (pretty) {
       gsonBuilder.setPrettyPrinting();
     }
+    gsonBuilder.setExclusionStrategies(new JsonExclusionStrategy());
     Gson gson = gsonBuilder.create();
     return gson.toJson(this);
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -149,3 +149,4 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("<p>markdown restarted</p>\n", p.getResult().message());
   }
 }
+

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -64,7 +64,6 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
     var index = _.findIndex($scope.interpreterSettings, { 'id': settingId });
 
     var request = {
-      option : angular.copy($scope.interpreterSettings[index].option),
       properties : angular.copy($scope.interpreterSettings[index].properties),
     };
 
@@ -169,7 +168,6 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
     $scope.newInterpreterSetting = {
       name : undefined,
       group : undefined,
-      option : { remote : true },
       properties : {}
     };
     emptyNewProperty($scope.newInterpreterSetting);


### PR DESCRIPTION
This PR remove the option part from the Interpreter setting REST API
 [x] Remove option from list settings
 [x] Remove option from Create settings and update settings
 [X] Update Create setting to return new created setting (jira 261) replacing pr # 258
Remove option from list setting is done by implementing a Exclusion strategy for the gson serialization.
Remove option from the Create\Update REST API is done by passing new InterpreterOption(remote=true) the the Factory and by omitting the InterpreterOption from the NewInterpreterSetting and UpdateInterpreterSetting classes.

REST API tests are managed in another 
Update to the documentation will be done in a separate PR 
