### PR TITLE
fix remoteinterpreterserver deadlock problem

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -354,11 +354,9 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
             if (p instanceof LazyOpenInterpreter) {
               lazy = (LazyOpenInterpreter) p;
             }
-            if (p instanceof SparkInterpreter) {
-              spark = (SparkInterpreter) p;
-            }
             p = ((WrappedInterpreter) p).getInnerInterpreter();
           }
+          spark = (SparkInterpreter) p;
         }
       }
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -344,21 +344,28 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
 
   private SparkInterpreter getSparkInterpreter() {
     InterpreterGroup intpGroup = getInterpreterGroup();
+    LazyOpenInterpreter lazy = null;
+    SparkInterpreter spark = null;
     synchronized (intpGroup) {
       for (Interpreter intp : getInterpreterGroup()){
         if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
           Interpreter p = intp;
           while (p instanceof WrappedInterpreter) {
             if (p instanceof LazyOpenInterpreter) {
-              ((LazyOpenInterpreter) p).open();
+              lazy = (LazyOpenInterpreter) p;
+            }
+            if (p instanceof SparkInterpreter) {
+              spark = (SparkInterpreter) p;
             }
             p = ((WrappedInterpreter) p).getInnerInterpreter();
           }
-          return (SparkInterpreter) p;
         }
       }
     }
-    return null;
+    if (lazy != null) {
+      lazy.open();
+    }
+    return spark;
   }
 
   public ZeppelinContext getZeppelinContext() {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -106,11 +106,9 @@ public class SparkSqlInterpreter extends Interpreter {
             if (p instanceof LazyOpenInterpreter) {
               lazy = (LazyOpenInterpreter) p;
             }
-            if (p instanceof SparkInterpreter) {
-              spark = (SparkInterpreter) p;
-            }
             p = ((WrappedInterpreter) p).getInnerInterpreter();
           }
+          spark = (SparkInterpreter) p;
         }
       }
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -96,21 +96,28 @@ public class SparkSqlInterpreter extends Interpreter {
 
   private SparkInterpreter getSparkInterpreter() {
     InterpreterGroup intpGroup = getInterpreterGroup();
+    LazyOpenInterpreter lazy = null;
+    SparkInterpreter spark = null;
     synchronized (intpGroup) {
-      for (Interpreter intp : getInterpreterGroup()) {
+      for (Interpreter intp : getInterpreterGroup()){
         if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
           Interpreter p = intp;
           while (p instanceof WrappedInterpreter) {
             if (p instanceof LazyOpenInterpreter) {
-              p.open();
+              lazy = (LazyOpenInterpreter) p;
+            }
+            if (p instanceof SparkInterpreter) {
+              spark = (SparkInterpreter) p;
             }
             p = ((WrappedInterpreter) p).getInnerInterpreter();
           }
-          return (SparkInterpreter) p;
         }
       }
     }
-    return null;
+    if (lazy != null) {
+      lazy.open();
+    }
+    return spark;
   }
 
   public boolean concurrentSQL() {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.SQLContext;
 import org.apache.spark.ui.jobs.JobProgressListener;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterPropertyBuilder;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -94,16 +95,19 @@ public class SparkSqlInterpreter extends Interpreter {
   }
 
   private SparkInterpreter getSparkInterpreter() {
-    for (Interpreter intp : getInterpreterGroup()) {
-      if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
-        Interpreter p = intp;
-        while (p instanceof WrappedInterpreter) {
-          if (p instanceof LazyOpenInterpreter) {
-            p.open();
+    InterpreterGroup intpGroup = getInterpreterGroup();
+    synchronized (intpGroup) {
+      for (Interpreter intp : getInterpreterGroup()) {
+        if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
+          Interpreter p = intp;
+          while (p instanceof WrappedInterpreter) {
+            if (p instanceof LazyOpenInterpreter) {
+              p.open();
+            }
+            p = ((WrappedInterpreter) p).getInnerInterpreter();
           }
-          p = ((WrappedInterpreter) p).getInnerInterpreter();
+          return (SparkInterpreter) p;
         }
-        return (SparkInterpreter) p;
       }
     }
     return null;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -63,13 +63,10 @@ public class LazyOpenInterpreter
       return;
     }
 
-    InterpreterGroup intpGroup = getInterpreterGroup();
-    synchronized (intpGroup) {
-      synchronized (intp) {
-        if (opened == false) {
-          intp.open();
-          opened = true;
-        }
+    synchronized (intp) {
+      if (opened == false) {
+        intp.open();
+        opened = true;
       }
     }
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -63,10 +63,13 @@ public class LazyOpenInterpreter
       return;
     }
 
-    synchronized (intp) {
-      if (opened == false) {
-        intp.open();
-        opened = true;
+    InterpreterGroup intpGroup = getInterpreterGroup();
+    synchronized (intpGroup) {
+      synchronized (intp) {
+        if (opened == false) {
+          intp.open();
+          opened = true;
+        }
       }
     }
   }


### PR DESCRIPTION
After using zeppelin server for some days, we often found that paragraph can't run while the zeppelin server process is on, restart interpreter is just not work. Then we find out that the RemoteInterpreterServer is in deadlock, and can't be stopped by zeppelin server. Unfortunately, this deadlocked RemoteInterpreterServer will still hold the hadoop resources, we need to kill the process manually each time. The detail Info shows in: https://issues.apache.org/jira/browse/ZEPPELIN-271
We figure out that the deadlock is caused by the lack of synchronized (intpGroup) in SparkSqlInterpreter.java