### PR TITLE
Lowering to ping timeout to have better keep-alive

### DIFF
--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -24,7 +24,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
     $rootScope.$broadcast('setConnectedStatus', true);
     setInterval(function(){
       websocketCalls.sendNewEvent({op: 'PING'});
-    }, 60000);
+    }, 10000);
   });
 
   websocketCalls.sendNewEvent = function(data) {


### PR DESCRIPTION
By default a lot of systems(nginx, apache) use 60 seconds as a keep-alive timeout value. This will disconnect the websocket when you don't do anything for that time, but the PING / PONG message can prevent this by sending a ping every 10 seconds instead of 60.