### PR TITLE
ZEPPELIN-276 Can not start zeppelin-deamon.sh on master

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -690,17 +690,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>../interpreter/spark/dep</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>      
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -345,17 +345,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>../interpreter/spark</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>      
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>


### PR DESCRIPTION
This patch providing fix for https://issues.apache.org/jira/browse/ZEPPELIN-276.

The reason was spark/pom.xml has maven-clean-plugin that clear interpreter/spark directory in maven 'clean' lifecycle. which results cleaning the directory interpreter/spark/dep created by spark-dependencies submodule, which directory supposed to have spark binaries.
