### PR TITLE
Enforcing maven version >= 3.1.0

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -32,6 +32,11 @@
   <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: web Application</name>
 
+  <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->
+  <prerequisites>
+    <maven>3.1.0</maven>
+  </prerequisites>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
As per eirslett/frontend-maven-plugin#229 zeppelin-web build requires maven version above 3.1.0

This PR enforces it though maven [prerequisites](http://maven.apache.org/ref/3.3.3/maven-model/maven.html#class_prerequisites). Documentation update is handled in #265.