### PR TITLE
ZEPPELIN-76 skip Selenium tests on 'mvn package'

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -396,6 +396,7 @@
         <executions>
           <execution>
             <id>test</id>
+            <phase>integration-test</phase>
             <goals>
               <goal>test</goal>
             </goals>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -357,7 +357,7 @@
           </execution>
         </executions>
         <configuration>
-	  <argLine>-Xmx2048m</argLine>
+          <argLine>-Xmx2048m</argLine>
         </configuration>
       </plugin>
 
@@ -448,9 +448,9 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-	<zeppelin.daemon.package.base>
-	  ../bin
-	</zeppelin.daemon.package.base>
+        <zeppelin.daemon.package.base>
+	        ../bin
+        </zeppelin.daemon.package.base>
       </properties>
     </profile>
 
@@ -460,9 +460,9 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
-	<zeppelin.daemon.package.base>
-	  ../zeppelin-distribution/target/zeppelin-${project.version}/zeppelin-${project.version}/bin
-	</zeppelin.daemon.package.base>
+        <zeppelin.daemon.package.base>
+	        ../zeppelin-distribution/target/zeppelin-${project.version}/zeppelin-${project.version}/bin
+        </zeppelin.daemon.package.base>
       </properties>
     </profile>
   </profiles>

--- a/zeppelin-server/src/test/scala/org/apache/zeppelin/AbstractFunctionalSuite.scala
+++ b/zeppelin-server/src/test/scala/org/apache/zeppelin/AbstractFunctionalSuite.scala
@@ -55,7 +55,7 @@ class AbstractFunctionalSuite extends FunSuite with WebBrowser with BeforeAndAft
   }
 
   def getDriver(): WebDriver = {
-    val possibleDrivers = List[() => WebDriver](safary, chrome, firefox)
+    val possibleDrivers = List[() => WebDriver](safari, chrome, firefox)
     val createdDriver = possibleDrivers.map(driverFactory => Try(driverFactory.apply())).find(_.isSuccess)
     createdDriver match {
       case Some(driver) => driver.get
@@ -63,7 +63,7 @@ class AbstractFunctionalSuite extends FunSuite with WebBrowser with BeforeAndAft
     }
   }
 
-  def safary(): WebDriver = {
+  def safari(): WebDriver = {
     new SafariDriver()
   }
 


### PR DESCRIPTION
Selenium-based tests are now triggerd by scalatest, instead of maven-failsafe-plugin, that is why they were triggered on `mvn package`.

This PR moves scalatest invocation further down the chain, i.e now only `mvn verify` or `mvn install` will trigger them.

No more `-DskipTests` by default!