### PR TITLE
Fix zeppelin-server security tests on case-sensitive hostname

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -18,29 +18,27 @@ package org.apache.zeppelin.utils;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 
 /**
- * Created by joelz on 8/19/15.
+ * Tools for securing Zeppelin
  */
 public class SecurityUtils {
+
   public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)
       throws UnknownHostException, URISyntaxException {
     if (sourceHost == null){
       return false;
     }
+    String sourceHostUriHost = new URI(sourceHost).getHost();
+    String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase();
 
-    URI sourceHostUri = new URI(sourceHost);
-    String currentHost = java.net.InetAddress.getLocalHost().getHostName().toLowerCase();
-    if (currentHost.equals(sourceHostUri.getHost()) ||
-            "localhost".equals(sourceHostUri.getHost()) ||
-            conf.getAllowedOrigins().contains(sourceHost) ||
-            conf.getAllowedOrigins().contains("*")) {
-      return true;
-    }
-
-    return false;
+    return conf.getAllowedOrigins().contains("*") ||
+            currentHost.equals(sourceHostUriHost) ||
+            "localhost".equals(sourceHostUriHost) ||
+            conf.getAllowedOrigins().contains(sourceHost);
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -30,15 +30,18 @@ public class SecurityUtils {
 
   public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)
       throws UnknownHostException, URISyntaxException {
-    if (sourceHost == null){
+    if (sourceHost == null || sourceHost.isEmpty()){
       return false;
     }
-    String sourceHostUriHost = new URI(sourceHost).getHost();
+    String sourceUriHost = new URI(sourceHost).getHost();
+    sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase();
+
+    sourceUriHost = sourceUriHost.toLowerCase();
     String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase();
 
     return conf.getAllowedOrigins().contains("*") ||
-            currentHost.equals(sourceHostUriHost) ||
-            "localhost".equals(sourceHostUriHost) ||
+            currentHost.equals(sourceUriHost) ||
+            "localhost".equals(sourceUriHost) ||
             conf.getAllowedOrigins().contains(sourceHost);
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.zeppelin.security;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.utils.SecurityUtils;
@@ -24,67 +24,61 @@ import org.junit.Test;
 
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.net.InetAddress;
 
-/**
- * Created by joelz on 8/19/15.
- */
+
 public class SecurityUtilsTest {
-    @Test
-    public void isInvalid() throws URISyntaxException, UnknownHostException {
-        Assert.assertFalse(SecurityUtils.isValidOrigin("http://127.0.1.1", ZeppelinConfiguration.create()));
-    }
 
-    @Test
-    public void isInvalidFromConfig() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertFalse(
-                SecurityUtils.isValidOrigin("http://otherinvalidhost.com",
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-    }
+  @Test
+  public void isInvalid() throws URISyntaxException, UnknownHostException {
+    assertFalse(SecurityUtils.isValidOrigin("http://127.0.1.1", ZeppelinConfiguration.create()));
+  }
 
-    @Test
-    public void isLocalhost() throws URISyntaxException, UnknownHostException {
-        Assert.assertTrue(SecurityUtils.isValidOrigin("http://localhost", ZeppelinConfiguration.create()));
-    }
+  @Test
+  public void isInvalidFromConfig() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(SecurityUtils.isValidOrigin("http://otherinvalidhost.com",
+          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
 
-    @Test
-    public void isLocalMachine() throws URISyntaxException, UnknownHostException {
-        Assert.assertTrue(SecurityUtils.isValidOrigin(
-                "http://" + java.net.InetAddress.getLocalHost().getHostName(),
-                ZeppelinConfiguration.create()));
-    }
+  @Test
+  public void isLocalhost() throws URISyntaxException, UnknownHostException {
+    assertTrue(SecurityUtils.isValidOrigin("http://localhost", ZeppelinConfiguration.create()));
+  }
 
-    @Test
-    public void isValidFromConfig() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertTrue(
-                SecurityUtils.isValidOrigin("http://otherhost.com",
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-    }
+  @Test
+  public void isLocalMachine() throws URISyntaxException, UnknownHostException {
+    String origin = "http://" + InetAddress.getLocalHost().getHostName();
+    assertTrue("Origin " + origin + " is not allowed. Please check your hostname.",
+               SecurityUtils.isValidOrigin(origin, ZeppelinConfiguration.create()));
+  }
 
-    @Test
-    public void isValidFromStar() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertTrue(
-                SecurityUtils.isValidOrigin("http://anyhost.com",
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
-    }
+  @Test
+  public void isValidFromConfig() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(SecurityUtils.isValidOrigin("http://otherhost.com",
+           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
 
-    @Test
-    public void nullOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertFalse(
-                SecurityUtils.isValidOrigin(null,
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-    }
+  @Test
+  public void isValidFromStar() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(SecurityUtils.isValidOrigin("http://anyhost.com",
+           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
+  }
 
-    @Test
-    public void emptyOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertFalse(
-                SecurityUtils.isValidOrigin("",
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-    }
+  @Test
+  public void nullOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(SecurityUtils.isValidOrigin(null,
+          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
 
-    @Test
-    public void notAURIOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
-        Assert.assertFalse(
-                SecurityUtils.isValidOrigin("test123",
-                        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-    }
+  @Test
+  public void emptyOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(SecurityUtils.isValidOrigin("",
+          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+  @Test
+  public void notAURIOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(SecurityUtils.isValidOrigin("test123",
+          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -19,34 +19,31 @@
  */
 package org.apache.zeppelin.socket;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import static org.junit.Assert.*;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
+import java.net.InetAddress;
 
 /**
  * BASIC Zeppelin rest api tests
- *
- *
- * @author joelz
- *
  */
-    public class NotebookServerTest {
+public class NotebookServerTest {
 
-    @Test
-    public void CheckOrigin() throws UnknownHostException {
-        NotebookServer server = new NotebookServer();
-         Assert.assertTrue(server.checkOrigin(new TestHttpServletRequest(),
-                 "http://" + java.net.InetAddress.getLocalHost().getHostName() + ":8080"));
-    }
+  @Test
+  public void checkOrigin() throws UnknownHostException {
+    NotebookServer server = new NotebookServer();
+    String origin = "http://" + InetAddress.getLocalHost().getHostName() + ":8080";
 
-    @Test
-    public void CheckInvalidOrigin(){
-        NotebookServer server = new NotebookServer();
-        Assert.assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://evillocalhost:8080"));
-    }
+    assertTrue("Origin " + origin + " is not allowed. Please check your hostname.",
+          server.checkOrigin(new TestHttpServletRequest(), origin));
+  }
+
+  @Test
+  public void checkInvalidOrigin(){
+    NotebookServer server = new NotebookServer();
+    assertFalse(server.checkOrigin(new TestHttpServletRequest(), "http://evillocalhost:8080"));
+  }
 }
+


### PR DESCRIPTION
On os x, w/ case-sensitive hostname some test for zeppelin-server were failing

```
$hostname 
MacBookPro.local

$mvn -pl zeppelin-server test
...
Results :

Failed tests:
  SecurityUtilsTest.isLocalMachine:56 null
  NotebookServerTest.CheckOrigin:43 null

Tests run: 22, Failures: 2, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

This PR changes fixes it.