### PR TITLE
[ZEPPELIN-283] IllegalArgumentException when running provided Spark 1.5.0 snapshot build

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -49,7 +49,8 @@ public enum SparkVersion {
 
   public static SparkVersion fromVersionString(String versionString) {
     for (SparkVersion v : values()) {
-      if (v.toString().equals(versionString)) {
+      // Check for the beginning of the version string to allow for "1.5.0-SNAPSHOT"
+      if (versionString.startsWith(v.toString())) {
         return v;
       }
     }

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkVersionTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkVersionTest.java
@@ -26,6 +26,7 @@ public class SparkVersionTest {
   public void testSparkVersion() {
     // test equals
     assertTrue(SparkVersion.SPARK_1_2_0 == SparkVersion.fromVersionString("1.2.0"));
+    assertTrue(SparkVersion.SPARK_1_5_0 == SparkVersion.fromVersionString("1.5.0-SNAPSHOT"));
 
     // test newer than
     assertFalse(SparkVersion.SPARK_1_2_0.newerThan(SparkVersion.SPARK_1_2_0));


### PR DESCRIPTION
This relax the Spark version check to allow for "1.5.0-SNAPSHOT"

@Leemoonsoo 