### PR TITLE
ZEPPELIN-276: Fix test failing on 'mvn clean package'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <executions>
           <execution>
             <id>copy-dependencies</id>
-            <phase>prepare-package</phase>
+            <phase>process-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>


### PR DESCRIPTION
Do so by moving copy dependencies to earlier mvn phase, so they got included in classpath from `interpreter.sh` on tests.

Details [ZEPPELIN-276](https://issues.apache.org/jira/browse/ZEPPELIN-276)