### PR TITLE
ZEPPELIN-294 Enable karma code coverage plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ zeppelin-web/.sass-cache
 zeppelin-web/bower_components
 **nbproject/
 **node/
+zeppelin-web/reports/coverage
 
 
 # project level

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -32,7 +32,8 @@
     "grunt-karma": "~0.8.3",
     "karma-phantomjs-launcher": "~0.1.4",
     "karma": "~0.12.23",
-    "karma-jasmine": "~0.1.5"
+    "karma-jasmine": "~0.1.5",
+    "karma-coverage": "^0.5.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -79,6 +79,7 @@
             <exclude>bower.json</exclude>
             <exclude>package.json</exclude>
             <exclude>*.md</exclude>
+            <exclude>reports/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -59,6 +59,7 @@ module.exports = function(config) {
       'src/app/app.js',
       'src/app/app.controller.js',
       'src/app/**/*.js',
+      'src/components/**/**/*.js',
       'test/spec/**/*.js'
     ],
 
@@ -80,10 +81,22 @@ module.exports = function(config) {
       'PhantomJS'
     ],
 
+    reporters: 'coverage',
+
+    preprocessors: {
+      'src/*/{*.js,!(test)/**/*.js}': 'coverage'
+    },
+
+    coverageReporter: {
+      type: 'html',
+      dir: 'coverage'
+    },
+
     // Which plugins to enable
     plugins: [
       'karma-phantomjs-launcher',
-      'karma-jasmine'
+      'karma-jasmine',
+      'karma-coverage'
     ],
 
     // Continuous Integration mode

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -59,7 +59,7 @@ module.exports = function(config) {
       'src/app/app.js',
       'src/app/app.controller.js',
       'src/app/**/*.js',
-      'src/components/**/**/*.js',
+      'src/components/**/*.js',
       'test/spec/**/*.js'
     ],
 
@@ -89,7 +89,7 @@ module.exports = function(config) {
 
     coverageReporter: {
       type: 'html',
-      dir: 'coverage'
+      dir: 'dist/reports/coverage'
     },
 
     // Which plugins to enable

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
 
     coverageReporter: {
       type: 'html',
-      dir: 'dist/reports/coverage'
+      dir: 'reports/coverage'
     },
 
     // Which plugins to enable


### PR DESCRIPTION
- grunt build generates the coverage report for js in zeppelin-web
- to view the report open `zeppelin-web/reports/coverage/PhantomJS 1.9.8 (Mac OS X 0.0.0)/index.html` in browser

<img width="1242" alt="screen shot 2015-09-10 at 12 45 28 pm" src="https://cloud.githubusercontent.com/assets/2031306/9782316/e27a2d8c-57b9-11e5-9c13-c9ff212c7bc0.png">

