### PR TITLE
ZEPPELIN-293  notebook execution results leaking to dashboard page

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -330,6 +330,7 @@ public class NotebookServer extends WebSocketServlet implements
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
       sendAllAngularObjects(note, conn);
     } else {
+      removeConnectionFromAllNote(conn);
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", null)));
     }
   }

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -53,4 +53,20 @@ limitations under the License.
 </div>
 
 
+<!-- Load notebook -->
+<div id="{{currentParagraph.id}}_paragraphColumn_main"
+     ng-show="notebookHome"
+     ng-repeat="currentParagraph in note.paragraphs"
+     ng-controller="ParagraphCtrl"
+     ng-Init="init(currentParagraph)"
+     ng-class="columnWidthClass(currentParagraph.config.colWidth)"
+     class="paragraph-col">
+  <div id="{{currentParagraph.id}}_paragraphColumn"
+       ng-if="currentParagraph.result"
+       ng-include src="'app/notebook/paragraph/paragraph.html'"
+       ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused}"
+       ng-hide="currentParagraph.config.tableHide && viewOnly">
+  </div>
+</div>
+
 <div style="clear:both;height:10px"></div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -53,20 +53,4 @@ limitations under the License.
 </div>
 
 
-<!-- Load notebook -->
-<div id="{{currentParagraph.id}}_paragraphColumn_main"
-     ng-show="notebookHome"
-     ng-repeat="currentParagraph in note.paragraphs"
-     ng-controller="ParagraphCtrl"
-     ng-Init="init(currentParagraph)"
-     ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-     class="paragraph-col">
-  <div id="{{currentParagraph.id}}_paragraphColumn"
-       ng-if="currentParagraph.result"
-       ng-include src="'app/notebook/paragraph/paragraph.html'"
-       ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused}"
-       ng-hide="currentParagraph.config.tableHide && viewOnly">
-  </div>
-</div>
-
 <div style="clear:both;height:10px"></div>


### PR DESCRIPTION
When we run a paragraph, and without it completing we navigate to dashboard page; upon execution  the results are displayed on the dashboard.

![screen shot 2015-09-09 at 1 50 35 pm](https://cloud.githubusercontent.com/assets/674497/9783325/15990682-57c1-11e5-82c4-da020f859e0a.png)
 