### PR TITLE
ZEPPELIN-303 Zeppelin should exit when jettyServer.start() throws an exception

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -99,8 +99,14 @@ public class ZeppelinServer extends Application {
     jettyServer.setHandler(contexts);
 
     LOG.info("Start zeppelin server");
-    jettyServer.start();
-    LOG.info("Started");
+    try {
+      jettyServer.start();
+    } catch (Exception e) {
+      LOG.error("Error while running jettyServer", e);
+      //TODO(jl): Fix the error status code
+      System.exit(-1);
+    }
+    LOG.info("Started zeppelin server");
 
     Runtime.getRuntime().addShutdownHook(new Thread(){
       @Override public void run() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -103,7 +103,6 @@ public class ZeppelinServer extends Application {
       jettyServer.start();
     } catch (Exception e) {
       LOG.error("Error while running jettyServer", e);
-      //TODO(jl): Fix the error status code
       System.exit(-1);
     }
     LOG.info("Started zeppelin server");


### PR DESCRIPTION
- Added exit condition while jetty cannot run properly