### PR TITLE
ZEPPELIN-296 add flink docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,11 @@
 ## Zeppelin project website
 
-## Build
+Welcome to the Zeppelin documentation!
+
+This readme will walk you through building the Zeppelin documentation, which is included here with the Zeppelin source code.
+
+
+## Build website
 See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 
 **tl;dr version:**
@@ -11,22 +16,25 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
     
 *On OS X 10.9 you may need to do "xcode-select --install"*
 
-## On local machine
 
-### Run
+## Run website
+
     bundle exec jekyll serve --watch
 
-### Deploy
- 1. generate static website in ```_site```
 
-    bundle exec jekyll build
- 2. checkout asf repo
+## Deploy to ASF svnpubsub infra (commiters only)
+ 1. generate static website in `./_site`
+    ```
+    bundle exec jekyll build --safe
+    ```
 
+ 2. checkout ASF repo
+    ```
     svn co https://svn.apache.org/repos/asf/incubator/zeppelin asf-zepplelin
-
+    ```
  3. copy zeppelin/_site to asf-zepplelin/site
- 4.  svn commit
+ 4. ```svn commit```
 
-### Add a new page
+## Adding a new page
+
     rake page name="new-page.md"
-    

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,7 +19,7 @@ group: nav-right
 
 **[Interpreters in zeppelin](manual/interpreters.html)**
 
-* [flink](../docs/pleasecontribute.html)
+* [flink](../docs/interpreter/flink.html)
 * [hive](../docs/pleasecontribute.html)
 * [ignite](../docs/pleasecontribute.html)
 * [lens](../docs/pleasecontribute.html)
@@ -51,6 +51,5 @@ group: nav-right
 * [Writing Zeppelin Interpreter](./development/writingzeppelininterpreter.html)
 * [How to contribute (code)](./development/howtocontribute.html)
 * [How to contribute (website)](./development/howtocontributewebsite.html)
-
 
 

--- a/docs/docs/interpreter/flink.md
+++ b/docs/docs/interpreter/flink.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: "Flink Interpreter"
+description: ""
+group: manual
+---
+{% include JB/setup %}
+
+
+## Flink interpreter for Apache Zeppelin
+[Apache Flink](https://flink.apache.org) is an open source platform for distributed stream and batch data processing.
+
+
+### How to start local Flink cluster, to test the interpreter
+Zeppelin comes with pre-configured flink-local interpreter, which starts Flink in a local mode on your machine, so you do not need to install anything.
+
+### How to configure interpreter to point to Flink cluster
+At the "Interpreters" menu, you have to create a new Flink interpreter and provide next properties:
+
+property | value    | Description
+---------|----------|-----
+host	 | local    | host name of running JobManager. 'local' runs flink in local mode (default)
+port	 | 6123     | port of running JobManager
+xxx    | yyy      | anything else from [Flink Configuration](https://ci.apache.org/projects/flink/flink-docs-release-0.9/setup/config.html)
+
+### How to test it's working
+
+In example, by using the [Zeppelin notebook](https://www.zeppelinhub.com/viewer/notebooks/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL05GTGFicy96ZXBwZWxpbi1ub3RlYm9va3MvbWFzdGVyL25vdGVib29rcy8yQVFFREs1UEMvbm90ZS5qc29u) is from [Till Rohrmann's presentation](http://www.slideshare.net/tillrohrmann/data-analysis-49806564) "Interactive data analysis with Apache Flink" for Apache Flink Meetup.
+
+
+```
+%sh
+rm 10.txt.utf-8
+wget http://www.gutenberg.org/ebooks/10.txt.utf-8
+```
+```
+%flink
+case class WordCount(word: String, frequency: Int)
+val bible:DataSet[String] = env.readTextFile("10.txt.utf-8")
+val partialCounts: DataSet[WordCount] = bible.flatMap{
+    line =>
+        """\b\w+\b""".r.findAllIn(line).map(word => WordCount(word, 1))
+//        line.split(" ").map(word => WordCount(word, 1))
+}
+val wordCounts = partialCounts.groupBy("word").reduce{
+    (left, right) => WordCount(left.word, left.frequency + right.frequency)
+}
+val result10 = wordCounts.first(10).collect()
+```

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,14 +8,16 @@ group: nav-right
 
 ### Download Zeppelin
 
-The latest release of Apache Zeppelin (incubating) is 0.5.0-incubating. Released on July 23, 2015 ([release notes](./docs/releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
+The latest release of Apache Zeppelin (incubating) is *0.5.0-incubating*.
 
-[Download](http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.0-incubating)
+  - 0.5.0-incubating released on July 23, 2015 ([release notes](./docs/releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
+
+    [Download](http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.0-incubating)
 
 
-### Build from source, installation
+### Build from source
 
-Check [install](./docs/install/install.html).
+For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [install](./docs/install/install.html) section.
 
 
 <!-- 


### PR DESCRIPTION
[ZEPPELIN-296](https://issues.apache.org/jira/browse/ZEPPELIN-296) initial documentation for Apache Flink interpreter

While we are at it, there are some minor updates for the docs too.