### PR TITLE
Fix HTML/ANGULAR extra rendering

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -624,7 +624,6 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     note.persist();
-    broadcastNote(note);
     try {
       note.run(paragraphId);
     } catch (Exception ex) {
@@ -678,7 +677,6 @@ public class NotebookServer extends WebSocketServlet implements
           e.printStackTrace();
         }
       }
-
       notebookServer.broadcastNote(note);
     }
   }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -87,7 +87,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       $location.path('/#');
     }
   };
-  
+
   $scope.runNote = function() {
     var result = confirm('Run all paragraphs?');
     if (result) {
@@ -298,8 +298,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     for (var i=$scope.note.paragraphs.length-1; i>=0; i--) {
       if (focus === false ) {
         if ($scope.note.paragraphs[i].id === currentParagraphId) {
-            focus = true;
-            continue;
+          focus = true;
+          continue;
         }
       } else {
         var p = $scope.note.paragraphs[i];
@@ -316,8 +316,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     for (var i=0; i<$scope.note.paragraphs.length; i++) {
       if (focus === false ) {
         if ($scope.note.paragraphs[i].id === currentParagraphId) {
-            focus = true;
-            continue;
+          focus = true;
+          continue;
         }
       } else {
         var p = $scope.note.paragraphs[i];
@@ -385,16 +385,18 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   var getInterpreterBindings = function(callback) {
     $http.get(baseUrlSrv.getRestApiBase()+ '/notebook/interpreter/bind/' +$scope.note.id).
-      success(function(data, status, headers, config) {
-        $scope.interpreterBindings = data.body;
-        $scope.interpreterBindingsOrig = jQuery.extend(true, [], $scope.interpreterBindings); // to check dirty
-        if (callback) {
-          callback();
-        }
-      }).
-      error(function(data, status, headers, config) {
+    success(function(data, status, headers, config) {
+      $scope.interpreterBindings = data.body;
+      $scope.interpreterBindingsOrig = jQuery.extend(true, [], $scope.interpreterBindings); // to check dirty
+      if (callback) {
+        callback();
+      }
+    }).
+    error(function(data, status, headers, config) {
+      if (status !== 0) {
         console.log('Error %o %o', status, data.message);
-      });
+      }
+    });
   };
 
   var getInterpreterBindingsCallBack = function() {
@@ -455,14 +457,14 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
 
     $http.put(baseUrlSrv.getRestApiBase() + '/notebook/interpreter/bind/' + $scope.note.id,
-             selectedSettingIds).
-      success(function(data, status, headers, config) {
-        console.log('Interpreter binding %o saved', selectedSettingIds);
-        $scope.showSetting = false;
-      }).
-      error(function(data, status, headers, config) {
-        console.log('Error %o %o', status, data.message);
-      });
+              selectedSettingIds).
+    success(function(data, status, headers, config) {
+      console.log('Interpreter binding %o saved', selectedSettingIds);
+      $scope.showSetting = false;
+    }).
+    error(function(data, status, headers, config) {
+      console.log('Error %o %o', status, data.message);
+    });
   };
 
   $scope.toggleSetting = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -437,6 +437,7 @@ angular.module('zeppelinWebApp')
     var langTools = ace.require('ace/ext/language_tools');
     var Range = ace.require('ace/range').Range;
 
+    _editor.$blockScrolling = Infinity;
     $scope.editor = _editor;
     _editor.$blockScrolling = Infinity;
     if (_editor.container.id !== '{{paragraph.id}}_editor') {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -43,13 +43,7 @@ angular.module('zeppelinWebApp')
 
     initializeDefault();
 
-    if (!$scope.lastData) {
-      $scope.lastData = {};
-    }
-
     if ($scope.getResultType() === 'TABLE') {
-      $scope.lastData.settings = angular.copy($scope.paragraph.settings);
-      $scope.lastData.config = angular.copy($scope.paragraph.config);
       $scope.loadTableData($scope.paragraph.result);
       $scope.setGraphMode($scope.getGraphMode(), false, false);
     } else if ($scope.getResultType() === 'HTML') {
@@ -70,7 +64,6 @@ angular.module('zeppelinWebApp')
           console.log('HTML rendering error %o', err);
         }
       } else {
-        $timeout(retryRenderer,10);
       }
     };
     $timeout(retryRenderer);
@@ -157,22 +150,17 @@ angular.module('zeppelinWebApp')
   // TODO: this may have impact on performance when there are many paragraphs in a note.
   $scope.$on('updateParagraph', function(event, data) {
     if (data.paragraph.id === $scope.paragraph.id &&
-        (
-      data.paragraph.dateCreated !== $scope.paragraph.dateCreated ||
-      data.paragraph.dateFinished !== $scope.paragraph.dateFinished ||
-      data.paragraph.dateStarted !== $scope.paragraph.dateStarted ||
-      data.paragraph.dateUpdated !== $scope.paragraph.dateUpdated ||
-      data.paragraph.status !== $scope.paragraph.status ||
-      data.paragraph.jobName !== $scope.paragraph.jobName ||
-      data.paragraph.title !== $scope.paragraph.title ||
-      data.paragraph.errorMessage !== $scope.paragraph.errorMessage ||
-      !angular.equals(data.paragraph.settings, $scope.lastData.settings) ||
-      !angular.equals(data.paragraph.config, $scope.lastData.config)
-    )
+        (data.paragraph.dateCreated !== $scope.paragraph.dateCreated ||
+         data.paragraph.dateFinished !== $scope.paragraph.dateFinished ||
+         data.paragraph.dateStarted !== $scope.paragraph.dateStarted ||
+         data.paragraph.dateUpdated !== $scope.paragraph.dateUpdated ||
+         data.paragraph.status !== $scope.paragraph.status ||
+         data.paragraph.jobName !== $scope.paragraph.jobName ||
+         data.paragraph.title !== $scope.paragraph.title ||
+         data.paragraph.errorMessage !== $scope.paragraph.errorMessage ||
+         !angular.equals(data.paragraph.settings, $scope.paragraph.settings) ||
+         !angular.equals(data.paragraph.config, $scope.paragraph.config))
        ) {
-      // store original data for comparison
-      $scope.lastData.settings = angular.copy(data.paragraph.settings);
-      $scope.lastData.config = angular.copy(data.paragraph.config);
 
       var oldType = $scope.getResultType();
       var newType = $scope.getResultType(data.paragraph);
@@ -230,9 +218,9 @@ angular.module('zeppelinWebApp')
         } else {
           $scope.setGraphMode(newGraphMode, false, true);
         }
-      } else if (newType === 'HTML') {
+      } else if (newType === 'HTML' && resultRefreshed) {
         $scope.renderHtml();
-      } else if (newType === 'ANGULAR') {
+      } else if (newType === 'ANGULAR' && resultRefreshed) {
         $scope.renderAngular();
       }
     }
@@ -439,7 +427,6 @@ angular.module('zeppelinWebApp')
 
     _editor.$blockScrolling = Infinity;
     $scope.editor = _editor;
-    _editor.$blockScrolling = Infinity;
     if (_editor.container.id !== '{{paragraph.id}}_editor') {
       $scope.editor.renderer.setShowGutter($scope.paragraph.config.lineNumbers);
       $scope.editor.setShowFoldWidgets(false);
@@ -447,8 +434,8 @@ angular.module('zeppelinWebApp')
       $scope.editor.setHighlightGutterLine(false);
       $scope.editor.setTheme('ace/theme/chrome');
       $scope.editor.focus();
-      var hight = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
-      setEditorHeight(_editor.container.id, hight);
+      var height = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
+      setEditorHeight(_editor.container.id, height);
 
       $scope.editor.getSession().setUseWrapMode(true);
       if (navigator.appVersion.indexOf('Mac') !== -1 ) {
@@ -540,8 +527,8 @@ angular.module('zeppelinWebApp')
 
 
       $scope.editor.getSession().on('change', function(e, editSession) {
-        hight = editSession.getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
-        setEditorHeight(_editor.container.id, hight);
+        height = editSession.getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
+        setEditorHeight(_editor.container.id, height);
         $scope.editor.resize();
       });
 
@@ -631,7 +618,7 @@ angular.module('zeppelinWebApp')
     return desc;
   };  
 
-  $scope.isResultOutdated = function() {      
+  $scope.isResultOutdated = function() {
     var pdata = $scope.paragraph;
     if (pdata.dateUpdated !==undefined && Date.parse(pdata.dateUpdated) > Date.parse(pdata.dateStarted)){
       return true;


### PR DESCRIPTION
1) The HTML and ANGULAR type of results were rendered for every change on the paragraph (ex: when editor is hidden)

I also took care of removing a few unnecessary variables.

2) When we run the paragraph, we received 3 to 4 times a response from the server
(1st from the run paragraph function, then one for each status change). I removed the run paragraph response since the status will take care of it.

We might want to consider in the future replacing the return value of runParagraph by the paragraph only instead of the full note.