### PR TITLE
Interpreter setting not getting saved

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -61,6 +61,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       return;
     }
 
+    $scope.addNewInterpreterProperty(settingId);
     var index = _.findIndex($scope.interpreterSettings, { 'id': settingId });
 
     var request = {
@@ -147,6 +148,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       return;
     }
 
+    $scope.addNewInterpreterProperty();
     var newSetting = angular.copy($scope.newInterpreterSetting);
 
     for (var p in $scope.newInterpreterSetting.properties) {
@@ -199,8 +201,9 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       // Add new property from edit form
       var index = _.findIndex($scope.interpreterSettings, { 'id': settingId });
       var setting = $scope.interpreterSettings[index];
-
-      setting.properties[setting.propertyKey] = setting.propertyValue;
+      if(setting.propertyKey){
+	    setting.properties[setting.propertyKey] = setting.propertyValue;
+      }
       emptyNewProperty(setting);
     }
   };


### PR DESCRIPTION
Scenario.
In the create new interpreter setting form
1)Press "+" to create a new key/value.
2) Enter details.(dont press "+" button)
3)Press "save" button
The interpreter setting doesnot have the property, and is not persisted.

Only when the "+" is pressed(or is there any other way), the setting is saved.
This is true for settings edit form as well.

Fixing this 