### PR TITLE
ZEPPELIN-315 Fix time-dependant scheduling test

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -193,13 +193,14 @@ public class NotebookTest implements JobListenerFactory{
     note.setConfig(config);
     notebook.refreshCron(note.id());
     Thread.sleep(1*1000);
-    dateFinished = p.getDateFinished();
-    assertNotNull(dateFinished);
-
+    
     // remove cron scheduler.
     config.put("cron", null);
     note.setConfig(config);
     notebook.refreshCron(note.id());
+    Thread.sleep(1000);
+    dateFinished = p.getDateFinished();
+    assertNotNull(dateFinished);
     Thread.sleep(1*1000);
     assertEquals(dateFinished, p.getDateFinished());
   }


### PR DESCRIPTION
test-schedule can fail when it starts late in a second, as the result will then return the next second due to in-system delays (particularly cron not reacting in time to config.put(cron, null)).
Adding an additional waiting second before measuring dateFinished allows us to take a value that is independent of a possible lagging execution, waiting another second makes sure that the process has properly stopped.

Alternatively, we can test the time and make sure to not write to cron when just before the full second - that would be quicker (less waiting) but slightly more hacky.

Please review.