### PR TITLE
ZEPPELIN-312: use threadpoll to do broadcast in zeppelin NotebookServer

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -24,6 +24,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
@@ -61,6 +63,7 @@ public class NotebookServer extends WebSocketServlet implements
   Gson gson = new Gson();
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final List<NotebookSocket> connectedSockets = new LinkedList<>();
+  final ExecutorService executorPool = Executors.newCachedThreadPool();
 
   private Notebook notebook() {
     return ZeppelinServer.notebook;
@@ -252,11 +255,7 @@ public class NotebookServer extends WebSocketServlet implements
       }
       LOG.info("SEND >> " + m.op);
       for (NotebookSocket conn : socketLists) {
-        try {
-          conn.send(serializeMessage(m));
-        } catch (IOException e) {
-          LOG.error("socket error", e);
-        }
+        executorPool.execute(new SendThread(conn, m));
       }
     }
   }
@@ -264,11 +263,7 @@ public class NotebookServer extends WebSocketServlet implements
   private void broadcastAll(Message m) {
     synchronized (connectedSockets) {
       for (NotebookSocket conn : connectedSockets) {
-        try {
-          conn.send(serializeMessage(m));
-        } catch (IOException e) {
-          LOG.error("socket error", e);
-        }
+        executorPool.execute(new SendThread(conn, m));
       }
     }
   }
@@ -761,6 +756,26 @@ public class NotebookServer extends WebSocketServlet implements
               new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
                       "noteId", noteId));
         }
+      }
+    }
+  }
+
+  class SendThread implements Runnable {
+    private NotebookSocket conn;
+    private Message m;
+
+
+    public SendThread(NotebookSocket conn, Message m){
+      this.conn = conn;
+      this.m = m;
+    }
+
+    @Override
+    public void run() {
+      try {
+        conn.send(serializeMessage(m));
+      } catch (IOException e) {
+        LOG.error("socket error", e);
       }
     }
   }


### PR DESCRIPTION
as the description in https://issues.apache.org/jira/browse/ZEPPELIN-312 say, broadcaseAll function will call conn.send(serializeMessage(m)) one by one to send message, and if one conn has some problem say: closed or send message timeout, it will block the other socket to get the message, so some zeppelin web url can't show any note in home page.
In this PR, we use threadpoll to do broadcast in zeppelin NotebookServer, so one bad socket connection will not affect the others.