### PR TITLE
[ZEPPELIN-319]wait an additional .5 seconds, if assertion will fail

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -39,6 +39,8 @@ import org.junit.Test;
 public class RemoteSchedulerTest {
 
   private SchedulerFactory schedulerSvc;
+  private static final int TICK_WAIT = 100;
+  private static final int MAX_WAIT_CYCLES = 100;
 
   @Before
   public void setUp() throws Exception{
@@ -108,24 +110,22 @@ public class RemoteSchedulerTest {
     };
     scheduler.submit(job);
 
-    while (job.isRunning() == false) {
-      Thread.sleep(100);
+    int cycles = 0;
+    while (job.isRunning() == false && cycles < MAX_WAIT_CYCLES) {
+      Thread.sleep(TICK_WAIT);
+      cycles++;
     }
+    assertTrue(job.isRunning);
 
-    Thread.sleep(500);
+    Thread.sleep(5*TICK_WAIT);
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(1, scheduler.getJobsRunning().size());
 
-    Thread.sleep(500);
-    
-    /* Test if our assertion will fail, if so,
-     * maybe the thread is just slow, give it some more time.
-     */
-    if (scheduler.getJobsRunning().size() == 1 
-     || scheduler.getJobsWaiting().size() == 1) {
-      Thread.sleep(500);
+    cycles = 0;
+    while (!job.isRunning && cycles < MAX_WAIT_CYCLES) {
+      Thread.sleep(TICK_WAIT);
+      cycles++;
     }
-
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(0, scheduler.getJobsRunning().size());
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -117,6 +117,14 @@ public class RemoteSchedulerTest {
     assertEquals(1, scheduler.getJobsRunning().size());
 
     Thread.sleep(500);
+    
+    /* Test if our assertion will fail, if so,
+     * maybe the thread is just slow, give it some more time.
+     */
+    if (scheduler.getJobsRunning().size() == 1 
+     || scheduler.getJobsWaiting().size() == 1) {
+      Thread.sleep(500);
+    }
 
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(0, scheduler.getJobsRunning().size());

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -123,12 +123,12 @@ public class RemoteSchedulerTest {
     assertEquals(1, scheduler.getJobsRunning().size());
 
     cycles = 0;
-    while (job.isRunning() && cycles < MAX_WAIT_CYCLES) {
+    while (!job.isTerminated() && cycles < MAX_WAIT_CYCLES) {
       Thread.sleep(TICK_WAIT);
       cycles++;
     }
     
-    assertTrue(!job.isRunning());
+    assertTrue(job.isTerminated());
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(0, scheduler.getJobsRunning().size());
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.scheduler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -111,21 +111,23 @@ public class RemoteSchedulerTest {
     scheduler.submit(job);
 
     int cycles = 0;
-    while (job.isRunning() == false && cycles < MAX_WAIT_CYCLES) {
+    while (!job.isRunning() && cycles < MAX_WAIT_CYCLES) {
       Thread.sleep(TICK_WAIT);
       cycles++;
     }
-    assertTrue(job.isRunning);
+    assertTrue(job.isRunning());
 
     Thread.sleep(5*TICK_WAIT);
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(1, scheduler.getJobsRunning().size());
 
     cycles = 0;
-    while (!job.isRunning && cycles < MAX_WAIT_CYCLES) {
+    while (job.isRunning() && cycles < MAX_WAIT_CYCLES) {
       Thread.sleep(TICK_WAIT);
       cycles++;
     }
+    
+    assertTrue(!job.isRunning());
     assertEquals(0, scheduler.getJobsWaiting().size());
     assertEquals(0, scheduler.getJobsRunning().size());
 


### PR DESCRIPTION
This test failed randomly during a build. To make sure this is not due to timing issues, we can optionally wait an additional .5 seconds.
This is a band-aid around bad design, but I'm pragmatically trying to get the build to be more stable. This should also help determine if there is an actual (randomly striking) issue in the underlying procedure being tested, by making the test more reliable.

Please review, and if you can come up with a better designed test (and avoid waiting for threads to finish in a fixed time interval) we should discuss it here or in the issue.