### PR TITLE
Spark 1.5 moved to first place

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ mvn clean package -DskipTests
 
 Build with specific Spark version
 
+Spark 1.5.x
+```
+mvn clean package -Pspark-1.5 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests
+```
 Spark 1.4.x
 ```
 mvn clean package -Pspark-1.4 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests
@@ -58,10 +62,6 @@ mvn clean package -Pspark-1.2 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests
 Spark 1.1.x
 ```
 mvn clean package -Pspark-1.1 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests 
-```
-Spark 1.5.x
-```
-mvn clean package -Pspark-1.5 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests
 ```
 CDH 5.X
 ```


### PR DESCRIPTION
for better readability: Spark 1.5 support was after Spark 1.1