### PR TITLE
ZEPPELIN-324: Zeppelin-web builds fail on OSX due to PhantomJS port conflicts on port 8080

### DIFF
--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -66,7 +66,7 @@ module.exports = function(config) {
     exclude: [],
 
     // web server port
-    port: 8080,
+    port: 9002,
 
     // Start these browsers, currently available:
     // - Chrome


### PR DESCRIPTION
The Zeppelin-Web module uses PhantomJS to run Karma JS unit tests. The test suite uses port 8080 by default and is supposed to detect port conflicts. However, on OSX, port conflicts are not detected correctly, and the tests time out causing the Zeppelin build to fail.

I noticed that the test suite also uses port 9001- since 9002 is an uncommonly used port and is close to already used 9001, this PR changes the PhantomJS default port to 9002, allowing builds to proceed successfully.