### PR TITLE
[ZEPPELIN-328] Interpreter page should clarify the % magic syntax for interpreter group.name

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -44,7 +44,7 @@ limitations under the License.
             <span ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
               <span ng-show="!$first">, </span>
-              %{{interpreter.name}}
+              %{{setting.name}}.{{interpreter.name}}
             </span>
           </small>
         </h3>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -43,8 +43,10 @@ limitations under the License.
           <small>
             <span ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
-              <span ng-show="$first">%{{setting.name}}</span>
-              <span ng-show="!$first">, %{{setting.name}}.{{interpreter.name}}</span>
+              <span ng-show="$parent.$first && $first">%{{setting.name}} (default)</span>
+              <span ng-show="$parent.$first && !$first">, %{{interpreter.name}}</span>
+              <span ng-show="!$parent.$first && $first">%{{setting.name}}</span>
+              <span ng-show="!$parent.$first && !$first">, %{{setting.name}}.{{interpreter.name}}</span>
             </span>
           </small>
         </h3>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -39,12 +39,12 @@ limitations under the License.
   <div>
     <div class="row interpreter">
       <div class="col-md-12">
-        <h3 class="interpreter-title">{{setting.name}} 
+        <h3 class="interpreter-title">{{setting.name}}
           <small>
             <span ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
-              <span ng-show="!$first">, </span>
-              %{{setting.name}}.{{interpreter.name}}
+              <span ng-show="$first">%{{setting.name}}</span>
+              <span ng-show="!$first">, %{{setting.name}}.{{interpreter.name}}</span>
             </span>
           </small>
         </h3>


### PR DESCRIPTION
Currently the Interpreter page like the interpreters as
hive %hql
However, this does not work unless hive is the default group - otherwise one would require the full %group.name.
It seems it would be better to list interpreter as %group.name on the page.