### PR TITLE
Send back message with note data on create and clone

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -376,7 +376,8 @@ public class NotebookServer extends WebSocketServlet implements
 
     return cronUpdated;
   }
-  private void createNote(WebSocket conn, Notebook notebook, Message message) throws IOException {
+  private void createNote(NotebookSocket conn, Notebook notebook,
+      Message message) throws IOException {
     Note note = notebook.createNote();
     note.addParagraph(); // it's an empty note. so add one paragraph
     if (message != null) {
@@ -388,6 +389,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     note.persist();
+    conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
     broadcastNote(note);
     broadcastNoteList();
   }
@@ -425,7 +427,7 @@ public class NotebookServer extends WebSocketServlet implements
     note.persist();
     broadcast(note.id(), new Message(OP.PARAGRAPH).put("paragraph", p));
   }
-  
+
   private void cloneNote(NotebookSocket conn, Notebook notebook, Message fromMessage)
       throws IOException, CloneNotSupportedException {
     String noteId = getOpenNoteId(conn);
@@ -446,6 +448,7 @@ public class NotebookServer extends WebSocketServlet implements
       newNote.addParagraph(p);
     }
     newNote.persist();
+    conn.send(serializeMessage(new Message(OP.NOTE).put("note", newNote)));
     broadcastNote(newNote);
     broadcastNoteList();
   }
@@ -765,4 +768,3 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
 }
-


### PR DESCRIPTION
We use web-socket api for creating and cloning notes from our servers. To know noteId of created or cloned note, we need some response message. I propose sending NOTE message to client on creating/cloning note.

There could be other ways to reach it. For example, we can send newId and note for creation an id, name, newId for cloning. If newId is not exists, we generate it on server.

Another way will be to create separate api for this, to not mix this with front-end api. It could be REST or smth.