### PR TITLE
zeppelin-333:Notebook create, delete & clone REST API

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -44,7 +44,7 @@ group: nav-right
 
 ### REST API
  * [Interpreter API](./rest-api/rest-interpreter.html)
- * [Notebook API](../docs/pleasecontribute.html)
+ * [Notebook API](./rest-api/rest-notebook.html)
 
 ### Development
 

--- a/docs/docs/rest-api/rest-interpreter.md
+++ b/docs/docs/rest-api/rest-interpreter.md
@@ -11,7 +11,7 @@ group: rest-api
  
  All REST API are available starting with the following endpoint ```http://[zeppelin-server]:[zeppelin-port]/api```
  
- Note that zeppein REST API receive or return JSON objects, it it recomended you install some JSON view such as 
+ Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON view such as 
  [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)
  
  

--- a/docs/docs/rest-api/rest-json/rest-json-notebook-create-response.json
+++ b/docs/docs/rest-api/rest-json/rest-json-notebook-create-response.json
@@ -1,0 +1,1 @@
+{"status": "CREATED","message": "","body": "2AZPHY918"}

--- a/docs/docs/rest-api/rest-json/rest-json-notebook-create.json
+++ b/docs/docs/rest-api/rest-json/rest-json-notebook-create.json
@@ -1,0 +1,1 @@
+{"name": "name of new notebook"}

--- a/docs/docs/rest-api/rest-json/rest-json-notebook-delete-response.json
+++ b/docs/docs/rest-api/rest-json/rest-json-notebook-delete-response.json
@@ -1,0 +1,1 @@
+{"status":"OK","message":""}

--- a/docs/docs/rest-api/rest-notebook.md
+++ b/docs/docs/rest-api/rest-notebook.md
@@ -1,0 +1,126 @@
+---
+layout: page
+title: "Notebook REST API"
+description: ""
+group: rest-api
+---
+{% include JB/setup %}
+
+## Zeppelin REST API
+ Zeppelin provides several REST API's for interaction and remote activation of zeppelin functionality.
+ 
+ All REST API are available starting with the following endpoint ```http://[zeppelin-server]:[zeppelin-port]/api```
+ 
+ Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON view such as 
+ [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)
+ 
+ 
+ If you work with zeppelin and find a need for an additional REST API please [file an issue or send us mail](../../community.html) 
+
+ <br />
+### Notebook REST API list
+  
+  Notebooks can be created, deleted or cloned using the following REST API
+  
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>Create notebook</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method create a new notebook using the given name or default name if none given.
+          The body field of the returned JSON contain the new notebook id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input </td>
+      <td> [Create JSON sample](rest-json/rest-json-notebook-create.json)</td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td> [Create response sample](rest-json/rest-json-notebook-create-response.json) </td>
+    </tr>
+  </table>
+  
+<br/>
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>Delete notebook</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method delete a notebook by the given notebook id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[notebookId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td> [Delete response sample](rest-json/rest-json-notebook-delete-response.json) </td>
+    </tr>
+  </table>
+  
+<br/>
+  
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>Clone notebook</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method clone a notebook by the given id and create a new notebook using the given name 
+          or default name if none given.
+          The body field of the returned JSON contain the new notebook id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[notebookId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input </td>
+      <td> [Clone JSON sample](rest-json/rest-json-notebook-create.json)</td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td> [Clone response sample](rest-json/rest-json-notebook-create-response.json) </td>
+    </tr>
+  </table>
+  

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -21,17 +21,16 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.rest.message.InterpreterSettingListForNoteBind;
+import org.apache.zeppelin.rest.message.NewInterpreterSettingRequest;
+import org.apache.zeppelin.rest.message.NewNotebookRequest;
 import org.apache.zeppelin.server.JsonResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,5 +107,32 @@ public class NotebookRestApi {
       }
     }
     return new JsonResponse(Status.OK, "", settingList).build();
+  }
+
+  @GET
+  @Path("/")
+  public Response getNotebookList() throws IOException {
+    return new JsonResponse(Status.OK, "", notebook.getAllNotes() ).build();
+  }
+
+  /**
+   * Create new note REST API
+   * @param message - JSON with new note name
+   * @return JSON with new note ID
+   * @throws IOException
+   */
+  @POST
+  @Path("/")
+  public Response createNote(String message) throws IOException {
+    NewNotebookRequest request = gson.fromJson(message,
+        NewNotebookRequest.class);
+    Note note = notebook.createNote();
+    note.addParagraph(); // it's an empty note. so add one paragraph
+    String noteName = request.getName();
+    if (noteName.isEmpty()) {
+      noteName = "Note " + note.getId();
+    }
+    note.setName(noteName);
+    return new JsonResponse(Status.CREATED, "", note.getId() ).build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -124,6 +124,7 @@ public class NotebookRestApi {
   @POST
   @Path("/")
   public Response createNote(String message) throws IOException {
+    logger.info("Create new notebook by JSON {}" , message);
     NewNotebookRequest request = gson.fromJson(message,
         NewNotebookRequest.class);
     Note note = notebook.createNote();
@@ -136,5 +137,24 @@ public class NotebookRestApi {
     note.persist();
     //TODO(eranw): figure out how to broadcastNote(note); broadcastNoteList();
     return new JsonResponse(Status.CREATED, "", note.getId() ).build();
+  }
+  /**
+   * Delete note REST API
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException
+   */
+  @DELETE
+  @Path("{notebookId}")
+  public Response deleteNote(@PathParam("notebookId") String notebookId) throws IOException {
+    logger.info("Delete notebook {} ", notebookId);
+    if (!(notebookId.isEmpty())) {
+      Note note = notebook.getNote(notebookId);
+      if (note != null) {
+        notebook.removeNote(notebookId);
+      }
+    }
+    //TODO(eranw): figure out how to broadcastNote(note); broadcastNoteList();
+    return new JsonResponse(Status.OK, "").build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -133,6 +133,8 @@ public class NotebookRestApi {
       noteName = "Note " + note.getId();
     }
     note.setName(noteName);
+    note.persist();
+    //TODO(eranw): figure out how to broadcastNote(note); broadcastNoteList();
     return new JsonResponse(Status.CREATED, "", note.getId() ).build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -140,7 +140,6 @@ public class NotebookRestApi {
     }
     note.setName(noteName);
     note.persist();
-    //TODO(eranw): figure out how to broadcastNote(note); broadcastNoteList();
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList();
     return new JsonResponse(Status.CREATED, "", note.getId() ).build();
@@ -162,7 +161,6 @@ public class NotebookRestApi {
         notebook.removeNote(notebookId);
       }
     }
-    //TODO(eranw): figure out how to broadcastNoteList();
     notebookServer.broadcastNoteList();
     return new JsonResponse(Status.OK, "").build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNotebookRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNotebookRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest.message;
+
+import java.util.Map;
+
+import org.apache.zeppelin.interpreter.InterpreterOption;
+
+/**
+ *  NewNotebookRequest rest api request message
+ *
+ */
+public class NewNotebookRequest {
+  String name;
+
+  public NewNotebookRequest (){
+
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -271,7 +271,7 @@ public class ZeppelinServer extends Application {
     ZeppelinRestApi root = new ZeppelinRestApi();
     singletons.add(root);
 
-    NotebookRestApi notebookApi = new NotebookRestApi(notebook);
+    NotebookRestApi notebookApi = new NotebookRestApi(notebook, notebookServer);
     singletons.add(notebookApi);
 
     InterpreterRestApi interpreterApi = new InterpreterRestApi(replFactory);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -273,11 +273,11 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
 
-  private void broadcastNote(Note note) {
+  public void broadcastNote(Note note) {
     broadcast(note.id(), new Message(OP.NOTE).put("note", note));
   }
 
-  private void broadcastNoteList() {
+  public void broadcastNoteList() {
     Notebook notebook = notebook();
 
     ZeppelinConfiguration conf = notebook.getConf();
@@ -430,22 +430,7 @@ public class NotebookServer extends WebSocketServlet implements
       throws IOException, CloneNotSupportedException {
     String noteId = getOpenNoteId(conn);
     String name = (String) fromMessage.get("name");
-    Note sourceNote = notebook.getNote(noteId);
-    Note newNote = notebook.createNote();
-    if (name != null) {
-      newNote.setName(name);
-    }
-    // Copy the interpreter bindings
-    List<String> boundInterpreterSettingsIds = notebook
-        .getBindedInterpreterSettingsIds(sourceNote.id());
-    notebook.bindInterpretersToNote(newNote.id(), boundInterpreterSettingsIds);
-
-    List<Paragraph> paragraphs = sourceNote.getParagraphs();
-    for (Paragraph para : paragraphs) {
-      Paragraph p = (Paragraph) para.clone();
-      newNote.addParagraph(p);
-    }
-    newNote.persist();
+    Note newNote = notebook.cloneNote(noteId, name);
     broadcastNote(newNote);
     broadcastNoteList();
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -184,7 +184,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testNotebookCreateWithName() throws IOException {
     String noteName = "Test note name";
-    testNotebookCreate (noteName);
+    testNotebookCreate(noteName);
   }
 
   @Test
@@ -218,6 +218,35 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     ZeppelinServer.notebook.removeNote(newNotebookId);
     post.releaseConnection();
 
+  }
+
+  @Test
+  public void  testDeleteNote() throws IOException {
+    LOG.info("testDeleteNote");
+    //Create note and get ID
+    Note note = ZeppelinServer.notebook.createNote();
+    String noteId = note.getId();
+    testDeleteNotebook(noteId);
+  }
+
+  @Test
+  public void testDeleteNoteBadId() throws IOException {
+    LOG.info("testDeleteNoteBadId");
+    testDeleteNotebook("2AZFXEX97");
+    testDeleteNotebook("bad_ID");
+  }
+
+  private void testDeleteNotebook(String notebookId) throws IOException {
+
+    DeleteMethod delete = httpDelete(("/notebook/" + notebookId));
+    LOG.info("testDeleteNotebook delete response\n" + delete.getResponseBodyAsString());
+    assertThat("Test delete method:", delete, isAllowed());
+    delete.releaseConnection();
+    // make sure note is deleted
+    if (!notebookId.isEmpty()) {
+      Note deletedNote = ZeppelinServer.notebook.getNote(notebookId);
+      assertNull("Deleted note should be null", deletedNote);
+    }
   }
 }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -206,6 +206,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     LOG.info("newNotebookId:=" + newNotebookId);
     Note newNote = ZeppelinServer.notebook.getNote(newNotebookId);
     assertNotNull("Can not find new note by id", newNote);
+    // This is partial test as newNote is in memory but is not persistent
     String newNoteName = newNote.getName();
     LOG.info("new note name is: " + newNoteName);
     String expectedNoteName = noteName;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -248,5 +248,39 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       assertNull("Deleted note should be null", deletedNote);
     }
   }
+
+  @Test
+  public void testCloneNotebook() throws IOException, CloneNotSupportedException, IllegalArgumentException {
+    LOG.info("testCloneNotebook");
+    // Create note to clone
+    Note note = ZeppelinServer.notebook.createNote();
+    assertNotNull("cant create new note", note);
+    note.setName("source note for clone");
+    Paragraph paragraph = note.addParagraph();
+    paragraph.setText("%md This is my new paragraph in my new note");
+    note.persist();
+    String sourceNoteID = note.getId();
+
+    String noteName = "clone Note Name";
+    // Call Clone Notebook REST API
+    String jsonRequest = "{\"name\":\"" + noteName + "\"}";
+    PostMethod post = httpPost("/notebook/" + sourceNoteID, jsonRequest);
+    LOG.info("testNotebookClone \n" + post.getResponseBodyAsString());
+    assertThat("test notebook clone method:", post, isCreated());
+
+    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {
+    }.getType());
+
+    String newNotebookId =  (String) resp.get("body");
+    LOG.info("newNotebookId:=" + newNotebookId);
+    Note newNote = ZeppelinServer.notebook.getNote(newNotebookId);
+    assertNotNull("Can not find new note by id", newNote);
+    assertEquals("Compare note names", noteName, newNote.getName());
+    assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs().size());
+    //cleanup
+    //ZeppelinServer.notebook.removeNote(note.getId());
+    //ZeppelinServer.notebook.removeNote(newNote.getId());
+    post.releaseConnection();
+  }
 }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -278,8 +278,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("Compare note names", noteName, newNote.getName());
     assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs().size());
     //cleanup
-    //ZeppelinServer.notebook.removeNote(note.getId());
-    //ZeppelinServer.notebook.removeNote(newNote.getId());
+    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(newNote.getId());
     post.releaseConnection();
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -118,6 +118,37 @@ public class Notebook {
     return note;
   }
 
+  /**
+   * Clone existing note.
+   * @param sourceNoteID - the note ID to clone
+   * @param newNoteName - the name of the new note
+   * @return noteId
+   * @throws IOException, CloneNotSupportedException, IllegalArgumentException
+   */
+  public Note cloneNote(String sourceNoteID, String newNoteName) throws
+      IOException, CloneNotSupportedException, IllegalArgumentException {
+
+    Note sourceNote = getNote(sourceNoteID);
+    if (sourceNote == null) {
+      throw new IllegalArgumentException(sourceNoteID + "not found");
+    }
+    Note newNote = createNote();
+    if (newNoteName != null) {
+      newNote.setName(newNoteName);
+    }
+    // Copy the interpreter bindings
+    List<String> boundInterpreterSettingsIds = getBindedInterpreterSettingsIds(sourceNote.id());
+    bindInterpretersToNote(newNote.id(), boundInterpreterSettingsIds);
+
+    List<Paragraph> paragraphs = sourceNote.getParagraphs();
+    for (Paragraph para : paragraphs) {
+      Paragraph p = (Paragraph) para.clone();
+      newNote.addParagraph(p);
+    }
+    newNote.persist();
+    return newNote;
+  }
+
   public void bindInterpretersToNote(String id,
       List<String> interpreterSettingIds) throws IOException {
     Note note = getNote(id);


### PR DESCRIPTION
Initial implementation of createNote REST API.
implementation overlap socket implementation, to minimal the effect for socket behavior, later PR can refactor the creation "logic" (create note, add paragraph, set name) to the zengine class and avoid duplication or even better migrate web client to use REST API as well.  
Still need to find a way to broadcast note list to all client same as socket does in 
```broadcastNote(note);``` and ```broadcastNoteList();``` 