### PR TITLE
Fix missing postcss npm package issue

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "bower": "",
     "grunt": "^0.4.1",
-    "grunt-autoprefixer": "^0.7.3",
+    "grunt-autoprefixer": "^3.0.3",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-concat": "^0.4.0",


### PR DESCRIPTION
When running on grunt-autoprefixer 0.7.3, I'm getting missing postcss npm package, using more recent grunt-autoprefixer fixes it, btw grunt-autoprefixer seems to be deprecated in favour of grunt-postcss.