### PR TITLE
ZEPPELIN-345 Duplicate "Ctri + n" in the keyboard list

### DIFF
--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -113,17 +113,6 @@ limitations under the License.
             Move cursor at the end
           </div>
         </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">N</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Move cursor Down
-          </div>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I deleted just several lines of code in modal-shortcut.html .