### PR TITLE
ZEPPELIN-349: Resolve NPE on null cell values

### DIFF
--- a/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
+++ b/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
@@ -89,6 +89,7 @@ public class PostgreSqlInterpreter extends Interpreter {
   static final String POSTGRESQL_SERVER_PASSWORD = "postgresql.password";
   static final String POSTGRESQL_SERVER_DRIVER_NAME = "postgresql.driver.name";
   static final String POSTGRESQL_SERVER_MAX_RESULT = "postgresql.max.result";
+  static final String EMPTY_COLUMN_VALUE = "";
 
   static {
     Interpreter.register(
@@ -275,6 +276,9 @@ public class PostgreSqlInterpreter extends Interpreter {
    * For %table response replace Tab and Newline characters from the content.
    */
   private String replaceReservedChars(boolean isTableResponseType, String str) {
+    if (str == null) {
+      return EMPTY_COLUMN_VALUE;
+    }
     return (!isTableResponseType) ? str : str.replace(TAB, WhITESPACE).replace(NEWLINE, WhITESPACE);
   }
 

--- a/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
+++ b/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
@@ -127,6 +127,27 @@ public class PostgreSqlInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
+  public void testNullColumnResult() throws SQLException {
+
+    when(psqlInterpreter.getMaxResult()).thenReturn(1000);
+
+    String sqlQuery = "select * from t";
+
+    result.addColumn("col1", new String[] {"val11", null});
+    result.addColumn("col2", new String[] {null, "val22"});
+
+    InterpreterResult interpreterResult = psqlInterpreter.interpret(sqlQuery, null);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.type());
+    assertEquals("col1\tcol2\nval11\t\n\tval22\n", interpreterResult.message());
+
+    verifySQLStatementExecuted(sqlQuery);
+    verifyAllResultSetsClosed();
+    verifyAllStatementsClosed();
+  }
+  
+  @Test
   public void testSelectQuery() throws SQLException {
 
     when(psqlInterpreter.getMaxResult()).thenReturn(1000);

--- a/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
+++ b/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
@@ -146,7 +146,7 @@ public class PostgreSqlInterpreterTest extends BasicJDBCTestCaseAdapter {
     verifyAllResultSetsClosed();
     verifyAllStatementsClosed();
   }
-  
+
   @Test
   public void testSelectQuery() throws SQLException {
 


### PR DESCRIPTION
When the query response contains null column values the following NPE is thrown: 
java.lang.NullPointerException
at org.apache.zeppelin.postgresql.PostgreSqlInterpreter.replaceReservedChars(PostgreSqlInterpreter.java:278)
at org.apache.zeppelin.postgresql.PostgreSqlInterpreter.executeSql(PostgreSqlInterpreter.java:235)