### PR TITLE
Format table and fix flink to flink.html

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,7 +19,7 @@ group: nav-right
 
 **[Interpreters in zeppelin](manual/interpreters.html)**
 
-* [flink](./docs/interpreter/flink.html)
+* [flink](./interpreter/flink.html)
 * [hive](../docs/pleasecontribute.html)
 * [ignite](../docs/pleasecontribute.html)
 * [lens](../docs/pleasecontribute.html)

--- a/docs/docs/interpreter/flink.md
+++ b/docs/docs/interpreter/flink.md
@@ -17,11 +17,30 @@ Zeppelin comes with pre-configured flink-local interpreter, which starts Flink i
 ### How to configure interpreter to point to Flink cluster
 At the "Interpreters" menu, you have to create a new Flink interpreter and provide next properties:
 
-property | value    | Description
----------|----------|-----
-host	 | local    | host name of running JobManager. 'local' runs flink in local mode (default)
-port	 | 6123     | port of running JobManager
-xxx    | yyy      | anything else from [Flink Configuration](https://ci.apache.org/projects/flink/flink-docs-release-0.9/setup/config.html)
+<table class="table-configuration">
+  <tr>
+    <th>property</th>
+    <th>value</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>host</td>
+    <td>local</td>
+    <td>host name of running JobManager. 'local' runs flink in local mode (default)</td>
+  </tr>
+  <tr>
+    <td>port</td>
+    <td>6123</td>
+    <td>port of running JobManager</td>
+  </tr>
+  <tr>
+    <td>xxx</td>
+    <td>yyy</td>
+    <td>anything else from [Flink Configuration](https://ci.apache.org/projects/flink/flink-docs-release-0.9/setup/config.html)</td>
+  </tr>
+</table>
+<br />
+
 
 ### How to test it's working
 


### PR DESCRIPTION
Format table for Flink interpreter doc introduced by https://github.com/apache/incubator-zeppelin/pull/303

which will change table formatting from

![image](https://cloud.githubusercontent.com/assets/1540981/10560737/0eb08998-754f-11e5-909a-a21b0784cea4.png)

to

![image](https://cloud.githubusercontent.com/assets/1540981/10560739/1c7c06d8-754f-11e5-81b1-615010e9e953.png)
