### PR TITLE
Spark 1.1.x and 1.2.x is removed from http://www.apache.org/dist/spark/

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -50,7 +50,7 @@
     <akka.group>org.spark-project.akka</akka.group>
     <akka.version>2.3.4-spark</akka.version>
 
-    <spark.download.url>http://www.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}.tgz</spark.download.url>
+    <spark.download.url>http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}.tgz</spark.download.url>
     <py4j.version>0.8.2.1</py4j.version>
   </properties>
 
@@ -594,7 +594,7 @@
     <profile>
       <id>pyspark</id>
       <properties>
-        <spark.download.url>http://www.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}.tgz
+        <spark.download.url>http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}.tgz
         </spark.download.url>
       </properties>
       <build>

--- a/testing/startSparkCluster.sh
+++ b/testing/startSparkCluster.sh
@@ -31,7 +31,7 @@ ZEPPELIN_HOME="$(cd "${FWDIR}/.."; pwd)"
 export SPARK_HOME=${ZEPPELIN_HOME}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
 echo "SPARK_HOME is ${SPARK_HOME} " 
 if [ ! -d "${SPARK_HOME}" ]; then
-    wget -q http://www.us.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+    wget -q http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
     tar zxf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 fi
 


### PR DESCRIPTION
Issue described https://issues.apache.org/jira/browse/ZEPPELIN-350

This PR fixes CI test failure by changing spark package download address from http://www.us.apache.org/dist/spark to http://archive.apache.org/dist/spark