### PR TITLE
Replace button to div in scatter settings

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -248,9 +248,9 @@ limitations under the License.
                   class="list-unstyled"
                   style="height:36px">
                 <li ng-if="paragraph.config.graph.scatter.xAxis">
-                  <button class="btn btn-primary btn-xs">
+                  <div class="btn btn-primary btn-xs">
                     {{paragraph.config.graph.scatter.xAxis.name}} <span class="fa fa-close" ng-click="removeScatterOptionXaxis($index)"></span>
-                  </button>
+                  </div>
                 </li>
               </ul>
             </span>
@@ -264,9 +264,9 @@ limitations under the License.
                   class="list-unstyled"
                   style="height:36px">
                 <li ng-if="paragraph.config.graph.scatter.yAxis">
-                  <button class="btn btn-success btn-xs">
+                  <div class="btn btn-success btn-xs">
                     {{paragraph.config.graph.scatter.yAxis.name}} <span class="fa fa-close" ng-click="removeScatterOptionYaxis($index)"></span>
-                  </button>
+                  </div>
                 </li>
               </ul>
             </span>
@@ -280,9 +280,9 @@ limitations under the License.
                   class="list-unstyled"
                   style="height:36px">
                 <li ng-if="paragraph.config.graph.scatter.group">
-                  <button class="btn btn-info btn-xs">
+                  <div class="btn btn-info btn-xs">
                     {{paragraph.config.graph.scatter.group.name}} <span class="fa fa-close" ng-click="removeScatterOptionGroup($index)"></span>
-                  </button>
+                  </div>
                 </li>
               </ul>
             </span>
@@ -302,9 +302,9 @@ limitations under the License.
                   class="list-unstyled"
                   style="height:36px">
                 <li ng-if="paragraph.config.graph.scatter.size">
-                  <button class="btn btn-xs" style="color:white" ng-class="{'btn-warning': isValidSizeOption(paragraph.config.graph.scatter, paragraph.result.rows)}">
+                  <div class="btn btn-xs" style="color:white" ng-class="{'btn-warning': isValidSizeOption(paragraph.config.graph.scatter, paragraph.result.rows)}">
                     {{paragraph.config.graph.scatter.size.name}} <span class="fa fa-close" ng-click="removeScatterOptionSize($index)"></span>
-                  </button>
+                  </div>
                 </li>
               </ul>
             </span>


### PR DESCRIPTION
This PR fixes same issue as [ZEPPELIN-351](https://issues.apache.org/jira/browse/ZEPPELIN-351?jql=project%20%3D%20ZEPPELIN) which Firefox/IE users cannot remove fields from pivot settings for scatter chart.