### PR TITLE
ZEPPELIN-359 add NOTICE and DISCLAIMER in the binary package

### DIFF
--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -55,6 +55,8 @@
       <includes>
         <include>README.md</include>
         <include>LICENSE*</include>
+        <include>NOTICE</include>
+        <include>DISCLAIMER</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
NOTICE and DISCLAIMER is missing in the binary package.

https://issues.apache.org/jira/browse/ZEPPELIN-359