### PR TITLE
ZEPPELIN-360 Remove "Copyright 2014, NFLabs inc." from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014, NFLabs inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 
 Portions of this software were developed at NFLabs, Inc. (http://www.nflabs.com)
-Copyright (c) 2010-2015 NFLabs Inc.
 
 
 


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/ZEPPELIN-360
Removing "Copyright 2014, NFLabs inc." from LICENSE.