### PR TITLE
[ZEPPELIN-357] Add support for a configurable list of repo for dependencies

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
@@ -68,6 +68,9 @@ public class DepInterpreter extends Interpreter {
         DepInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
             .add("zeppelin.dep.localrepo", "local-repo", "local repository for dependency loader")
+            .add("zeppelin.dep.additionalRemoteRepository",
+                "spark-packages,http://dl.bintray.com/spark-packages/maven,false;",
+                "A list of 'id,remote-repository-URL,is-snapshot;' for each remote repository.")
             .build());
 
   }
@@ -146,7 +149,8 @@ public class DepInterpreter extends Interpreter {
     intp.setContextClassLoader();
     intp.initializeSynchronous();
 
-    depc = new DependencyContext(getProperty("zeppelin.dep.localrepo"));
+    depc = new DependencyContext(getProperty("zeppelin.dep.localrepo"),
+                                 getProperty("zeppelin.dep.additionalRemoteRepository"));
     completor = new SparkJLineCompletion(intp);
 
     intp.interpret("@transient var _binder = new java.util.HashMap[String, Object]()");

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -228,7 +228,10 @@ public class SparkInterpreter extends Interpreter {
 
   public DependencyResolver getDependencyResolver() {
     if (dep == null) {
-      dep = new DependencyResolver(intp, sc, getProperty("zeppelin.dep.localrepo"));
+      dep = new DependencyResolver(intp,
+                                   sc,
+                                   getProperty("zeppelin.dep.localrepo"),
+                                   getProperty("zeppelin.dep.additionalRemoteRepository"));
     }
     return dep;
   }

--- a/spark/src/main/java/org/apache/zeppelin/spark/dep/Booter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/dep/Booter.java
@@ -67,4 +67,9 @@ public class Booter {
   public static RemoteRepository newCentralRepository() {
     return new RemoteRepository("central", "default", "http://repo1.maven.org/maven2/");
   }
+
+  public static RemoteRepository newLocalRepository() {
+    return new RemoteRepository("local",
+        "default", "file://" + System.getProperty("user.home") + "/.m2/repository");
+  }
 }

--- a/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
@@ -92,7 +92,7 @@ public class DepInterpreterTest {
     assertEquals(1, dep.getDependencyContext().getFilesDist().size());
 
     // Add a test for the spark-packages repo - default in additionalRemoteRepository
-    ret = dep.interpret("z.load(\"com.databricks:spark-csv_2.11:1.2.0\")", context);
+    ret = dep.interpret("z.load(\"amplab:spark-indexedrdd:0.3\")", context);
     assertEquals(Code.SUCCESS, ret.code());
 
     // Reset at the end of the test

--- a/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
@@ -90,5 +90,12 @@ public class DepInterpreterTest {
 
     assertEquals(1, dep.getDependencyContext().getFiles().size());
     assertEquals(1, dep.getDependencyContext().getFilesDist().size());
+
+    // Add a test for the spark-packages repo - default in additionalRemoteRepository
+    ret = dep.interpret("z.load(\"com.databricks:spark-csv_2.11:1.2.0\")", context);
+    assertEquals(Code.SUCCESS, ret.code());
+
+    // Reset at the end of the test
+    dep.getDependencyContext().reset();
   }
 }


### PR DESCRIPTION
Make it configurable via `zeppelin.dep.additionalRemoteRepository`, with spark-packages default. This enables notebook to load dependencies with having to add spark-packages each time.

There is a fair bit of overlap between `DependencyResolver` and `DependencyContext`, but it appears in order for any custom repo available it needs to be in both components. We should discuss how best to address overlaps between the two components.

@corneadoug 
@Leemoonsoo 