### PR TITLE
ZEPPELIN-299 Support clearing output for paragraph

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
@@ -95,6 +95,7 @@ public class Message {
                 // @param notes serialized List<NoteInfo> object
 
     PARAGRAPH_REMOVE,
+    PARAGRAPH_CLEAR_OUTPUT,
     PING,
 
     ANGULAR_OBJECT_UPDATE,  // [s-c] add/update angular object

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -137,6 +137,9 @@ public class NotebookServer extends WebSocketServlet implements
           case PARAGRAPH_REMOVE:
             removeParagraph(conn, notebook, messagereceived);
             break;
+          case PARAGRAPH_CLEAR_OUTPUT:
+            clearParagraphOutput(conn, notebook, messagereceived);
+            break;
           case NOTE_UPDATE:
             updateNote(conn, notebook, messagereceived);
             break;
@@ -449,6 +452,18 @@ public class NotebookServer extends WebSocketServlet implements
       note.persist();
       broadcastNote(note);
     }
+  }
+
+  private void clearParagraphOutput(NotebookSocket conn, Notebook notebook,
+      Message fromMessage) throws IOException {
+    final String paragraphId = (String) fromMessage.get("id");
+    if (paragraphId == null) {
+      return;
+    }
+
+    final Note note = notebook.getNote(getOpenNoteId(conn));
+    note.clearParagraphOutput(paragraphId);
+    broadcastNote(note);
   }
 
   private void completion(NotebookSocket conn, Notebook notebook,

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -79,6 +79,13 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
   };
 
+  $scope.clearAllParagraphOutput = function(noteId) {
+    var result = confirm('Do you want to clear all paragraph output?');
+    if (result) {
+      websocketMsgSrv.deleteNotebook(noteId);
+    }
+  };
+
   //Clone note
   $scope.cloneNote = function(noteId) {
     var result = confirm('Do you want to clone this notebook?');
@@ -102,6 +109,15 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       angular.element('#' + n.id + '_paragraphColumn_main').scope().saveParagraph();
     });
     $scope.isNoteDirty = null;
+  };
+
+  $scope.clearAllParagraphOutput = function() {
+    var result = confirm('Do you want to clear all output?');
+    if (result) {
+      _.forEach($scope.note.paragraphs, function(n, key) {
+        angular.element('#' + n.id + '_paragraphColumn_main').scope().clearParagraphOutput(n.id);
+      });
+    }
   };
 
   $scope.toggleAllEditor = function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -108,7 +108,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     var result = confirm('Do you want to clear all output?');
     if (result) {
       _.forEach($scope.note.paragraphs, function(n, key) {
-        angular.element('#' + n.id + '_paragraphColumn_main').scope().clearParagraphOutput(n.id);
+        angular.element('#' + n.id + '_paragraphColumn_main').scope().clearParagraphOutput();
       });
     }
   };

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -79,13 +79,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
   };
 
-  $scope.clearAllParagraphOutput = function(noteId) {
-    var result = confirm('Do you want to clear all paragraph output?');
-    if (result) {
-      websocketMsgSrv.deleteNotebook(noteId);
-    }
-  };
-
   //Clone note
   $scope.cloneNote = function(noteId) {
     var result = confirm('Do you want to clone this notebook?');

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -40,6 +40,14 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
+              ng-click="clearAllParagraphOutput(note.id)"
+              ng-hide="viewOnly"
+              ng-class="{'disabled':isNoteRunning()}"
+              tooltip-placement="bottom" tooltip="Clear output">
+        <i class="fa fa-eraser"></i>
+      </button>
+      <button type="button"
+              class="btn btn-default btn-xs"
               ng-click="removeNote(note.id)"
               ng-hide="viewOnly"
               tooltip-placement="bottom" tooltip="Remove the notebook">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -40,7 +40,7 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-click="clearAllParagraphOutput(note.id)"
+              ng-click="clearAllParagraphOutput()"
               ng-hide="viewOnly"
               ng-class="{'disabled':isNoteRunning()}"
               tooltip-placement="bottom" tooltip="Clear output">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -273,6 +273,10 @@ angular.module('zeppelinWebApp')
     }
   };
 
+  $scope.clearParagraphOutput = function() {
+    websocketMsgSrv.clearParagraphOutput($scope.paragraph.id);
+  };
+
   $scope.toggleEditor = function() {
     if ($scope.paragraph.config.editorHide) {
       $scope.openEditor();
@@ -633,7 +637,7 @@ angular.module('zeppelinWebApp')
       desc += ' (outdated)';
     }
     return desc;
-  };  
+  };
 
   $scope.isResultOutdated = function() {
     var pdata = $scope.paragraph;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -470,6 +470,10 @@ limitations under the License.
                ng-click="goToSingleParagraph()"> Link this paragraph</a>
         </li>
         <li>
+          <a class="fa fa-eraser" style="cursor:pointer"
+             ng-click="clearParagraphOutput()"> Clear output</a>
+        </li>
+        <li>
           <!-- remove paragraph -->
           <a class="fa fa-times" style="cursor:pointer"
              ng-click="removeParagraph()"> Remove</a>

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -85,6 +85,10 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       websocketEvents.sendNewEvent({op: 'PARAGRAPH_REMOVE', data: {id: paragraphId}});
     },
 
+    clearParagraphOutput: function(paragraphId) {
+      websocketEvents.sendNewEvent({op: 'PARAGRAPH_CLEAR_OUTPUT', data: {id: paragraphId}});
+    },
+
     completion: function(paragraphId, buf, cursor) {
       websocketEvents.sendNewEvent({
         op : 'COMPLETION',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -188,6 +188,25 @@ public class Note implements Serializable, JobListener {
   }
 
   /**
+   * Clear paragraph output by id.
+   *
+   * @param paragraphId
+   * @return
+   */
+  public Paragraph clearParagraphOutput(String paragraphId) {
+    synchronized (paragraphs) {
+      for (int i = 0; i < paragraphs.size(); i++) {
+        Paragraph p = paragraphs.get(i);
+        if (p.getId().equals(paragraphId)) {
+          p.setReturn(null, null);
+          return p;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
    * Move paragraph into the new index (order from 0 ~ n-1).
    *
    * @param paragraphId

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -161,6 +161,21 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
+  public void testClearParagraphOutput() throws IOException, SchedulerException{
+    Note note = notebook.createNote();
+    Paragraph p1 = note.addParagraph();
+    p1.setText("hello world");
+    note.run(p1.getId());
+
+    while(p1.isTerminated()==false || p1.getResult()==null) Thread.yield();
+    assertEquals("repl1: hello world", p1.getResult().message());
+
+    // clear paragraph output/result
+    note.clearParagraphOutput(p1.getId());
+    assertNull(p1.getResult());
+  }
+
+  @Test
   public void testRunAll() throws IOException {
     Note note = notebook.createNote();
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());


### PR DESCRIPTION
add an option to clear output/result for paragraph on UI and necessary backend changes

<img width="569" alt="clear-output-notebook" src="https://cloud.githubusercontent.com/assets/2031306/10750542/9d4a246c-7c9c-11e5-953e-53036d7da109.png">
--
<img width="560" alt="clear-output-paragraph" src="https://cloud.githubusercontent.com/assets/2031306/10750543/9d4c1754-7c9c-11e5-87a8-fa35b8457dfa.png">