### PR TITLE
ZEPPELIN-372 : Exporting a notebook

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -79,6 +79,16 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
   };
 
+  //Export notebook
+  $scope.exportNotebook = function() {
+    var jsonContent = 'data:text/json;charset=utf-8,' + JSON.stringify($scope.note);
+    var encodedUri = encodeURI(jsonContent);
+    var link = document.createElement('a');
+    link.setAttribute('href', encodedUri);
+    link.setAttribute('download', $scope.note.name + '.json');
+    link.click();
+  };
+
   //Clone note
   $scope.cloneNote = function(noteId) {
     var result = confirm('Do you want to clone this notebook?');

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -53,6 +53,13 @@ limitations under the License.
               >
         <i class="fa fa-copy"></i>
       </button>
+      <button type="button"
+              class="btn btn-default btn-xs"
+              ng-hide="viewOnly"
+              ng-click="exportNotebook()"
+              tooltip-placement="bottom" tooltip="Export the notebook">
+        <i class="fa fa-download"></i>
+      </button>
     </span>
 
     <span ng-hide="viewOnly">


### PR DESCRIPTION
Exporting a notebook in a JSON format, which can later be used/imported in a different environment.

<img width="203" alt="screen shot 2015-10-29 at 12 29 41 pm" src="https://cloud.githubusercontent.com/assets/674497/10812117/d6611b82-7e38-11e5-9074-d14eebf19e72.png">
