### PR TITLE
ZEPPELIN-375 HOTFIX move geode from default build to profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
     <module>shell</module>
     <module>hive</module>
     <module>phoenix</module>
-    <module>geode</module>
     <module>postgresql</module>
     <module>tajo</module>
     <module>flink</module>
@@ -587,6 +586,14 @@
   </build>
 
   <profiles>
+    <!-- Geode can be enabled by -Pgeode. see https://issues.apache.org/jira/browse/ZEPPELIN-375 -->
+    <profile>
+      <id>geode</id>
+      <modules>
+        <module>geode</module>
+      </modules>
+    </profile>
+
     <profile>
       <id>build-distr</id>
       <activation>


### PR DESCRIPTION
Hot fix for https://issues.apache.org/jira/browse/ZEPPELIN-375, until we get better resolution.
This patch moves geode from default build to profile.