### PR TITLE
ZEPPELIN-389: Longer Paragraph Title will wrap to new line and interfere with code below

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -178,7 +178,7 @@
 
 .paragraph .title {
   margin: 3px 0px 0px 0px;
-  height: 20px;
+  min-height: 20px;
   font-size: 12px;
 }
 


### PR DESCRIPTION
This PR relates to: https://issues.apache.org/jira/browse/ZEPPELIN-389 fixing a bug with paragraph titles longer than 1 line.

Current long paragraph title:
<img width="1258" alt="screen shot 2015-11-03 at 12 16 26 pm" src="https://cloud.githubusercontent.com/assets/6380209/10919812/6e5b919a-8232-11e5-9963-8e7847b8bd67.png">


After the pull request:
<img width="1247" alt="screen shot 2015-11-03 at 1 15 35 pm" src="https://cloud.githubusercontent.com/assets/6380209/10919819/7a4053f6-8232-11e5-878a-0a423c042520.png">
