### PR TITLE
ZEPPELIN-431 - Show Karma test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ conf/interpreter.json
 
 # other generated files
 spark/dependency-reduced-pom.xml
+reports
 
 #webapp
 zeppelin-web/node_modules
@@ -26,7 +27,6 @@ zeppelin-web/.sass-cache
 zeppelin-web/bower_components
 **nbproject/
 **node/
-zeppelin-web/reports/coverage
 
 
 # project level

--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,7 @@
           <configuration>
             <excludes>
               <exclude>**/*.keywords</exclude>
+              <exclude>reports/**</exclude>
               <exclude>**/.idea/</exclude>
               <exclude>**/*.iml</exclude>
               <exclude>.git/</exclude>
@@ -480,10 +481,10 @@
               <exclude>docs/Rakefile</exclude>
               <exclude>docs/rss.xml</exclude>
               <exclude>docs/sitemap.txt</exclude>
-              
+
               <!-- bundled from jekyll -->
               <exclude>docs/assets/themes/zeppelin/css/syntax.css</exclude>
-              
+
               <!-- docs (website) build target dir -->
               <exclude>docs/_site/**</exclude>
               <exclude>docs/Gemfile.lock</exclude>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -79,7 +79,6 @@
             <exclude>bower.json</exclude>
             <exclude>package.json</exclude>
             <exclude>*.md</exclude>
-            <exclude>reports/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -81,7 +81,7 @@ module.exports = function(config) {
       'PhantomJS'
     ],
 
-    reporters: 'coverage',
+    reporters: ['coverage','progress'],
 
     preprocessors: {
       'src/*/{*.js,!(test)/**/*.js}': 'coverage'
@@ -89,7 +89,8 @@ module.exports = function(config) {
 
     coverageReporter: {
       type: 'html',
-      dir: 'reports/coverage'
+      dir: '../reports/zeppelin-web-coverage',
+      subdir: '.'
     },
 
     // Which plugins to enable


### PR DESCRIPTION
There has been a few karma issues during build, after trying it today I realized that running ``./grunt test`` wasn't really showing the usual output.

Some time Before:
<img width="697" alt="screen shot 2015-11-04 at 11 50 34 pm" src="https://cloud.githubusercontent.com/assets/710411/10941613/b557764a-834f-11e5-944d-073a629d35d2.png">

Now:
<img width="704" alt="screen shot 2015-11-04 at 11 51 18 pm" src="https://cloud.githubusercontent.com/assets/710411/10941618/b87c589a-834f-11e5-89da-706eab7aae5b.png">

I'm thinking that Karma coverage might have been hidding those karma results, and therefore we can't see what is really happening or which rest is failing.