### PR TITLE
ZEPPELIN-388: auto nav to new note

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
@@ -91,6 +91,8 @@ public class Message {
 
     LIST_NOTES, // [c-s] ask list of note
 
+    LIST_NEW_NOTE, // [s-c] ask for newly created note id
+
     NOTES_INFO, // [s-c] list of note infos
                 // @param notes serialized List<NoteInfo> object
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -273,6 +273,10 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
 
+  public void broadcastNewNote(Note note) {
+    broadcastAll(new Message(OP.LIST_NEW_NOTE).put("note", note));
+  }
+
   public void broadcastNote(Note note) {
     broadcast(note.id(), new Message(OP.NOTE).put("note", note));
   }
@@ -390,6 +394,7 @@ public class NotebookServer extends WebSocketServlet implements
     note.persist();
     broadcastNote(note);
     broadcastNoteList();
+    broadcastNewNote(note);
   }
 
   private void removeNote(WebSocket conn, Notebook notebook, Message fromMessage)
@@ -433,6 +438,7 @@ public class NotebookServer extends WebSocketServlet implements
     Note newNote = notebook.cloneNote(noteId, name);
     broadcastNote(newNote);
     broadcastNoteList();
+    broadcastNewNote(newNote);
   }
 
   private void removeParagraph(NotebookSocket conn, Notebook notebook,

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -14,10 +14,15 @@
 
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, websocketMsgSrv) {
+angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, $location, websocketMsgSrv) {
   var vm = this;
   vm.websocketMsgSrv = websocketMsgSrv;
   $scope.note = {};
+
+  $scope.$on('setNewNote', function(event, note) {
+    $location.path('/notebook/'+note.id);
+  });
+
   vm.createNote = function(){
   	  if(!vm.clone){
 		  vm.websocketMsgSrv.createNotebook($scope.note.notename);

--- a/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
+++ b/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
@@ -13,28 +13,14 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').factory('notebookListDataFactory', function($location) {
+angular.module('zeppelinWebApp').factory('notebookListDataFactory', function() {
   var notes = {};
 
   notes.list = [];
 
   notes.setNotes = function(notesList) {
-  	if(notes.list.length && notes.list.length+1===notesList.length){
-		var newNoteID = getNewNoteID(notesList);
-		$location.path('/notebook/'+newNoteID);
-    }
     notes.list = angular.copy(notesList);
   };
-
-  function getNewNoteID(newNotes){
-    var currentNotes = notes.list.map(function(note){return note.id;});
-    var newestNote = newNotes.filter(function(note){
-      if(currentNotes.indexOf(note.id)===-1){
-        return true;
-      }
-    });
-    return newestNote[0].id;
-  }
 
   return notes;
 });

--- a/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
+++ b/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
@@ -13,14 +13,28 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').factory('notebookListDataFactory', function() {
+angular.module('zeppelinWebApp').factory('notebookListDataFactory', function($location) {
   var notes = {};
 
   notes.list = [];
 
   notes.setNotes = function(notesList) {
+  	if(notes.list.length!==0 && notes.list.length+1===notesList.length){
+		var newNoteID = getNewNoteID(notesList);
+		$location.path('/notebook/'+newNoteID);
+    }
     notes.list = angular.copy(notesList);
   };
+
+  function getNewNoteID(newNotes){
+    var currentNotes = notes.list.map(function(note){return note.id;});
+    var newestNote = newNotes.filter(function(note){
+      if(currentNotes.indexOf(note.id)===-1){
+        return true;
+      }
+    });
+    return newestNote[0].id;
+  }
 
   return notes;
 });

--- a/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
+++ b/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
@@ -19,7 +19,7 @@ angular.module('zeppelinWebApp').factory('notebookListDataFactory', function($lo
   notes.list = [];
 
   notes.setNotes = function(notesList) {
-  	if(notes.list.length!==0 && notes.list.length+1===notesList.length){
+  	if(notes.list.length && notes.list.length+1===notesList.length){
 		var newNoteID = getNewNoteID(notesList);
 		$location.path('/notebook/'+newNoteID);
     }

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -46,6 +46,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
     var data = payload.data;
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
+    } else if (op === 'LIST_NEW_NOTE') {
+      $rootScope.$broadcast('setNewNote', data.note);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'PARAGRAPH') {


### PR DESCRIPTION
This PR relates to: https://issues.apache.org/jira/browse/ZEPPELIN-388 Auto navigate to the newly created Note right after its creation.

Current User Experience of Adding New Note (No response after creating a new note):
![current note med](https://cloud.githubusercontent.com/assets/6380209/10981007/a50ceff6-83ca-11e5-8280-4c966c2750f3.gif)

After Pull Request (auto navigates to new note):
![new note med](https://cloud.githubusercontent.com/assets/6380209/10981049/df9a6f4a-83ca-11e5-998d-47c397569a04.gif)


