### PR TITLE
[ZEPPELIN-394] Update cassandra-spark profiles to latest connector versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ Ignite (1.1.0-incubating and later)
 mvn clean package -Dignite.version=1.1.0-incubating -DskipTests
 ```
 
+Spark-Cassandra integration (Spark 1.1.x)
+```
+mvn clean package -Pcassandra-spark-1.1 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
+
+Spark-Cassandra integration (Spark 1.2.x)
+```
+mvn clean package -Pcassandra-spark-1.2 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
+
+Spark-Cassandra integration (Spark 1.3.x)
+```
+mvn clean package -Pcassandra-spark-1.3 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
+
+Spark-Cassandra integration (Spark 1.4.x)
+```
+mvn clean package -Pcassandra-spark-1.4 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
+
+Spark-Cassandra integration (Spark 1.5.x)
+```
+mvn clean package -Pcassandra-spark-1.5 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
+
+
+
 ### Configure
 If you wish to configure Zeppelin option (like port number), configure the following files:
 ```

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -432,9 +432,7 @@
         <dependency>
           <groupId>com.datastax.spark</groupId>
           <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-          <!--You need to build your own version of Spark Cassandra connector 1.3.0-SNAPSHOT
-              because it is not yet released-->
-          <version>1.3.0-SNAPSHOT</version>
+          <version>1.3.1</version>
           <exclusions>
             <exclusion>
               <groupId>org.joda</groupId>
@@ -456,6 +454,27 @@
     </profile>
 
     <profile>
+      <id>cassandra-spark-1.4</id>
+      <properties>
+        <spark.version>1.4.1</spark.version>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>com.datastax.spark</groupId>
+          <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
+          <version>1.4.0</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.joda</groupId>
+              <artifactId>joda-convert</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
       <id>spark-1.5</id>
       <properties>
         <spark.version>1.5.1</spark.version>
@@ -467,7 +486,31 @@
       <dependencies>
       </dependencies>
     </profile>
-    
+ 
+    <profile>
+      <id>cassandra-spark-1.5</id>
+      <properties>
+        <spark.version>1.5.1</spark.version>
+        <akka.group>com.typesafe.akka</akka.group>
+        <akka.version>2.3.11</akka.version>
+        <protobuf.version>2.5.0</protobuf.version>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>com.datastax.spark</groupId>
+          <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
+          <version>1.5.0-M2</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.joda</groupId>
+              <artifactId>joda-convert</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+   
     <profile>
       <id>hadoop-0.23</id>
       <!-- SPARK-1121: Adds an explicit dependency on Avro to work around a


### PR DESCRIPTION
Below is the version matrix. Updates are in bold

<table>
    <tr>
     <th><strong>Maven profile</strong></th>
     <th><strong>Spark Cassandra connector version</strong></th>  
    </tr>
    <tr>
     <td>cassandra-spark-1.1</td>
     <td>1.1.1</td>  
    </tr>
    <tr>
     <td>cassandra-spark-1.2</td>
     <td>1.2.1</td>  
    </tr>
    <tr>
     <td><strong>cassandra-spark-1.3</strong></td>
     <td><strong>1.3.1</strong></td>  
    </tr>
    <tr>
     <td><strong>cassandra-spark-1.4</strong></td>
     <td><strong>1.4.0</strong></td>  
    </tr>
    <tr>
     <td><strong>cassandra-spark-1.5</strong></td>
     <td><strong>1.5.0-M2</strong></td>  
    </tr>
</table> 