### PR TITLE
ZEPPELIN-396 Add -Pypspark profile for release binary

### DIFF
--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -122,7 +122,7 @@ function make_binary_release() {
     rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
 }
 
-make_binary_release all -Pyarn
+make_binary_release all "-Pyarn -Ppyspark"
 
 # remove non release files and dirs
 rm -rf ${WORKING_DIR}/zeppelin


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-396
Add -Ppyspark to enable pyspark in default configuration (without SPARK_HOME specified).
