### PR TITLE
ZEPPELIN-397 Activate spark-1.5 and hadoop-2.4 by default in release script

### DIFF
--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -122,7 +122,7 @@ function make_binary_release() {
     rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
 }
 
-make_binary_release all -Pyarn
+make_binary_release all "-Pspark-1.5 -Phadoop-2.4 -Pyarn"
 
 # remove non release files and dirs
 rm -rf ${WORKING_DIR}/zeppelin


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-397

Activate spark-1.5 and hadoop-2.4 by default
That'll enable use sc.textFile("s3...") with default configuration without specify SPARK_HOME.
