### PR TITLE
ZEPPELIN-401 Improve autoscroll

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -303,7 +303,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
         }
       } else {
         var p = $scope.note.paragraphs[i];
-        if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
+        if (!p.config.hide && !p.config.editorHide) {
           $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id, -1);
           break;
         }
@@ -321,7 +321,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
         }
       } else {
         var p = $scope.note.paragraphs[i];
-        if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
+        if (!p.config.hide && !p.config.editorHide) {
           $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id, 0);
           break;
         }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -304,7 +304,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       } else {
         var p = $scope.note.paragraphs[i];
         if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
-          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id);
+          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id, -1);
           break;
         }
       }
@@ -322,7 +322,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       } else {
         var p = $scope.note.paragraphs[i];
         if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
-          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id);
+          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id, 0);
           break;
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -632,7 +632,7 @@ angular.module('zeppelinWebApp')
      // only make sense when editor is focused
      return;
     }
-    var lineHeight = 16;  // Line height
+    var lineHeight = $scope.editor.renderer.lineHeight;
     var headerHeight = 103; // menubar, notebook titlebar
     var scrollTriggerEdgeMargin = 50;
     

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -633,7 +633,7 @@ angular.module('zeppelinWebApp')
     var calculatedCursorPosition = editorPosition.top + lastCursorPosition.top + 16*lastCursorMove;
 
     if (calculatedCursorPosition < scrollPosition + headerHeight + scrollTriggerEdgeMargin) {
-      var scrollTargetPos = calculatedCursorPosition - ((windowHeight-headerHeight)/3);
+      var scrollTargetPos = calculatedCursorPosition - headerHeight - ((windowHeight-headerHeight)/3);
       if (scrollTargetPos < 0) {
         scrollTargetPos = 0;
       }
@@ -690,9 +690,19 @@ angular.module('zeppelinWebApp')
     }
   });
 
-  $scope.$on('focusParagraph', function(event, paragraphId) {
+  $scope.$on('focusParagraph', function(event, paragraphId, cursorPos) {
     if ($scope.paragraph.id === paragraphId) {
+      // focus editor
       $scope.editor.focus();
+      // move cursor to the first row (or the last row)
+      if (cursorPos >= 0) {
+        var row = cursorPos;
+        var column = 0;
+        $scope.editor.gotoLine(row, 0);
+      } else {
+        var row = $scope.editor.session.getLength() - 1;
+        $scope.editor.gotoLine(row + 1, 0);
+      }
       $scope.scrollToCursor($scope.paragraph.id, 0);
     }
   });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -647,14 +647,12 @@ angular.module('zeppelinWebApp')
     var calculatedCursorPosition = editorPosition.top + lastCursorPosition.top + 16*lastCursorMove;
 
     if (calculatedCursorPosition < scrollPosition + headerHeight + scrollTriggerEdgeMargin) {
-      console.log("scrollUp");
       var scrollTargetPos = calculatedCursorPosition - headerHeight - ((windowHeight-headerHeight)/3);
       if (scrollTargetPos < 0) {
         scrollTargetPos = 0;
       }
       $('body').scrollTo(scrollTargetPos, {duration:200});
     } else if(calculatedCursorPosition > scrollPosition + scrollTriggerEdgeMargin + windowHeight - headerHeight) {
-      console.log("scrollDown");
       var scrollTargetPos = calculatedCursorPosition - headerHeight - ((windowHeight-headerHeight)*2/3);
 
       if (scrollTargetPos > documentHeight) {
@@ -709,7 +707,6 @@ angular.module('zeppelinWebApp')
   $scope.$on('focusParagraph', function(event, paragraphId, cursorPos) {
     if ($scope.paragraph.id === paragraphId) {
       // focus editor
-      console.log("Focus %o", paragraphId);
       $scope.editor.focus();
 
       // move cursor to the first row (or the last row)

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -711,7 +711,7 @@ angular.module('zeppelinWebApp')
       // focus editor
       console.log("Focus %o", paragraphId);
       $scope.editor.focus();
-      /*
+
       // move cursor to the first row (or the last row)
       if (cursorPos >= 0) {
         var row = cursorPos;
@@ -721,7 +721,7 @@ angular.module('zeppelinWebApp')
         var row = $scope.editor.session.getLength() - 1;
         $scope.editor.gotoLine(row + 1, 0);
       }
-      */
+
       $scope.scrollToCursor($scope.paragraph.id, 0);
     }
   });


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/ZEPPELIN-401

This PR improves autoscroll behavior when using keyboard navigation (up/down key)

* When cursor closes to edge of top/bottom of notebook, autoscroll triggers
* Autoscroll will scroll notebook to position cursor to the middle of browser window
* When last paragraph is executed, a new paragraph is inserted after. now notebook autoscrolls to newly inserted paragraph. 