### PR TITLE
[ZEPPELIN-434] Fix website build warning due to depecrated settings

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "vendor", "node_modules", "scss"]
-pygments: true
+highlighter: true
 markdown: redcarpet
 encoding: utf-8
 


### PR DESCRIPTION
pygment has been depecrated in favor of highlighter attribute