### PR TITLE
ZEPPELIN-404 Certain project dependencies are pulled from 3rd parties repos instead of ASF or public Maven 

### DIFF
--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -228,7 +228,7 @@
 
   <profiles>
     <profile>
-      <id>vender-repo</id>
+      <id>vendor-repo</id>
       <repositories>
         <repository>
           <id>cloudera</id>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -225,80 +225,16 @@
 
     </plugins>
   </build>
-  <repositories>
-    <repository>
-      <id>inmobi.repo</id>
-      <url>https://github.com/InMobi/mvn-repo/raw/master/releases</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>inmobi.snapshots</id>
-      <url>https://github.com/InMobi/mvn-repo/raw/master/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>central</id>
-      <url>http://repo1.maven.org/maven2</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>cloudera</id>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>Codehaus repository</id>
-      <url>http://repository.codehaus.org/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>apache.snapshots.repo</id>
-      <url>https://repository.apache.org/content/groups/snapshots</url>
-      <name>Apache Snapshots Repository</name>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>default</id>
-      <url>https://repository.apache.org/content/groups/public/</url>
-    </repository>
-    <repository>
-      <id>projectlombok.org</id>
-      <url>http://projectlombok.org/mavenrepo</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <!-- see https://jira.springsource.org/browse/SHL-52 -->
-    <repository>
-      <id>ext-release-local</id>
-      <url>http://repo.springsource.org/simple/ext-release-local/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
+  <profiles>
+    <profile>
+      <id>vender-repo</id>
+      <repositories>
+        <repository>
+          <id>cloudera</id>
+          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 </project>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -343,7 +343,7 @@
 
   <profiles>
     <profile>
-      <id>vender-repo</id>
+      <id>vendor-repo</id>
       <repositories>
         <repository>
           <id>cloudera</id>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -54,13 +54,6 @@
     <py4j.version>0.8.2.1</py4j.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>cloudera</id>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -349,6 +342,16 @@
   </dependencies>
 
   <profiles>
+    <profile>
+      <id>vender-repo</id>
+      <repositories>
+        <repository>
+          <id>cloudera</id>
+          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+      </repositories>
+    </profile>
+
     <profile>
       <id>spark-1.1</id>
       <dependencies>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -296,7 +296,7 @@
 
   <profiles>
     <profile>
-      <id>vender-repo</id>
+      <id>vendor-repo</id>
       <repositories>
         <repository>
           <id>cloudera</id>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,13 +43,6 @@
     <py4j.version>0.8.2.1</py4j.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>cloudera</id>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-    </repository>
-  </repositories>
-  
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -300,6 +293,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>vender-repo</id>
+      <repositories>
+        <repository>
+          <id>cloudera</id>
+          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-404

This PR removes / move 3rd party repository into profile.
cloudera repo is disabled by default and can be activated by -Pvendor-repo