### PR TITLE
ZEPPELIN-372 : fix for Export not working on Firefox and Safari

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -15,7 +15,9 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $route, $routeParams, $location, $rootScope, $http, websocketMsgSrv, baseUrlSrv, $timeout) {
+angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $route, $routeParams, $location,
+                                                                     $rootScope, $http, websocketMsgSrv, baseUrlSrv,
+                                                                     $timeout, browserDetectService) {
   $scope.note = null;
   $scope.showEditor = false;
   $scope.editorToggled = false;
@@ -81,13 +83,25 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   //Export notebook
   $scope.exportNotebook = function() {
-    var jsonContent = 'data:image/svg;charset=utf-8,' + encodeURIComponent(JSON.stringify($scope.note));
-    jQuery('h3').append('<a class="exportNotebook"></a>');
-    jQuery('h3 a.exportNotebook').attr('href', jsonContent);
-    jQuery('h3 a.exportNotebook').attr('download', $scope.note.name + '.json');
-    jQuery('h3 a.exportNotebook').attr('target', '_blank');
-    jQuery('h3 a.exportNotebook')[0].click();
-    jQuery('h3 a.exportNotebook').remove();
+    var jsonContent = JSON.stringify($scope.note);
+    if (browserDetectService.detectIE()) {
+      jQuery('h3').append('<iframe id="myFrame" style="display:none"></iframe>');
+      var myFrame = jQuery('#myFrame')[0].contentWindow;
+      myFrame.document.open('text/html', 'replace');
+      myFrame.document.write(jsonContent);
+      myFrame.document.close();
+      myFrame.focus();
+      myFrame.document.execCommand('SaveAs', true, $scope.note.name + '.json');
+      jQuery('h3 iframe').remove();
+    } else {
+      jsonContent = 'data:image/svg;charset=utf-8,' + encodeURIComponent(jsonContent);
+      jQuery('h3').append('<a class="exportNotebook"></a>');
+      jQuery('h3 a.exportNotebook').attr('href', jsonContent);
+      jQuery('h3 a.exportNotebook').attr('download', $scope.note.name + '.json');
+      jQuery('h3 a.exportNotebook').attr('target', '_blank');
+      jQuery('h3 a.exportNotebook')[0].click();
+      jQuery('h3 a.exportNotebook').remove();
+    }
   };
 
   //Clone note

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -17,7 +17,7 @@
 
 angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $route, $routeParams, $location,
                                                                      $rootScope, $http, websocketMsgSrv, baseUrlSrv,
-                                                                     $timeout, browserDetectService) {
+                                                                     $timeout, SaveAsService) {
   $scope.note = null;
   $scope.showEditor = false;
   $scope.editorToggled = false;
@@ -84,24 +84,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   //Export notebook
   $scope.exportNotebook = function() {
     var jsonContent = JSON.stringify($scope.note);
-    if (browserDetectService.detectIE()) {
-      jQuery('h3').append('<iframe id="myFrame" style="display:none"></iframe>');
-      var myFrame = jQuery('#myFrame')[0].contentWindow;
-      myFrame.document.open('text/html', 'replace');
-      myFrame.document.write(jsonContent);
-      myFrame.document.close();
-      myFrame.focus();
-      myFrame.document.execCommand('SaveAs', true, $scope.note.name + '.json');
-      jQuery('h3 iframe').remove();
-    } else {
-      jsonContent = 'data:image/svg;charset=utf-8,' + encodeURIComponent(jsonContent);
-      jQuery('h3').append('<a class="exportNotebook"></a>');
-      jQuery('h3 a.exportNotebook').attr('href', jsonContent);
-      jQuery('h3 a.exportNotebook').attr('download', $scope.note.name + '.json');
-      jQuery('h3 a.exportNotebook').attr('target', '_blank');
-      jQuery('h3 a.exportNotebook')[0].click();
-      jQuery('h3 a.exportNotebook').remove();
-    }
+    SaveAsService.SaveAs(jsonContent, $scope.note.name, 'json');
   };
 
   //Clone note

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -81,12 +81,13 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   //Export notebook
   $scope.exportNotebook = function() {
-    var jsonContent = 'data:text/json;charset=utf-8,' + JSON.stringify($scope.note);
-    var encodedUri = encodeURI(jsonContent);
-    var link = document.createElement('a');
-    link.setAttribute('href', encodedUri);
-    link.setAttribute('download', $scope.note.name + '.json');
-    link.click();
+    var jsonContent = 'data:image/svg;charset=utf-8,' + encodeURIComponent(JSON.stringify($scope.note));
+    jQuery('h3').append('<a class="exportNotebook"></a>');
+    jQuery('h3 a.exportNotebook').attr('href', jsonContent);
+    jQuery('h3 a.exportNotebook').attr('download', $scope.note.name + '.json');
+    jQuery('h3 a.exportNotebook').attr('target', '_blank');
+    jQuery('h3 a.exportNotebook')[0].click();
+    jQuery('h3 a.exportNotebook').remove();
   };
 
   //Clone note

--- a/zeppelin-web/src/components/browser-detect/browserDetect.service.js
+++ b/zeppelin-web/src/components/browser-detect/browserDetect.service.js
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('zeppelinWebApp').service('browserDetectService', function() {
+
+  this.detectIE = function() {
+    var ua = window.navigator.userAgent;
+    var msie = ua.indexOf('MSIE ');
+    if (msie > 0) {
+      // IE 10 or older => return version number
+      return parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+    }
+    var trident = ua.indexOf('Trident/');
+    if (trident > 0) {
+      // IE 11 => return version number
+      var rv = ua.indexOf('rv:');
+      return parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+    }
+    var edge = ua.indexOf('Edge/');
+    if (edge > 0) {
+      // IE 12 (aka Edge) => return version number
+      return parseInt(ua.substring(edge + 5, ua.indexOf('.', edge)), 10);
+    }
+    // other browser
+    return false;
+  };
+
+});

--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('zeppelinWebApp').service('SaveAsService', function(browserDetectService) {
+
+  this.SaveAs = function(content, filename, extension) {
+    if (browserDetectService.detectIE()) {
+      angular.element('body').append('<iframe id="SaveAsId" style="display: none"></iframe>');
+      var frameSaveAs = angular.element('body > iframe#SaveAsId')[0].contentWindow;
+      frameSaveAs.document.open('text/json', 'replace');
+      frameSaveAs.document.write(content);
+      frameSaveAs.document.close();
+      frameSaveAs.focus();
+      var t1 = Date.now();
+      frameSaveAs.document.execCommand('SaveAs', false, filename + '.' + extension);
+      var t2 = Date.now();
+
+      //This means, this version of IE dosen't support auto download of a file with extension provided in param
+      //falling back to ".txt"
+      if (t1 === t2) {
+        frameSaveAs.document.execCommand('SaveAs', true, filename + '.txt');
+      }
+      angular.element('body > iframe#SaveAsId').remove();
+    } else {
+      content = 'data:image/svg;charset=utf-8,' + encodeURIComponent(content);
+      angular.element('body').append('<a id="SaveAsId"></a>');
+      var saveAsElement = angular.element('body > a#SaveAsId');
+      saveAsElement.attr('href', content);
+      saveAsElement.attr('download', filename + '.' + extension);
+      saveAsElement.attr('target', '_blank');
+      saveAsElement[0].click();
+      saveAsElement.remove();
+    }
+  };
+
+});

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -139,6 +139,7 @@ limitations under the License.
     <script src="components/notebookListDataFactory/notebookList.datafactory.js"></script>
     <script src="components/baseUrl/baseUrl.service.js"></script>
     <script src="components/browser-detect/browserDetect.service.js"></script>
+    <script src="components/saveAs/saveAs.service.js"></script>
     <!-- endbuild -->
   </body>
 </html>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -138,6 +138,7 @@ limitations under the License.
     <script src="components/websocketEvents/websocketEvents.factory.js"></script>
     <script src="components/notebookListDataFactory/notebookList.datafactory.js"></script>
     <script src="components/baseUrl/baseUrl.service.js"></script>
+    <script src="components/browser-detect/browserDetect.service.js"></script>
     <!-- endbuild -->
   </body>
 </html>


### PR DESCRIPTION
With reference to bug in https://github.com/apache/incubator-zeppelin/pull/376#issuecomment-154801136
The export link was not working on Firefox and Safari. 
Have made a fix, this should enable download on Firefox and Safari. 
