### PR TITLE
[ZEPPELIN-328] Interpreter page should clarify the % magic syntax for interpreter group.name

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -44,7 +44,9 @@ limitations under the License.
             <span style="display:inline-block" ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
               <span ng-show="!$first">, </span>
-              %<span ng-show="setting.group !== interpreter.name && !$parent.$first">{{setting.group}}.</span>{{interpreter.name}}
+              %<span ng-show="!$parent.$first || $first">{{setting.group}}</span
+              ><span ng-show="(!$parent.$first || $first) && !$first">.</span
+              ><span ng-show="!$first">{{interpreter.name}}</span>
               <span ng-show="$parent.$first && $first">(default)</span>
             </span>
           </small>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -41,12 +41,11 @@ limitations under the License.
       <div class="col-md-12">
         <h3 class="interpreter-title">{{setting.name}}
           <small>
-            <span ng-repeat="interpreter in setting.interpreterGroup"
+            <span style="display:inline-block" ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
-              <span ng-show="$parent.$first && $first">%{{setting.name}} (default)</span>
-              <span ng-show="$parent.$first && !$first">, %{{interpreter.name}}</span>
-              <span ng-show="!$parent.$first && $first">%{{setting.name}}</span>
-              <span ng-show="!$parent.$first && !$first">, %{{setting.name}}.{{interpreter.name}}</span>
+              <span ng-show="!$first">, </span>
+              %<span ng-show="setting.group !== interpreter.name && !$parent.$first">{{setting.group}}.</span>{{interpreter.name}}
+              <span ng-show="$parent.$first && $first">(default)</span>
             </span>
           </small>
         </h3>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -154,7 +154,9 @@ limitations under the License.
             <small>
               <span style="display:inline-block" ng-repeat="intp in item.interpreters">
                 <span ng-show="!$first">, </span>
-                %<span ng-show="item.group !== intp.name && !$parent.$first">{{item.group}}.</span>{{intp.name}}
+                %<span ng-show="!$parent.$first || $first">{{item.group}}</span
+                ><span ng-show="(!$parent.$first || $first) && !$first">.</span
+                ><span ng-show="!$first">{{intp.name}}</span>
                 <span ng-show="$parent.$first && $first">(default)</span>
               </span>
             </small>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -149,7 +149,16 @@ limitations under the License.
           <div as-sortable-item-handle
                ng-click="item.selected = !item.selected"
                class="btn"
-               ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}"><font style="font-size:16px">{{item.name}}</font> <small><span ng-repeat="intp in item.interpreters"><span ng-show="!$first">, </span>%{{intp.name}}</span></small></div>
+               ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
+            <font style="font-size:16px">{{item.name}}</font>
+            <small>
+              <span style="display:inline-block" ng-repeat="intp in item.interpreters">
+                <span ng-show="!$first">, </span>
+                %<span ng-show="item.group !== intp.name && !$parent.$first">{{item.group}}.</span>{{intp.name}}
+                <span ng-show="$parent.$first && $first">(default)</span>
+              </span>
+            </small>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Display %interpreterGroup.interpreterName instead of %settingName.interpreterName

  Before
  <img width="538" alt="2015-11-09 10 54 43" src="https://cloud.githubusercontent.com/assets/8503346/11035667/354425b6-8737-11e5-82f7-e76376ec6140.png">

  After
  <img width="415" alt="2015-11-09 10 54 18" src="https://cloud.githubusercontent.com/assets/8503346/11035670/3bf56992-8737-11e5-89e6-85c5562ba196.png">

* Clarify available interpreter as `%group.name` in each notebook when interpreter group name is different from interpreter name.
  * %hql -> %hive.hql
  * %tql -> %tajo.tql
  * %ignite, %ignitesql -> %ignite, %ignite.ignitesql

  Before
  <img width="1225" alt="2015-11-09 10 51 16" src="https://cloud.githubusercontent.com/assets/8503346/11035678/45f186c4-8737-11e5-8178-d5c57f5a663e.png">

  After
  <img width="1225" alt="2015-11-09 10 55 45" src="https://cloud.githubusercontent.com/assets/8503346/11035683/4c8fca72-8737-11e5-99da-043686bde3a4.png">

