### PR TITLE
ZEPPELIN-410 Autoscroll only in y axis

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -669,7 +669,7 @@ angular.module('zeppelinWebApp')
         scrollTargetPos = documentHeight;
       }
     }
-    angular.element('body').scrollTo(scrollTargetPos, {duration:200});
+    angular.element('body').scrollTo(scrollTargetPos, {axis: 'y', interrupt: true, duration:200});
   };
 
   var setEditorHeight = function(id, height) {


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/ZEPPELIN-410
Autoscroll scrolls not only vertical, but also horizontal scrollbar. but horizontal scrollbar should not be touched from it.