### PR TITLE
ZEPPELIN-408 Fix configuration bug of notebook and interpreter directory

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -36,10 +36,6 @@ if [[ -z "${ZEPPELIN_LOG_DIR}" ]]; then
   export ZEPPELIN_LOG_DIR="${ZEPPELIN_HOME}/logs"
 fi
 
-if [[ -z "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
-  export ZEPPELIN_NOTEBOOK_DIR="${ZEPPELIN_HOME}/notebook"
-fi
-
 if [[ -z "$ZEPPELIN_PID_DIR" ]]; then
   export ZEPPELIN_PID_DIR="${ZEPPELIN_HOME}/run"
 fi
@@ -50,10 +46,6 @@ if [[ -z "${ZEPPELIN_WAR}" ]]; then
   else
     export ZEPPELIN_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web*.war")
   fi
-fi
-
-if [[ -z "$ZEPPELIN_INTERPRETER_DIR" ]]; then
-  export ZEPPELIN_INTERPRETER_DIR="${ZEPPELIN_HOME}/interpreter"
 fi
 
 if [[ -f "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh" ]]; then


### PR DESCRIPTION
Detail description of this issue is in [JIRA](https://issues.apache.org/jira/browse/ZEPPELIN-408). This PR removes some lines of code to set directory configuration in `common.sh`. Although we remove the codes, configuration will be okay because `ZeppelinConfiguration` object has default values.