### PR TITLE
Zeppelin-web-docs] angular (beta) description fix

### DIFF
--- a/docs/docs/displaysystem/angular.md
+++ b/docs/docs/displaysystem/angular.md
@@ -40,10 +40,10 @@ z.angularBind(String name, Object object)
 z.angularBindGlobal(String name, Object object)
 
 // unbind angular scope variable 'name' in current notebook.
-z.angularBind(String name)
+z.angularUnbind(String name)
 
 // unbind angular scope variable 'name' in all notebooks related to current interpreter.
-z.angularBindGlobal(String name)
+z.angularUnbindGlobal(String name)
 
 ```
 


### PR DESCRIPTION
Modify the incorrect description of the angular parts of the document unbind.

original
```
// bind my 'object' as angular scope variable 'name' in current notebook.
z.angularBind(String name, Object object)

// bind my 'object' as angular scope variable 'name' in all notebooks related to current interpreter.
z.angularBindGlobal(String name, Object object)

// unbind angular scope variable 'name' in current notebook.
z.angularBind(String name)

// unbind angular scope variable 'name' in all notebooks related to current interpreter.
z.angularBindGlobal(String name)
In the example, let's bind "world" variable 'name'. Then you can see AngularJs view are updated immediately.
```

fix
```
// bind my 'object' as angular scope variable 'name' in current notebook.
z.angularBind(String name, Object object)

// bind my 'object' as angular scope variable 'name' in all notebooks related to current interpreter.
z.angularBindGlobal(String name, Object object)

// unbind angular scope variable 'name' in current notebook.
z.angularUnbind(String name)

// unbind angular scope variable 'name' in all notebooks related to current interpreter.
z.angularUnbindGlobal(String name)
In the example, let's bind "world" variable 'name'. Then you can see AngularJs view are updated immediately.

```

unbind description 
**angularBind -> angularUnbind**
global unbind description
**angularBindGlobal -> angularUnbindGlobal**
