### PR TITLE
Deactivate IE scrollbar on page

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -20,6 +20,7 @@ body {
 html,
 body {
   height: 100%;
+  -ms-overflow-style: scrollbar;
 }
 
 .bodyAsIframe {


### PR DESCRIPTION
The page scrollbar of IE (at least 10) is covering the content of the page
<img width="177" alt="screen shot 2015-11-13 at 4 39 29 pm" src="https://cloud.githubusercontent.com/assets/710411/11141176/25106cda-8a26-11e5-97b3-0d292d4bd6fe.png">

This PR is removing that style for a traditional scrollbar
<img width="181" alt="screen shot 2015-11-13 at 4 45 00 pm" src="https://cloud.githubusercontent.com/assets/710411/11141183/323fbd48-8a26-11e5-8056-b56e712e7d65.png">
