### PR TITLE
ZEPPELIN-418 Keep paragraph height the same with/without executionTime label

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -697,7 +697,7 @@ angular.module('zeppelinWebApp')
       }
       return '';
     }
-    var desc = 'Took ' + (timeMs/1000) + ' seconds.';
+    var desc = 'Took ' + (timeMs/1000) + ' seconds';
     if ($scope.isResultOutdated()){
       desc += ' (outdated)';
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -18,7 +18,7 @@
 
 .paragraph-space {
   margin-bottom: 5px !important;
-  padding: 10px 10px 0px 10px !important;
+  padding: 10px 10px 10px 10px !important;
   min-height : 30px;
 }
 
@@ -75,7 +75,6 @@
 
 .paragraph .paragraphFooter { 
   height: 9px;
-  margin-bottom: 10px;
 }
 
 .paragraph .executionTime {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -18,7 +18,8 @@
 
 .paragraph-space {
   margin-bottom: 5px !important;
-  padding: 10px !important;
+  padding: 10px 10px 0px 10px !important;
+  min-height : 30px;
 }
 
 .paragraph-margin {
@@ -42,6 +43,7 @@
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
   font-size: 12px !important;
   margin-bottom: 5px !important;
+  padding-top: 2px;
 }
 
 .paragraph table {
@@ -69,6 +71,11 @@
 
 .resizable-helper {
   border: 3px solid #DDDDDD;
+}
+
+.paragraph .paragraphFooter { 
+  height: 9px;
+  margin-bottom: 10px;
 }
 
 .paragraph .executionTime {
@@ -177,8 +184,7 @@
 */
 
 .paragraph .title {
-  margin: 3px 0px 0px 0px;
-  min-height: 20px;
+  margin: 0px 0px 0px 0px;
   font-size: 12px;
 }
 
@@ -284,6 +290,12 @@
 /*
   Table Display CSS
 */
+
+.tableDisplay {
+}
+
+.tableDisplay div {
+}
 
 .tableDisplay img {
   display: block;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -392,10 +392,9 @@ limitations under the License.
            ng-if="paragraph.status == 'ERROR'"
            ng-bind="paragraph.errorMessage">
       </div>
-
-      <div ng-if="!asIframe" id="{{paragraph.id}}_executionTime" class="executionTime" ng-bind-html="getExecutionTime()"></div>
     </div>
   </div>
+
   <div id="{{paragraph.id}}_control" class="control" ng-show="!asIframe">
 
     <span>
@@ -481,4 +480,10 @@ limitations under the License.
       </ul>
     </span>
   </div>
+
+  <div ng-if="!asIframe" class="paragraphFooter">
+    <div ng-show="!paragraph.config.tableHide && !viewOnly" id="{{paragraph.id}}_executionTime" class="executionTime" ng-bind-html="getExecutionTime()">
+    </div>
+  </div>
+  
 </div>

--- a/zeppelin-web/src/assets/styles/looknfeel/simple.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/simple.css
@@ -57,8 +57,8 @@ body {
   visibility: hidden;
   height: 0px;
   position: relative;
-  top : -5px;
-  margin-bottom: 0px;  
+  top : -13px;
+  z-index: 99;
 }
 
 .paragraph .executionTime {

--- a/zeppelin-web/src/assets/styles/looknfeel/simple.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/simple.css
@@ -53,6 +53,25 @@ body {
   visibility: visible;
 }
 
+.paragraph .paragraphFooter {
+  visibility: hidden;
+  height: 0px;
+  position: relative;
+  top : -5px;
+  margin-bottom: 0px;  
+}
+
+.paragraph .executionTime {
+  font-size: 8px;
+  text-align: right;
+  margin-right: 5px;
+}
+
+.paragraph:hover .paragraphFooter {
+  visibility: visible;
+}
+
+
 .noteAction span,
 .noteAction button,
 .noteAction form {


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/ZEPPELIN-418.

* [x] executionTime label ("took xx seconds") keeps it's space while paragraph is running
* [x] show executionTime label only on hover mouse in 'simple' look n feel

#### 'default' look n feel

Before
![image](https://cloud.githubusercontent.com/assets/1540981/11144800/d92565ba-8a42-11e5-9948-ec1dce8afb2a.png)


After
![image](https://cloud.githubusercontent.com/assets/1540981/11144767/988a2342-8a42-11e5-889f-988a3d3aefcb.png)


#### 'simple' look n feel

Before

![image](https://cloud.githubusercontent.com/assets/1540981/11144821/06c38510-8a43-11e5-9839-843861c97edd.png)

After

![image](https://cloud.githubusercontent.com/assets/1540981/11144834/27c86d84-8a43-11e5-9214-936cff901abe.png)



