### PR TITLE
Zeppelin 337 configurable context path (2)

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -32,6 +32,12 @@
 </property>
 
 <property>
+  <name>zeppelin.server.context.path</name>
+  <value>/</value>
+  <description>Context Path of the Web Application</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.dir</name>
   <value>notebook</value>
   <description>path or URI for notebook persist</description>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -83,6 +83,12 @@ Configuration can be done by both environment variable(conf/zeppelin-env.sh) and
     <td>Zeppelin server port. Note that port+1 is used for web socket</td>
   </tr>
   <tr>
+    <td>ZEPPELIN_CONTEXT_PATH</td>
+    <td>zeppelin.server.context.path</td>
+    <td>/</td>
+    <td>Context Path of the Web Application</td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_NOTEBOOK_DIR</td>
     <td>zeppelin.notebook.dir</td>
     <td>notebook</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -83,7 +83,7 @@ Configuration can be done by both environment variable(conf/zeppelin-env.sh) and
     <td>Zeppelin server port. Note that port+1 is used for web socket</td>
   </tr>
   <tr>
-    <td>ZEPPELIN_CONTEXT_PATH</td>
+    <td>ZEPPELIN_SERVER_CONTEXT_PATH</td>
     <td>zeppelin.server.context.path</td>
     <td>/</td>
     <td>Context Path of the Web Application</td>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -218,8 +218,8 @@ public class ZeppelinServer extends Application {
 
     final ServletContextHandler cxfContext = new ServletContextHandler();
     cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath(conf.getServerContextPath() + "/api");
-    cxfContext.addServlet(cxfServletHolder, "/*");
+    cxfContext.setContextPath(conf.getServerContextPath());
+    cxfContext.addServlet(cxfServletHolder, "/api/*");
 
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -170,7 +170,7 @@ public class ZeppelinServer extends Application {
         ServletContextHandler.SESSIONS);
 
     cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath(conf.getContextPath());
+    cxfContext.setContextPath(conf.getServerContextPath());
     cxfContext.addServlet(servletHolder, "/ws/*");
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
@@ -218,7 +218,7 @@ public class ZeppelinServer extends Application {
 
     final ServletContextHandler cxfContext = new ServletContextHandler();
     cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath(conf.getContextPath() + "/api");
+    cxfContext.setContextPath(conf.getServerContextPath() + "/api");
     cxfContext.addServlet(cxfServletHolder, "/*");
 
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
@@ -235,7 +235,7 @@ public class ZeppelinServer extends Application {
       // Development mode, read from FS
       // webApp.setDescriptor(warPath+"/WEB-INF/web.xml");
       webApp.setResourceBase(warPath.getPath());
-      webApp.setContextPath(conf.getContextPath());
+      webApp.setContextPath(conf.getServerContextPath());
       webApp.setParentLoaderPriority(true);
     } else {
       // use packaged WAR

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -230,12 +230,12 @@ public class ZeppelinServer extends Application {
       ZeppelinConfiguration conf) {
 
     WebAppContext webApp = new WebAppContext();
+    webApp.setContextPath(conf.getServerContextPath());
     File warPath = new File(conf.getString(ConfVars.ZEPPELIN_WAR));
     if (warPath.isDirectory()) {
       // Development mode, read from FS
       // webApp.setDescriptor(warPath+"/WEB-INF/web.xml");
       webApp.setResourceBase(warPath.getPath());
-      webApp.setContextPath(conf.getServerContextPath());
       webApp.setParentLoaderPriority(true);
     } else {
       // use packaged WAR

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -85,7 +85,7 @@ public class ZeppelinServer extends Application {
     jettyServer = setupJettyServer(conf);
 
     // REST api
-    final ServletContextHandler restApi = setupRestApiContextHandler();
+    final ServletContextHandler restApi = setupRestApiContextHandler(conf);
 
     // Notebook server
     final ServletContextHandler notebook = setupNotebookServer(conf);
@@ -170,7 +170,7 @@ public class ZeppelinServer extends Application {
         ServletContextHandler.SESSIONS);
 
     cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath("/");
+    cxfContext.setContextPath(conf.getContextPath());
     cxfContext.addServlet(servletHolder, "/ws/*");
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
@@ -210,7 +210,7 @@ public class ZeppelinServer extends Application {
     return scf.getSslContext();
   }
 
-  private static ServletContextHandler setupRestApiContextHandler() {
+  private static ServletContextHandler setupRestApiContextHandler(ZeppelinConfiguration conf) {
     final ServletHolder cxfServletHolder = new ServletHolder(new CXFNonSpringJaxrsServlet());
     cxfServletHolder.setInitParameter("javax.ws.rs.Application", ZeppelinServer.class.getName());
     cxfServletHolder.setName("rest");
@@ -218,7 +218,7 @@ public class ZeppelinServer extends Application {
 
     final ServletContextHandler cxfContext = new ServletContextHandler();
     cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath("/api");
+    cxfContext.setContextPath(conf.getContextPath() + "/api");
     cxfContext.addServlet(cxfServletHolder, "/*");
 
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
@@ -235,7 +235,7 @@ public class ZeppelinServer extends Application {
       // Development mode, read from FS
       // webApp.setDescriptor(warPath+"/WEB-INF/web.xml");
       webApp.setResourceBase(warPath.getPath());
-      webApp.setContextPath("/");
+      webApp.setContextPath(conf.getContextPath());
       webApp.setParentLoaderPriority(true);
     } else {
       // use packaged WAR

--- a/zeppelin-web/src/components/baseUrl/baseUrl.service.js
+++ b/zeppelin-web/src/components/baseUrl/baseUrl.service.js
@@ -32,7 +32,7 @@ angular.module('zeppelinWebApp').service('baseUrlSrv', function() {
 
   this.getWebsocketUrl = function() {
     var wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return wsProtocol + '//' + location.hostname + ':' + this.getPort() + '/ws';
+    return wsProtocol + '//' + location.hostname + ':' + this.getPort() + skipTrailingSlash(location.pathname) + '/ws';
   };
 
   this.getRestApiBase = function() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -268,6 +268,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getInt(ConfVars.ZEPPELIN_PORT);
   }
 
+  public String getContextPath() {
+    return getString(ConfVars.ZEPPELIN_CONTEXT_PATH);
+  }
+
   public String getKeyStorePath() {
     return getRelativeDir(
             String.format("%s/%s",
@@ -383,6 +387,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_HOME("zeppelin.home", "../"),
     ZEPPELIN_ADDR("zeppelin.server.addr", "0.0.0.0"),
     ZEPPELIN_PORT("zeppelin.server.port", 8080),
+    ZEPPELIN_CONTEXT_PATH("zeppelin.server.context.path", "/"),
     ZEPPELIN_SSL("zeppelin.ssl", false),
     ZEPPELIN_SSL_CLIENT_AUTH("zeppelin.ssl.client.auth", false),
     ZEPPELIN_SSL_KEYSTORE_PATH("zeppelin.ssl.keystore.path", "keystore"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -268,8 +268,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getInt(ConfVars.ZEPPELIN_PORT);
   }
 
-  public String getContextPath() {
-    return getString(ConfVars.ZEPPELIN_CONTEXT_PATH);
+  public String getServerContextPath() {
+    return getString(ConfVars.ZEPPELIN_SERVER_CONTEXT_PATH);
   }
 
   public String getKeyStorePath() {
@@ -387,7 +387,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_HOME("zeppelin.home", "../"),
     ZEPPELIN_ADDR("zeppelin.server.addr", "0.0.0.0"),
     ZEPPELIN_PORT("zeppelin.server.port", 8080),
-    ZEPPELIN_CONTEXT_PATH("zeppelin.server.context.path", "/"),
+    ZEPPELIN_SERVER_CONTEXT_PATH("zeppelin.server.context.path", "/"),
     ZEPPELIN_SSL("zeppelin.ssl", false),
     ZEPPELIN_SSL_CLIENT_AUTH("zeppelin.ssl.client.auth", false),
     ZEPPELIN_SSL_KEYSTORE_PATH("zeppelin.ssl.keystore.path", "keystore"),


### PR DESCRIPTION
Allow to configure the context path of the webapp via zeppelin.server.context.path property or ZEPPELIN_SERVER_CONTEXT_PATH env variable + documentation for this.

(replaces #385)
