### PR TITLE
[ZEPPELIN-421] Remove deprecated spark interpreter properties from in…

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -82,9 +82,6 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
         "spark",
         PySparkInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
-          .add("spark.home",
-               SparkInterpreter.getSystemDefault("SPARK_HOME", "spark.home", ""),
-               "Spark home path. Should be provided for pyspark")
           .add("zeppelin.pyspark.python",
                SparkInterpreter.getSystemDefault("PYSPARK_PYTHON", null, "python"),
                "Python command to run pyspark with").build());
@@ -95,16 +92,6 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
 
     scriptPath = System.getProperty("java.io.tmpdir") + "/zeppelin_pyspark.py";
   }
-
-  private String getSparkHome() {
-    String sparkHome = getProperty("spark.home");
-    if (sparkHome == null) {
-      throw new InterpreterException("spark.home is undefined");
-    } else {
-      return sparkHome;
-    }
-  }
-
 
   private void createPythonScript() {
     ClassLoader classLoader = getClass().getClassLoader();

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -100,10 +100,6 @@ public class SparkInterpreter extends Interpreter {
             .add("spark.cores.max",
                 getSystemDefault(null, "spark.cores.max", ""),
                 "Total number of cores to use. Empty value uses all available core.")
-            .add("spark.yarn.jar",
-                getSystemDefault("SPARK_YARN_JAR", "spark.yarn.jar", ""),
-                "The location of the Spark jar file. If you use yarn as a cluster, "
-                + "we should set this value")
             .add("zeppelin.spark.useHiveContext",
                 getSystemDefault("ZEPPELIN_SPARK_USEHIVECONTEXT",
                     "zeppelin.spark.useHiveContext", "true"),
@@ -310,7 +306,7 @@ public class SparkInterpreter extends Interpreter {
     }
 
     //TODO(jongyoul): Move these codes into PySparkInterpreter.java
-    String pysparkBasePath = getSystemDefault("SPARK_HOME", "spark.home", null);
+    String pysparkBasePath = getSystemDefault("SPARK_HOME", null, null);
     File pysparkPath;
     if (null == pysparkBasePath) {
       pysparkBasePath = getSystemDefault("ZEPPELIN_HOME", "zeppelin.home", "../");


### PR DESCRIPTION
…terpreter ui

Removed deprecated properties `spark.home`, `spark.yarn.jar`.
Corresponding docs will be updated in different PR after #430, #431 merged.