### PR TITLE
ZEPPELIN-414 - Contain result inside paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -77,6 +77,10 @@
   font-family: 'Roboto', sans-serif;
 }
 
+.paragraph .resultContained {
+  overflow: auto;
+}
+
 /*
   Paragraph as Iframe CSS
 */

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -372,11 +372,13 @@ limitations under the License.
       </div>
 
       <div id="p{{paragraph.id}}_html"
+           class="resultContained"
            ng-if="paragraph.result.type == 'HTML'"
            ng-Init="loadResultType(paragraph.result)">
       </div>
 
       <div id="p{{paragraph.id}}_angular"
+           class="resultContained"
            ng-if="paragraph.result.type == 'ANGULAR'"
            ng-Init="loadResultType(paragraph.result)">
       </div>


### PR DESCRIPTION
Taking care of https://issues.apache.org/jira/browse/ZEPPELIN-414

I only applied it on ``HTML`` and ``ANGULAR`` result, because it is the only one that i saw breaking.
Didn't have any problem with other types, although I couldn't test with the response type ``IMG``, any good example to test it?

Here is how it looks now:
![screen shot 2015-11-16 at 11 54 47 am](https://cloud.githubusercontent.com/assets/710411/11173419/8d137ebe-8c59-11e5-924b-a7fcc43447cf.png)
