### PR TITLE
[ZEPPELIN-428] Support Python programmatic access to dynamic form

### DIFF
--- a/docs/manual/dynamicform.md
+++ b/docs/manual/dynamicform.md
@@ -67,12 +67,60 @@ Here're some examples.
 
 Text input form
 
+You can do this in Scala
+```scala
+%spark
+println("Hello "+z.input("name"))
+```
+
+Or Python
+```python
+%pyspark
+print("Hello "+z.input("name"))
+```
+
 <img src="../../assets/themes/zeppelin/img/screenshots/form_input_prog.png" />
 
 Text input form with default value
 
+Scala
+```scala
+%spark
+println("Hello "+z.input("name", "sun"))
+```
+
+Python
+```python
+%pyspark
+print("Hello "+z.input("name", "sun"))
+```
+
 <img src="../../assets/themes/zeppelin/img/screenshots/form_input_default_prog.png" />
 
 Select form
+
+Scala
+```scala
+%spark
+println("Hello "+z.select("day", Seq(("1","mon"),
+                                    ("2","tue"),
+                                    ("3","wed"),
+                                    ("4","thurs"),
+                                    ("5","fri"),
+                                    ("6","sat"),
+                                    ("7","sun"))))
+```
+
+Python
+```python
+%pyspark
+print("Hello "+z.select("day", [("1","mon"),
+                                ("2","tue"),
+                                ("3","wed"),
+                                ("4","thurs"),
+                                ("5","fri"),
+                                ("6","sat"),
+                                ("7","sun")]))
+```
 
 <img src="../../assets/themes/zeppelin/img/screenshots/form_select_prog.png" />

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -78,6 +78,19 @@ class PyZeppelinContext(dict):
   def get(self, key):
     return self.__getitem__(key)
 
+  def input(self, name, defaultValue = ""):
+    return self.z.input(name, defaultValue)
+
+  def select(self, name, options, defaultValue = ""):
+    optionsTuple = map(lambda items: __tupleToScalaTuple2(items), options)
+
+  def __tupleToScalaTuple2(self, tuple):
+    if (len(tuple) == 2):
+      return gateway.jvm.scala.Tuple2(tuple[0], tuple[1])
+    else:
+      raise IndexError("options must be a list of tuple of 2")
+
+
 class SparkVersion(object):
   SPARK_1_4_0 = 140
   SPARK_1_3_0 = 130

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -82,7 +82,10 @@ class PyZeppelinContext(dict):
     return self.z.input(name, defaultValue)
 
   def select(self, name, options, defaultValue = ""):
-    optionsTuple = map(lambda items: __tupleToScalaTuple2(items), options)
+    # auto_convert to ArrayList doesn't match the method signature on JVM side
+    tuples = map(lambda items: self.__tupleToScalaTuple2(items), options)
+    iterables = gateway.jvm.scala.collection.JavaConversions.collectionAsScalaIterable(tuples)
+    return self.z.select(name, defaultValue, iterables)
 
   def __tupleToScalaTuple2(self, tuple):
     if (len(tuple) == 2):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-428

This is what it looks like:
![image](https://cloud.githubusercontent.com/assets/8969467/11176543/f5a5f8a6-8bf2-11e5-9f26-ba0d7a9148af.png)

![image](https://cloud.githubusercontent.com/assets/8969467/11176547/f8d554a4-8bf2-11e5-8ced-c03eaa84f504.png)
