### PR TITLE
ZEPPELIN-430 - Remove deprecated grunt-autoprefixer for grunt-postcss

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -83,7 +83,7 @@ module.exports = function (grunt) {
           '<%= yeoman.app %>/assets/styles/**/*.css',
           '<%= yeoman.app %>/fonts/**/*.css'
         ],
-        tasks: ['newer:copy:styles', 'autoprefixer']
+        tasks: ['newer:copy:styles', 'postcss']
       },
       gruntfile: {
         files: ['Gruntfile.js']
@@ -186,9 +186,12 @@ module.exports = function (grunt) {
     },
 
     // Add vendor prefixed styles
-    autoprefixer: {
+    postcss: {
       options: {
-        browsers: ['last 1 version']
+        map: true,
+        processors: [
+          require('autoprefixer')({browsers: ['last 2 versions']})
+        ]
       },
       dist: {
         files: [{
@@ -410,7 +413,7 @@ module.exports = function (grunt) {
       'clean:server',
       'wiredep',
       'concurrent:server',
-      'autoprefixer',
+      'postcss',
       'connect:livereload',
       'watch'
     ]);
@@ -425,7 +428,7 @@ module.exports = function (grunt) {
     'clean:server',
     'wiredep',
     'concurrent:test',
-    'autoprefixer',
+    'postcss',
     'connect:test',
     'karma'
   ]);
@@ -436,7 +439,7 @@ module.exports = function (grunt) {
     'wiredep',
     'useminPrepare',
     'concurrent:dist',
-    'autoprefixer',
+    'postcss',
     'concat',
     'ngAnnotate',
     'copy:dist',
@@ -451,7 +454,7 @@ module.exports = function (grunt) {
     'wiredep',
     'useminPrepare',
     'concurrent:dist',
-    'autoprefixer',
+    'postcss',
     'concat',
     'ngAnnotate',
     'copy:dist',

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -6,9 +6,9 @@
     "grunt-dom-munger": "^3.4.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.1.0",
     "bower": "",
     "grunt": "^0.4.1",
-    "grunt-autoprefixer": "^0.7.3",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-concat": "^0.4.0",
@@ -22,6 +22,7 @@
     "grunt-filerev": "^0.2.1",
     "grunt-newer": "^0.7.0",
     "grunt-ng-annotate": "^0.10.0",
+    "grunt-postcss": "^0.7.1",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "~2.0.0",


### PR DESCRIPTION
Making a switch off grunt plugin since grunt-autoprefixer is deprecated, and its version of autoprefixer is old.