### PR TITLE
ZEPPELIN-427: Upgrade to Apache TAJO 0.11.0

### DIFF
--- a/tajo/pom.xml
+++ b/tajo/pom.xml
@@ -33,7 +33,7 @@
   <url>http://www.apache.org</url>
 
   <properties>
-    <tajo.version>0.10.0</tajo.version>
+    <tajo.version>0.11.0</tajo.version>
   </properties>
 
   <dependencies>

--- a/tajo/src/main/java/org/apache/zeppelin/tajo/TajoInterpreter.java
+++ b/tajo/src/main/java/org/apache/zeppelin/tajo/TajoInterpreter.java
@@ -165,18 +165,16 @@ public class TajoInterpreter extends Interpreter {
 
   @Override
   public void cancel(InterpreterContext context) {
-    // Currently, Tajo doesn't provide JDBC cancel method. It will be implemented in
-    // Tajo 0.11.0 version. You can find related issue progress at TAJO-751.
-//    if (statement != null) {
-//      try {
-//        statement.cancel();
-//      }
-//      catch (SQLException ex) {
-//      }
-//      finally {
-//        statement = null;
-//      }
-//    }
+    if (statement != null) {
+      try {
+        statement.cancel();
+      }
+      catch (SQLException ex) {
+      }
+      finally {
+        statement = null;
+      }
+    }
   }
 
   @Override

--- a/tajo/src/test/java/org/apache/zeppelin/tajo/TajoInterpreterTest.java
+++ b/tajo/src/test/java/org/apache/zeppelin/tajo/TajoInterpreterTest.java
@@ -18,16 +18,11 @@
 
 package org.apache.zeppelin.tajo;
 
-import com.google.gson.JsonParseException;
-import org.apache.tajo.catalog.CatalogConstants;
-import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.jdbc.TajoDriver;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.util.Properties;

--- a/tajo/src/test/java/org/apache/zeppelin/tajo/TajoInterpreterTest.java
+++ b/tajo/src/test/java/org/apache/zeppelin/tajo/TajoInterpreterTest.java
@@ -19,6 +19,8 @@
 package org.apache.zeppelin.tajo;
 
 import com.google.gson.JsonParseException;
+import org.apache.tajo.catalog.CatalogConstants;
+import org.apache.tajo.conf.TajoConf;
 import org.apache.tajo.jdbc.TajoDriver;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.junit.After;
@@ -27,10 +29,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * Tajo interpreter unit tests
@@ -45,20 +47,19 @@ public class TajoInterpreterTest {
   }
 
   @Test
-  public void test() {
+  public void testTajoInterpreter() throws Exception {
     TajoInterpreter t = new TesterTajoInterpreter(new Properties());
     t.open();
 
-    Class clazz;
-    try {
-      clazz = Class.forName(t.TAJO_DRIVER_NAME);
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-      throw new JsonParseException(e);
-    }
-
     // check tajo jdbc driver
+    Class clazz = Class.forName(t.TAJO_DRIVER_NAME);
     assertNotNull(clazz);
+
+    Constructor cons = clazz.getConstructor(new Class[]{});
+
+    TajoDriver driver = (TajoDriver) cons.newInstance();
+    assertTrue(driver.acceptsURL("jdbc:tajo:"));
+    assertFalse(driver.acceptsURL("jdbc:taju:"));
 
     // simple select test
     InterpreterResult result = t.interpret("select * from t", null);
@@ -67,6 +68,9 @@ public class TajoInterpreterTest {
     // explain test
     result = t.interpret("explain select * from t", null);
     assertEquals(result.type(), InterpreterResult.Type.TEXT);
+
     t.close();
   }
+
+
 }


### PR DESCRIPTION
I bumped up Tajo to 0.11.0. And I enabled ```cancel()``` because Tajo supports it since 0.11.0 release. For the reference, this patch ran successfully on my Tajo testing cluster.