### PR TITLE
ZEPPELIN-426 - Allowing new paragraph under the last one

### DIFF
--- a/zeppelin-web/.jshintrc
+++ b/zeppelin-web/.jshintrc
@@ -25,6 +25,12 @@
     "angular": false,
     "_": false,
     "jQuery": false,
-    "hljs": false
+    "hljs": false,
+    "confirm": false,
+    "alert": false,
+    "nv": false,
+    "$": false,
+    "ace": false,
+    "d3": false
   }
 }

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -1,4 +1,3 @@
-/* global confirm:false, alert:false, _:false */
 /* jshint loopfunc: true */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,7 +104,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
 
   $scope.newInterpreterGroupChange = function() {
     var el = _.pluck(_.filter($scope.availableInterpreters, { 'group': $scope.newInterpreterSetting.group }), 'properties');
-    
+
     var properties = {};
     for (var i=0; i < el.length; i++) {
       var intpInfo = el[i];
@@ -116,7 +115,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
         };
       }
     }
-    
+
     $scope.newInterpreterSetting.properties = properties;
   };
 
@@ -189,7 +188,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       if (!$scope.newInterpreterSetting.propertyKey || $scope.newInterpreterSetting.propertyKey === '') {
         return;
       }
-      
+
       $scope.newInterpreterSetting.properties[$scope.newInterpreterSetting.propertyKey] = {
         value: $scope.newInterpreterSetting.propertyValue
       };

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1,4 +1,3 @@
-/* global confirm:false, alert:false */
 /* jshint loopfunc: true */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -298,10 +297,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       }
     }
 
-    if (newIndex === $scope.note.paragraphs.length) {
-      alert('Cannot insert after the last paragraph.');
-      return;
-    }
     if (newIndex < 0 || newIndex > $scope.note.paragraphs.length) {
       return;
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1,4 +1,3 @@
-/* global $:false, jQuery:false, ace:false, confirm:false, d3:false, nv:false*/
 /*jshint loopfunc: true, unused:false */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -649,7 +648,7 @@ angular.module('zeppelinWebApp')
     var lineHeight = $scope.editor.renderer.lineHeight;
     var headerHeight = 103; // menubar, notebook titlebar
     var scrollTriggerEdgeMargin = 50;
-    
+
     var documentHeight = angular.element(document).height();
     var windowHeight = angular.element(window).height();  // actual viewport height
 

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -1,4 +1,3 @@
-/* global $:false */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +22,9 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   vm.connected = websocketMsgSrv.isConnected();
   vm.websocketMsgSrv = websocketMsgSrv;
   vm.arrayOrderingSrv = arrayOrderingSrv;
-  
+
   $('#notebook-list').perfectScrollbar({suppressScrollX: true});
-  
+
   $scope.$on('setNoteMenu', function(event, notes) {
     notebookListDataFactory.setNotes(notes);
   });


### PR DESCRIPTION
Adding a paragraph under the last one of the notebook was not allowed.
I tested a lot of different cases:
* While running the full note
* With or Without content in the last paragraph
* with or Without saved content in the last paragraph

And didn't find any issue to allow that feature on that last paragraph