### PR TITLE
ZEPPELIN-293 notebook execution results leaking to dashboard page

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -359,6 +359,7 @@ public class NotebookServer extends WebSocketServlet implements
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
       sendAllAngularObjects(note, conn);
     } else {
+      removeConnectionFromAllNote(conn);
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", null)));
     }
   }


### PR DESCRIPTION
Original PR https://github.com/apache/incubator-zeppelin/pull/293

When we run a paragraph, and without it completing we navigate to dashboard page; upon execution the results are displayed on the dashboard.

![leaking result](https://cloud.githubusercontent.com/assets/674497/9783325/15990682-57c1-11e5-82c4-da020f859e0a.png)
