### PR TITLE
ZEPPELIN-390 Update download page and add release note

### DIFF
--- a/download.md
+++ b/download.md
@@ -21,9 +21,39 @@ limitations under the License.
 
 ### Download Zeppelin
 
-The latest release of Apache Zeppelin (incubating) is *0.5.0-incubating*.
+The latest release of Apache Zeppelin (incubating) is **0.5.5-incubating**.
 
-  - 0.5.0-incubating released on July 23, 2015 ([release notes](./docs/releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
+  - 0.5.5-incubating released on Nov 18, 2015 ([release notes](./releases/zeppelin-release-0.5.5-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.5))
+
+    * Source:
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-src', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz'">zeppelin-0.5.5-incubating.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.sha))
+
+    * Binary package:
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-bin', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz'">zeppelin-0.5.5-incubating-bin-all.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.sha))
+
+
+
+### Verify the integrity of the files
+
+It is essential that you [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files using the PGP or MD5 signatures. This signature should be matched against the [KEYS](https://www.apache.org/dist/incubator/zeppelin/KEYS) file.
+
+
+
+### Build from source
+
+For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [install](./docs/snapshot/install/install.html) section.
+
+
+
+### Old releases
+
+  - 0.5.0-incubating released on July 23, 2015 ([release notes](./releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
 
 
     * Source:
@@ -47,16 +77,6 @@ The latest release of Apache Zeppelin (incubating) is *0.5.0-incubating*.
     
 
 
-
-### Verify the integrity of the files
-
-It is essential that you [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files using the PGP or MD5 signatures. This signature should be matched against the [KEYS](https://www.apache.org/dist/incubator/zeppelin/KEYS) file.
-
-
-
-### Build from source
-
-For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [install](./docs/install/install.html) section.
 
 
 <!-- 

--- a/download.md
+++ b/download.md
@@ -47,7 +47,7 @@ It is essential that you [verify](https://www.apache.org/info/verification.html)
 
 ### Build from source
 
-For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [install](./docs/snapshot/install/install.html) section.
+For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [README](https://github.com/apache/incubator-zeppelin/blob/master/README.md).
 
 
 

--- a/releases/zeppelin-release-0.5.0-incubating.md
+++ b/releases/zeppelin-release-0.5.0-incubating.md
@@ -1,0 +1,77 @@
+---
+layout: page
+title: "Zeppelin Release 0.5.0-incubating"
+description: ""
+group: release
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+### Zeppelin Release 0.5.0-incubating
+
+Zeppelin 0.5.0-incubating is the first release under Apache incubation, with contributions from 42 developers and more than 600 commits.
+
+To download Zeppelin 0.5.0-incubating visit the [download](../../download.html) page.
+
+You can visit [issue tracker](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316221&version=12329850) for full list of issues being resolved.
+
+### Contributors
+
+The following developers contributed to this release:
+
+* Akshat Aranya - New features and Improvements in UI.
+* Alexander Bezzubov -Improvements and Bug fixes in Core, UI, Build system. New feature and Improvements in Spark interpreter. Documentation in roadmap.
+* Anthony Corbacho - Improvements in Website. Bug fixes Build system. Improvements and Bug fixes in UI. Documentation in roadmap.
+* Brennon York - Improvements and Bug fixes in Build system.
+* CORNEAU Damien - New feature, Improvements and Bug fixes in UI and Build system.
+* Corey Huang - Improvements in Build system. New feature in Core.
+* Digeratus - Improvements in Tutorials.
+* Dimitrios Liapis - Improvements in Documentation.
+* DuyHai DOAN - New feature in Build system.
+* Emmanuelle Raffenne - Bug fixes in UI.
+* Eran Medan - Improvements in Documentation.
+* Eugene Morozov - Bug fixes in Core.
+* Felix Cheung - Improvements in Spark interpreter. Improvements in Documentation. New features, Improvements and Bug fixes in UI.
+* Hung Lin - Improvements in Core.
+* Hyungu Roh - Bug fixes in UI.
+* Ilya Ganelin - Improvements in Tutorials.
+* JaeHwa Jung - New features in Tajo interpreter.
+* Jakob Homan - Improvements in Website.
+* James Carman - Improvements in Build system.
+* Jongyoul Lee - Improvements in Core, Build system and Spark interpreter. Bug fixes in Spark Interpreter. New features in Build system and Spark interpreter. Improvements in Documentation.
+* Juarez Bochi - Bug fixes in Build system.
+* Julien Buret - Bug fixes in Spark interpreter.
+* Jérémy Subtil - Bug fixes in Build system.
+* Kevin (SangWoo) Kim - New features in Core, Tutorials. Improvements in Documentation. New features, Improvements and Bug fixes in UI.
+* Kyoung-chan Lee - Improvements in Documentation.
+* Lee moon soo - Improvements in Tutorials. New features, Improvements and Bug fixes in Core, UI, Build system and Spark interpreter. New features in Flink interpreter. Improvments in Documentation.
+* Mina Lee - Improvements and Bug fixes in UI. New features in UI. Improvements in Core, Website.
+* Rajat Gupta - Bug fixes in Spark interpreter.
+* Ram Venkatesh - Improvements in Core, Build system, Spark interpreter and Markdown interpreter. New features and Bug fixes in Hive interpreter.
+* Sebastian YEPES - Improvements in Core.
+* Seckin Savasci - Improvements in Build system.
+* Timothy Shelton - Bug fixes in UI.
+* Vincent Botta - New features in UI.
+* Young boom - Improvements in UI.
+* bobbych - Improvements in Spark interpreter.
+* debugger87 - Bug fixes in Core.
+* dobachi - Improvements in UI.
+* epahomov - Improvements in Core and Spark interpreter.
+* kevindai0126 - Improvements in Core.
+* rahul agarwal - Bug fixes in Core.
+* whisperstream - Improvements in Spark interpreter.
+* yundai - Improvements in Core.
+
+Thanks to everyone who made this release possible!

--- a/releases/zeppelin-release-0.5.5-incubating.md
+++ b/releases/zeppelin-release-0.5.5-incubating.md
@@ -91,19 +91,18 @@ The following developers contributed to this release:
 * DuyHai DOAN - Cassandra interpreter. Improvements in Spark interpreter.
 * Eran Witkon - New features in Core. Bug fixes in UI. Improvements in Core and UI.
 * Eric Charles - Bug fixes in UI.
-* Felix Cheung - New features and Improvements in Spark interpreter, Build system and Documentation. Improvements in UI. Improvements and Bug fixes in UI.
 * Felix Cheung - New feature in Spark interpreter. Improvements and Bug fixes in UI, Documentation and Spark interpreter.
 * Hyung sung Shim - Improvements in Core.
 * Jeff Steinmetz - Improvements in Documentation.
 * Joel Zambrano - New features, Improvements and Bug fixes in Core.
-* Jon Buffington - Improvments in Cassandra interpreter.
+* Jon Buffington - Improvements in Cassandra interpreter.
 * Jongyoul Lee - Improvements in Core, Build system and Spark interpreter.
 * Ivan Vasyliev - New features in Core.
 * Karuppayya - New features in Core and UI.
 * Kevin (SangWoo) Kim - Improvements in UI.
 * Kirill A. Korinsky - New features in UI.
 * Khalid Huseynov - New features in Core.
-* Lee moon soo - New features in Core, UI and Spark interpreter. Improvements and Bug fixes in Core, UI, Build system and Spark interpreter. Improvments in Documentation, Flink interpreter.
+* Lee moon soo - New features in Core, UI and Spark interpreter. Improvements and Bug fixes in Core, UI, Build system and Spark interpreter. Improvements in Documentation, Flink interpreter.
 * Luca Rosellini - Improvements in Spark interpreter.
 * Madhuka Udantha- New features and Bug fixes in UI. Improvements in Build system.
 * Michael Koltsov - Improvements in UI.
@@ -131,8 +130,8 @@ The following developers contributed to this release:
 * Zeng Linxi - Bug fixes in Core.
 * Zhong Jian - Kylin interpreter.
 * caofangkun - New features and Improvements in Build system.
-* fantazic - Improvments in Documentation.
-* george.jw - Improvments in Documentation.
+* fantazic - Improvements in Documentation.
+* george.jw - Improvements in Documentation.
 * opsun - Improvements in UI.
 
 

--- a/releases/zeppelin-release-0.5.5-incubating.md
+++ b/releases/zeppelin-release-0.5.5-incubating.md
@@ -22,8 +22,8 @@ limitations under the License.
 ## Zeppelin Release 0.5.5-incubating
 
 The Apache Zeppelin (incubating) community is pleased to announce the availability of the 0.5.5-incubating release.
-The community put sigificant effort into improving Apache Zeppelin since the last release, focusing on having
-new backend support, improvements on stability and simplifying the configuratin. More than 60 contributors provided new features,
+The community puts significant effort into improving Apache Zeppelin since the last release, focusing on having
+new backend support, improvements on stability and simplifying the configuration. More than 60 contributors provided new features,
 improvements and verifying release. More than 90 issues has been resolved.
 
 We encourage [download](../../download.html) the latest release. Feedback through the [mailing lists](../../community.html) is very welcome.

--- a/releases/zeppelin-release-0.5.5-incubating.md
+++ b/releases/zeppelin-release-0.5.5-incubating.md
@@ -1,0 +1,166 @@
+---
+layout: page
+title: "Zeppelin Release 0.5.5-incubating"
+description: ""
+group: release
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+## Zeppelin Release 0.5.5-incubating
+
+The Apache Zeppelin (incubating) community is pleased to announce the availability of the 0.5.5-incubating release.
+The community put sigificant effort into improving Apache Zeppelin since the last release, focusing on having
+new backend support, improvements on stability and simplifying the configuratin. More than 60 contributors provided new features,
+improvements and verifying release. More than 90 issues has been resolved.
+
+We encourage [download](../../download.html) the latest release. Feedback through the [mailing lists](../../community.html) is very welcome.
+
+<br />
+
+### Backend support
+
+This release includes new backend support for
+
+   * Apache Ignite
+   * Apache Lens
+   * Apache Cassandra
+   * Postgresql
+   * Apache Geode (Not included in binary package)
+
+
+<br />
+### Spark integration
+
+Until last release, Zeppelin need to be built for specific version of Spark (and Hadoop).
+From this release, a single binary package can be used for any Spark (and Hadoop) version without rebuild.
+
+Configuration is simplified to two steps. Regardless of Spark deployment type (Standalone / Yarn / Mesos),
+
+ * `export SPARK_HOME=`  in *conf/zeppelin-env.sh*
+ * set `master` property in GUI (interpreter menu)
+
+
+
+<br />
+### REST Api and Websocket Secutity
+
+Zeppelin REST Api and Websocket server can be secured from Cross Origin Request problem by setting `zeppelin.server.allowed.origins` property in zeppelin-site.xml
+
+
+
+<br />
+### Improvements
+
+Some notable improvements are
+
+ * [[ZEPPELIN-210]](https://issues.apache.org/jira/browse/ZEPPELIN-210) - User specified notebook as a homescreen
+ * [[ZEPPELIN-126]](https://issues.apache.org/jira/browse/ZEPPELIN-126) - create notebook based on existing notebook
+ * [[ZEPPELIN-74]](https://issues.apache.org/jira/browse/ZEPPELIN-74) - Change interpreter selection from %[Name] to %[Group].[Name]
+ * [[ZEPPELIN-133]](https://issues.apache.org/jira/browse/ZEPPELIN-133) - Ability to sync notebooks from local to other storage systems
+ * [[ZEPPELIN-333]](https://issues.apache.org/jira/browse/ZEPPELIN-333) - Add notebook REST API for create, delete and clone operations
+
+
+You can visit [issue tracker](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316221&version=12333531) for full list of issues being resolved.
+
+
+<br />
+### Contributors
+
+The following developers contributed to this release:
+
+* Alexander Bezzubov - Improvements and Bug fixes in Core, Build system. Improvements in Documentation.
+* Andrey Gura - Ignite interpreter. Improvements in Iginite interpreter.
+* Antoine Augusti - Improvements in Documentation.
+* Christian Tzolov - Geode interpreter. Postgresql interpreter. Improvements and Bug fixes in UI. Bug fixes in Postgresql interpreter. Improvements in Postgresql interpreter and Documentation.
+* Corey Huang - Improvements in Core.
+* Damien Corneau - New features in UI. Improvements and Bug fixes in UI and Build system.
+* Darren Ha - New features in UI and Core.
+* DuyHai DOAN - Cassandra interpreter. Improvements in Spark interpreter.
+* Eran Witkon - New features in Core. Bug fixes in UI. Improvements in Core and UI.
+* Eric Charles - Bug fixes in UI.
+* Felix Cheung - New features and Improvements in Spark interpreter, Build system and Documentation. Improvements in UI. Improvements and Bug fixes in UI.
+* Felix Cheung - New feature in Spark interpreter. Improvements and Bug fixes in UI, Documentation and Spark interpreter.
+* Hyung sung Shim - Improvements in Core.
+* Jeff Steinmetz - Improvements in Documentation.
+* Joel Zambrano - New features, Improvements and Bug fixes in Core.
+* Jon Buffington - Improvments in Cassandra interpreter.
+* Jongyoul Lee - Improvements in Core, Build system and Spark interpreter.
+* Ivan Vasyliev - New features in Core.
+* Karuppayya - New features in Core and UI.
+* Kevin (SangWoo) Kim - Improvements in UI.
+* Kirill A. Korinsky - New features in UI.
+* Khalid Huseynov - New features in Core.
+* Lee moon soo - New features in Core, UI and Spark interpreter. Improvements and Bug fixes in Core, UI, Build system and Spark interpreter. Improvments in Documentation, Flink interpreter.
+* Luca Rosellini - Improvements in Spark interpreter.
+* Madhuka Udantha- New features and Bug fixes in UI. Improvements in Build system.
+* Michael Koltsov - Improvements in UI.
+* Mina Lee - New features in Core. Improvements and Bug fixes in UI.
+* Neville Li - Improvements in UI.
+* Peng Cheng - Improvements in UI, Build system and Spark interpreter.
+* Prabhjyot Singh - Improvements and Bug fixes in UI.
+* Pranav Agarwal - Lens interpreter. Improvements in Lens interpreter.
+* Rafal Wojdyla - Improvements in build system.
+* Rajat Gupta - Improvements in UI and Core. Bug fixes in Core.
+* Rajesh Koilpillai - Improvements in Documentation.
+* Randy Gelhausen - Phoenix interpreter. Improvements in UI, Documentation and Build system.
+* Renjith Kamath - New features and Improvements in UI. Improvements in Build system.
+* Rex Xiong - Improvements in UI.
+* Rick Moritz - Improvements in Core.
+* Rohit Agarwal - Improvements and Bug fixes in Core.
+* Romi Kuntsman - Improvements in Documentation.
+* Ryu Ah young - Improvements in UI. Improvements in Documentation.
+* Sibao Hong - Bug fixes in Core.
+* Sjoerd Mulder - Improvements in UI.
+* Till Rohrmann - Improvements in Flink interpreter.
+* Tomas Hudik - Improvements in UI and Documentation.
+* Victor Manuel - New features in Core. Improvements in UI and Documentation.
+* Vinay Shukla - Improvements in Documentation.
+* Zeng Linxi - Bug fixes in Core.
+* Zhong Jian - Kylin interpreter.
+* caofangkun - New features and Improvements in Build system.
+* fantazic - Improvments in Documentation.
+* george.jw - Improvments in Documentation.
+* opsun - Improvements in UI.
+
+
+The following people helped verifying this release:
+
+* Alexander Bezzubov
+* Amos B. Elberg
+* Anthony Corbacho
+* Damien Corneau
+* DuyHai Doan
+* Eran Witkon
+* Felix Cheung
+* Guillaume
+* Henry Saputra
+* Jeff Steinmetz
+* Jonathan Kelly
+* Jongyoul Lee
+* Justin Mclean
+* Khalid Huseynov
+* Lee moon soo
+* Madhuka Udantha
+* Mina Lee
+* Paul Curtis
+* Pranav Agarwal
+* Renjith Kamath
+* Rohit Choudhary
+* Steve Loughra
+* Victor Manuel
+* Vinay Shukla
+* Zhong Jian
+


### PR DESCRIPTION
Vote for 0.5.5-incubating is passed

Dev list vote result : [here](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-dev/201511.mbox/%3CCALf24sZAbn0ZVtT_SSdDSpj7vSrCjpd0izq_g_ex9MJF2VALUw%40mail.gmail.com%3E)
IPMC vote result: [here](http://mail-archives.apache.org/mod_mbox/incubator-general/201511.mbox/%3CCALf24sYUhPBqRFLXasE639O%2BfU7S7aGvR2XSkUNiX1OUyMMRSw%40mail.gmail.com%3E)

This PR Update download page and add a release note for 0.5.5-incubating.
Please review `releases/zeppelin-release-0.5.5-incubating.md` and give me any feedback, addition, correction, etc. Once this PR is merged, 0.5.5-incubating release will announced.

This PR also bringing back release note of previous release, 0.5.0-incubating, removed by mistake https://github.com/apache/incubator-zeppelin/commit/71db6d57e711ba1eeca01422d2c00f240294ba29.
