### PR TITLE
ZEPPELIN-437 Improvement Autoscroll

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -228,11 +228,13 @@ angular.module('zeppelinWebApp')
       if (statusChanged || resultRefreshed) {
         // when last paragraph runs, zeppelin automatically appends new paragraph.
         // this broadcast will focus to the newly inserted paragraph
-
-        // rendering output can took some time. So delay scrolling event firing for sometime.
-        setTimeout(function() {
-          $rootScope.$broadcast('scrollToCursor');
-        }, 500);
+        var paragraphs = $('div[id$="_paragraphColumn_main"');
+        if (paragraphs.length >= 2 && paragraphs[paragraphs.length-2].id.startsWith($scope.paragraph.id)) {
+          // rendering output can took some time. So delay scrolling event firing for sometime.
+          setTimeout(function() {
+            $rootScope.$broadcast('scrollToCursor');
+          }, 500);
+        }
       }
     }
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -228,7 +228,11 @@ angular.module('zeppelinWebApp')
       if (statusChanged || resultRefreshed) {
         // when last paragraph runs, zeppelin automatically appends new paragraph.
         // this broadcast will focus to the newly inserted paragraph
-        $rootScope.$broadcast('scrollToCursor');
+
+        // rendering output can took some time. So delay scrolling event firing for sometime.
+        setTimeout(function() {
+          $rootScope.$broadcast('scrollToCursor');
+        }, 500);
       }
     }
 
@@ -633,7 +637,11 @@ angular.module('zeppelinWebApp')
   };
 
   $rootScope.$on('scrollToCursor', function(event) {
-    $scope.scrollToCursor($scope.paragraph.id, 0);
+    // scroll on 'scrollToCursor' event only when cursor is in the last paragraph
+    var paragraphs = $('div[id$="_paragraphColumn_main"');
+    if (paragraphs[paragraphs.length-1].id.startsWith($scope.paragraph.id)) {
+      $scope.scrollToCursor($scope.paragraph.id, 0);
+    }
   });
 
   /** scrollToCursor if it is necessary

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -228,7 +228,7 @@ angular.module('zeppelinWebApp')
       if (statusChanged || resultRefreshed) {
         // when last paragraph runs, zeppelin automatically appends new paragraph.
         // this broadcast will focus to the newly inserted paragraph
-        var paragraphs = $('div[id$="_paragraphColumn_main"');
+        var paragraphs = angular.element('div[id$="_paragraphColumn_main"');
         if (paragraphs.length >= 2 && paragraphs[paragraphs.length-2].id.startsWith($scope.paragraph.id)) {
           // rendering output can took some time. So delay scrolling event firing for sometime.
           setTimeout(function() {
@@ -603,7 +603,7 @@ angular.module('zeppelinWebApp')
         if ($scope.editor.completer && $scope.editor.completer.activated) { // if autocompleter is active
         } else {
           // fix ace editor focus issue in chrome (textarea element goes to top: -1000px after focused by cursor move)
-          $('#' + $scope.paragraph.id + '_editor > textarea').css("top", 0);
+          angular.element('#' + $scope.paragraph.id + '_editor > textarea').css("top", 0);
 
           var numRows;
           var currentRow;
@@ -643,7 +643,7 @@ angular.module('zeppelinWebApp')
 
   $rootScope.$on('scrollToCursor', function(event) {
     // scroll on 'scrollToCursor' event only when cursor is in the last paragraph
-    var paragraphs = $('div[id$="_paragraphColumn_main"');
+    var paragraphs = angular.element('div[id$="_paragraphColumn_main"');
     if (paragraphs[paragraphs.length-1].id.startsWith($scope.paragraph.id)) {
       $scope.scrollToCursor($scope.paragraph.id, 0);
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -603,7 +603,7 @@ angular.module('zeppelinWebApp')
         if ($scope.editor.completer && $scope.editor.completer.activated) { // if autocompleter is active
         } else {
           // fix ace editor focus issue in chrome (textarea element goes to top: -1000px after focused by cursor move)
-          angular.element('#' + $scope.paragraph.id + '_editor > textarea').css("top", 0);
+          angular.element('#' + $scope.paragraph.id + '_editor > textarea').css('top', 0);
 
           var numRows;
           var currentRow;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -600,6 +600,9 @@ angular.module('zeppelinWebApp')
       $scope.editor.keyBinding.onCommandKey = function(e, hashId, keyCode) {
         if ($scope.editor.completer && $scope.editor.completer.activated) { // if autocompleter is active
         } else {
+          // fix ace editor focus issue in chrome (textarea element goes to top: -1000px after focused by cursor move)
+          $('#' + $scope.paragraph.id + '_editor > textarea').css("top", 0);
+
           var numRows;
           var currentRow;
 
@@ -741,7 +744,6 @@ angular.module('zeppelinWebApp')
         row = $scope.editor.session.getLength() - 1;
         $scope.editor.gotoLine(row + 1, 0);
       }
-
       $scope.scrollToCursor($scope.paragraph.id, 0);
     }
   });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-437

This PR changes

  * Autoscroll to cursor on paragraph status change, only when cursor is on the last paragraph (to tail the notebook)
  * When tail the notebook, waits for sometime to output is rendered and then fire autoscroll event.