### PR TITLE
ZEPPELIN-447: removing of redundant "$" in jshintrc

### DIFF
--- a/zeppelin-web/.jshintrc
+++ b/zeppelin-web/.jshintrc
@@ -29,7 +29,6 @@
     "confirm": false,
     "alert": false,
     "nv": false,
-    "$": false,
     "ace": false,
     "d3": false
   }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -412,7 +412,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     $http.get(baseUrlSrv.getRestApiBase()+ '/notebook/interpreter/bind/' +$scope.note.id).
     success(function(data, status, headers, config) {
       $scope.interpreterBindings = data.body;
-      $scope.interpreterBindingsOrig = jQuery.extend(true, [], $scope.interpreterBindings); // to check dirty
+      $scope.interpreterBindingsOrig = angular.copy($scope.interpreterBindings); // to check dirty
       if (callback) {
         callback();
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -54,11 +54,11 @@ angular.module('zeppelinWebApp')
 
   $scope.renderHtml = function() {
     var retryRenderer = function() {
-      if (jQuery('#p' + $scope.paragraph.id + '_html').length) {
+      if (angular.element('#p' + $scope.paragraph.id + '_html').length) {
         try {
-          jQuery('#p' + $scope.paragraph.id + '_html').html($scope.paragraph.result.msg);
+          angular.element('#p' + $scope.paragraph.id + '_html').html($scope.paragraph.result.msg);
 
-          jQuery('#p' + $scope.paragraph.id + '_html').find('pre code').each(function(i, e) {
+          angular.element('#p' + $scope.paragraph.id + '_html').find('pre code').each(function(i, e) {
             hljs.highlightBlock(e);
           });
         } catch (err) {
@@ -133,7 +133,7 @@ angular.module('zeppelinWebApp')
   $scope.getIframeDimensions = function () {
     if ($scope.asIframe) {
       var paragraphid = '#' + $routeParams.paragraphId + '_container';
-      var height = jQuery(paragraphid).height();
+      var height = angular.element(paragraphid).height();
       return height;
     }
     return 0;
@@ -467,7 +467,7 @@ angular.module('zeppelinWebApp')
       $scope.editor.focus();
 
       autoAdjustEditorHeight(_editor.container.id);
-      jQuery(window).resize(function() {
+      angular.element(window).resize(function() {
         autoAdjustEditorHeight(_editor.container.id);
       });
 
@@ -629,7 +629,7 @@ angular.module('zeppelinWebApp')
     var editor = $scope.editor;
     var height = editor.getSession().getScreenLength() * editor.renderer.lineHeight + editor.renderer.scrollBar.getWidth();
 
-    jQuery('#' + id).height(height.toString() + 'px');
+    angular.element('#' + id).height(height.toString() + 'px');
     editor.resize();
   };
 
@@ -837,7 +837,7 @@ angular.module('zeppelinWebApp')
       clearUnknownColsFromGraphOption();
       // set graph height
       var height = $scope.paragraph.config.graph.height;
-      jQuery('#p' + $scope.paragraph.id + '_graph').height(height);
+      angular.element('#p' + $scope.paragraph.id + '_graph').height(height);
 
       if (!type || type === 'table') {
         setTable($scope.paragraph.result, refresh);
@@ -923,16 +923,16 @@ angular.module('zeppelinWebApp')
 
       html += '</table>';
 
-      jQuery('#p' + $scope.paragraph.id + '_table').html(html);
-      jQuery('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
+      angular.element('#p' + $scope.paragraph.id + '_table').html(html);
+      angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
 
       // set table height
       var height = $scope.paragraph.config.graph.height;
-      jQuery('#p' + $scope.paragraph.id + '_table').height(height);
+      angular.element('#p' + $scope.paragraph.id + '_table').height(height);
     };
 
     var retryRenderer = function() {
-      if (jQuery('#p' + $scope.paragraph.id + '_table').length) {
+      if (angular.element('#p' + $scope.paragraph.id + '_table').length) {
         try {
           renderTable();
         } catch(err) {
@@ -1066,7 +1066,7 @@ angular.module('zeppelinWebApp')
     };
 
     var retryRenderer = function() {
-      if (jQuery('#p' + $scope.paragraph.id + '_' + type + ' svg').length !== 0) {
+      if (angular.element('#p' + $scope.paragraph.id + '_' + type + ' svg').length !== 0) {
         try {
           renderChart();
         } catch(err) {
@@ -1741,7 +1741,7 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.setGraphHeight = function() {
-    var height = jQuery('#p' + $scope.paragraph.id + '_graph').height();
+    var height = angular.element('#p' + $scope.paragraph.id + '_graph').height();
 
     var newParams = angular.copy($scope.paragraph.settings.params);
     var newConfig = angular.copy($scope.paragraph.config);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -54,12 +54,14 @@ angular.module('zeppelinWebApp')
 
   $scope.renderHtml = function() {
     var retryRenderer = function() {
-      if ($('#p'+$scope.paragraph.id+'_html').length) {
+      if (jQuery('#p' + $scope.paragraph.id + '_html').length) {
         try {
-          $('#p'+$scope.paragraph.id+'_html').html($scope.paragraph.result.msg);
+          jQuery('#p' + $scope.paragraph.id + '_html').html($scope.paragraph.result.msg);
 
-          $('#p'+$scope.paragraph.id+'_html').find('pre code').each(function(i, e) { hljs.highlightBlock(e); });
-        } catch(err) {
+          jQuery('#p' + $scope.paragraph.id + '_html').find('pre code').each(function(i, e) {
+            hljs.highlightBlock(e);
+          });
+        } catch (err) {
           console.log('HTML rendering error %o', err);
         }
       } else {
@@ -131,7 +133,7 @@ angular.module('zeppelinWebApp')
   $scope.getIframeDimensions = function () {
     if ($scope.asIframe) {
       var paragraphid = '#' + $routeParams.paragraphId + '_container';
-      var height = $(paragraphid).height();
+      var height = jQuery(paragraphid).height();
       return height;
     }
     return 0;
@@ -465,7 +467,7 @@ angular.module('zeppelinWebApp')
       $scope.editor.focus();
 
       autoAdjustEditorHeight(_editor.container.id);
-      $(window).resize(function(){
+      jQuery(window).resize(function() {
         autoAdjustEditorHeight(_editor.container.id);
       });
 
@@ -627,7 +629,7 @@ angular.module('zeppelinWebApp')
     var editor = $scope.editor;
     var height = editor.getSession().getScreenLength() * editor.renderer.lineHeight + editor.renderer.scrollBar.getWidth();
 
-    $('#' + id).height(height.toString() + 'px');
+    jQuery('#' + id).height(height.toString() + 'px');
     editor.resize();
   };
 
@@ -835,7 +837,7 @@ angular.module('zeppelinWebApp')
       clearUnknownColsFromGraphOption();
       // set graph height
       var height = $scope.paragraph.config.graph.height;
-      $('#p'+$scope.paragraph.id+'_graph').height(height);
+      jQuery('#p' + $scope.paragraph.id + '_graph').height(height);
 
       if (!type || type === 'table') {
         setTable($scope.paragraph.result, refresh);
@@ -921,16 +923,16 @@ angular.module('zeppelinWebApp')
 
       html += '</table>';
 
-      $('#p' + $scope.paragraph.id + '_table').html(html);
-      $('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
+      jQuery('#p' + $scope.paragraph.id + '_table').html(html);
+      jQuery('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
 
       // set table height
       var height = $scope.paragraph.config.graph.height;
-      $('#p'+$scope.paragraph.id+'_table').height(height);
+      jQuery('#p' + $scope.paragraph.id + '_table').height(height);
     };
 
     var retryRenderer = function() {
-      if ($('#p'+$scope.paragraph.id+'_table').length) {
+      if (jQuery('#p' + $scope.paragraph.id + '_table').length) {
         try {
           renderTable();
         } catch(err) {
@@ -1064,7 +1066,7 @@ angular.module('zeppelinWebApp')
     };
 
     var retryRenderer = function() {
-      if ($('#p'+$scope.paragraph.id+'_'+type+' svg').length !== 0) {
+      if (jQuery('#p' + $scope.paragraph.id + '_' + type + ' svg').length !== 0) {
         try {
           renderChart();
         } catch(err) {
@@ -1739,7 +1741,7 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.setGraphHeight = function() {
-    var height = $('#p'+$scope.paragraph.id+'_graph').height();
+    var height = jQuery('#p' + $scope.paragraph.id + '_graph').height();
 
     var newParams = angular.copy($scope.paragraph.settings.params);
     var newConfig = angular.copy($scope.paragraph.config);

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -14,7 +14,9 @@
 
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootScope, $routeParams, notebookListDataFactory, websocketMsgSrv, arrayOrderingSrv) {
+angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootScope, $routeParams,
+                                                                notebookListDataFactory, websocketMsgSrv,
+                                                                arrayOrderingSrv) {
   /** Current list of notes (ids) */
 
   var vm = this;
@@ -23,7 +25,7 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   vm.websocketMsgSrv = websocketMsgSrv;
   vm.arrayOrderingSrv = arrayOrderingSrv;
 
-  $('#notebook-list').perfectScrollbar({suppressScrollX: true});
+  jQuery('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
   $scope.$on('setNoteMenu', function(event, notes) {
     notebookListDataFactory.setNotes(notes);

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -25,7 +25,7 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   vm.websocketMsgSrv = websocketMsgSrv;
   vm.arrayOrderingSrv = arrayOrderingSrv;
 
-  jQuery('#notebook-list').perfectScrollbar({suppressScrollX: true});
+  angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
   $scope.$on('setNoteMenu', function(event, notes) {
     notebookListDataFactory.setNotes(notes);


### PR DESCRIPTION
Allow only jQuery, so that its always more readable.