### PR TITLE
Fix broken link in the front page of the website

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ Currently Zeppelin supports many interpreters such as Scala(with Apache Spark), 
 
 <img class="img-responsive" src="assets/themes/zeppelin/img/screenshots/multiple_language_backend.png" />
 
-Adding new language-backend is really simple. Learn [how to write a zeppelin interpreter](./docs/development/writingzeppelininterpreter.html).
+Adding new language-backend is really simple. Learn [how to write a zeppelin interpreter](./docs/latest/development/writingzeppelininterpreter.html).
 
 
 <br />
@@ -58,7 +58,7 @@ Zeppelin provides built-in Apache Spark integration. You don't need to build a s
 Zeppelin's Spark integration provides
 
 - Automatic SparkContext and SQLContext injection
-- Runtime jar dependency loading from local filesystem or maven repository. Learn more about [dependency loader](./docs/interpreter/spark.html#dependencyloading).
+- Runtime jar dependency loading from local filesystem or maven repository. Learn more about [dependency loader](./docs/latest/interpreter/spark.html#dependencyloading).
 - Canceling job and displaying its progress
 
 <br />
@@ -84,7 +84,7 @@ With simple drag and drop Zeppelin aggeregates the values and display them in pi
     <img class="img-responsive" src="./assets/themes/zeppelin/img/screenshots/pivot.png" />
   </div>
 </div>
-Learn more about Zeppelin's Display system. ( [text](./docs/displaysystem/display.html), [html](./docs/displaysystem/display.html#html), [table](./docs/displaysystem/table.html), [angular](./docs/displaysystem/angular.html) )
+Learn more about Zeppelin's Display system. ( [text](./docs/latest/displaysystem/display.html), [html](./docs/latest/displaysystem/display.html#html), [table](./docs/latest/displaysystem/table.html), [angular](./docs/latest/displaysystem/angular.html) )
 
 
 <br />
@@ -94,7 +94,7 @@ Zeppelin can dynamically create some input forms into your notebook.
 
 <img class="img-responsive" src="./assets/themes/zeppelin/img/screenshots/form_input.png" />
 
-Learn more about [Dynamic Forms](./docs/manual/dynamicform.html).
+Learn more about [Dynamic Forms](./docs/latest/manual/dynamicform.html).
 
 
 <br />
@@ -117,7 +117,7 @@ This way, you can easily embed it as an iframe inside of your website.</p>
 <br />
 ### 100% Opensource
 
-Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](https://github.com/apache/incubator-zeppelin) and [How to contribute](./docs/development/howtocontribute.html)
+Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](https://github.com/apache/incubator-zeppelin) and [How to contribute](./docs/latest/development/howtocontribute.html)
 
 Zeppelin has a very active development community.
 Join the [Mailing list](./community.html) and report issues on our [Issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN).


### PR DESCRIPTION
After deploying https://github.com/apache/incubator-zeppelin/pull/431,
front page of the website has broken link.

This PR updates link to point latest version of documentation.
(This patch is applied to current deployment )