### PR TITLE
Run button do not have rounded border

### DIFF
--- a/zeppelin-web/src/assets/styles/looknfeel/report.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/report.css
@@ -69,3 +69,7 @@ body {
 .lastEmptyParagraph {
   display: none;
 }
+
+.noteAction button.btn {
+  border-radius: 4px !important;
+}


### PR DESCRIPTION
Run button in case of report view have squarish border 

Before:
<img width="1430" alt="Before square edge" src="https://cloud.githubusercontent.com/assets/674497/11298358/62dae7ec-8fa4-11e5-88f4-82fb86f481c3.png">


After:
<img width="1436" alt="after rounded edge" src="https://cloud.githubusercontent.com/assets/674497/11298359/62dbb7b2-8fa4-11e5-94e7-81d55bbd7bda.png">

