### PR TITLE
[ZEPPELIN-37] Upload to sonatype maven repository the spark interpreter module.

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -329,15 +329,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>


### PR DESCRIPTION
Since maven-deploy-plugin is set as skip in the spark pom.xml, it'll be removed.
related issue : https://issues.apache.org/jira/browse/ZEPPELIN-37