### PR TITLE
Improve storing notebook.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -214,11 +214,12 @@ public class VFSNotebookRepo implements NotebookRepo {
       throw new IOException(noteDir.getName().toString() + " is not a directory");
     }
 
-    FileObject noteJson = noteDir.resolveFile("note.json", NameScope.CHILD);
+    FileObject noteJson = noteDir.resolveFile(".note.json", NameScope.CHILD);
     // false means not appending. creates file if not exists
     OutputStream out = noteJson.getContent().getOutputStream(false);
     out.write(json.getBytes(conf.getString(ConfVars.ZEPPELIN_ENCODING)));
     out.close();
+    noteJson.moveTo(noteDir.resolveFile("note.json", NameScope.CHILD));
   }
 
   @Override


### PR DESCRIPTION
This PR relates to: https://issues.apache.org/jira/browse/ZEPPELIN-454
Storing the notebook process changed. (store".note.json" temporary file first and if  it is succeed ".note.json" move to "note.json")
