### PR TITLE
[Minor] Fix travis setting for testing Spark 1.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - mvn package -DskipTests -Phadoop-2.3 -Ppyspark -B
+  - mvn package -DskipTests -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
 
 before_script:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - mvn package -Pbuild-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
   - ./testing/startSparkCluster.sh 1.5.2 2.3
   - echo "export SPARK_HOME=`pwd`/spark-1.5.2-bin-hadoop2.3" > conf/zeppelin-env.sh
-  - mvn verify -Pusing-packaged-distr -Phadoop-2.3 -Ppyspark -B
+  - mvn verify -Pusing-packaged-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
   - ./testing/stopSparkCluster.sh 1.5.2 2.3
  # spark 1.4
   - rm -rf `pwd`/interpreter/spark

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 
 script:
  # spark 1.5
-  - mvn package -Pbuild-distr -Phadoop-2.3 -Ppyspark -B
+  - mvn package -Pbuild-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
   - ./testing/startSparkCluster.sh 1.5.2 2.3
   - echo "export SPARK_HOME=`pwd`/spark-1.5.2-bin-hadoop2.3" > conf/zeppelin-env.sh
   - mvn verify -Pusing-packaged-distr -Phadoop-2.3 -Ppyspark -B


### PR DESCRIPTION
Zeppelin builds Spark 1.4 by default. For testing Spark 1.5.x, we should use `-Pspark-1.5`