### PR TITLE
ZEPPELIN-413: Fix ability to link a single paragraph

### DIFF
--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -18,37 +18,40 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $ro
   var vm = this;
   vm.websocketMsgSrv = websocketMsgSrv;
   $scope.note = {};
-  vm.createNote = function(){
-  	  if(!vm.clone){
-		  vm.websocketMsgSrv.createNotebook($scope.note.notename);
-  	  }else{
-	  	 var noteId = $routeParams.noteId;
-  	  	 vm.websocketMsgSrv.cloneNotebook(noteId, $scope.note.notename);
-  	  }
+
+  vm.createNote = function() {
+      if (!vm.clone) {
+        vm.websocketMsgSrv.createNotebook($scope.note.notename);
+      } else {
+       var noteId = $routeParams.noteId;
+       vm.websocketMsgSrv.cloneNotebook(noteId, $scope.note.notename);
+      }
   };
 
   $scope.$on('setNoteContent', function(event, note) {
-    if(note !== undefined) {
+    if (note !== undefined) {
       window.location = '#/notebook/' + note.id;
       console.log(note);
     }
   });
 
-  vm.preVisible = function(clone){
-		var generatedName = vm.generateName();
-		$scope.note.notename = 'Note ' + generatedName;
-		vm.clone = clone;
-		$scope.$apply();
+  vm.preVisible = function(clone) {
+    var generatedName = vm.generateName();
+    $scope.note.notename = 'Note ' + generatedName;
+    vm.clone = clone;
+    $scope.$apply();
   };
+
   vm.generateName = function () {
-		var DICTIONARY = [ '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
-				'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q', 'R',
-				'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' ];
-		var randIndex, name = '';
-		for (var i = 0; i < 9; i++) {
-			randIndex = Math.floor(Math.random() * 32);
-			name += DICTIONARY[randIndex];
-		}
-		return name;
-	};
+    var DICTIONARY = [ '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+        'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q', 'R',
+        'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' ];
+    var randIndex, name = '';
+    for (var i = 0; i < 9; i++) {
+      randIndex = Math.floor(Math.random() * 32);
+      name += DICTIONARY[randIndex];
+    }
+    return name;
+  };
+
 });

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, websocketMsgSrv) {
+angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, websocketMsgSrv, $location) {
   var vm = this;
   vm.websocketMsgSrv = websocketMsgSrv;
   $scope.note = {};
@@ -29,9 +29,10 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $ro
   };
 
   $scope.$on('setNoteContent', function(event, note) {
-    if (note !== undefined) {
-      window.location = '#/notebook/' + note.id;
-      console.log(note);
+    //a hack, to make it run only after notebook creation
+    //it should not run i.e in case of linking to the paragraph
+    if (note && $location.path().indexOf(note.id) < 0) {
+      $location.path('notebook/' + note.id);
     }
   });
 


### PR DESCRIPTION
Fixes [ZEPPELIN-413](https://issues.apache.org/jira/browse/ZEPPELIN-413)

Relevant changes in `setNoteContent ` handler

Test plan:
 - Link a paragraph from Zeppelin Tutorial i.e [/#/notebook/2A94M5J1Z/paragraph/20150210-015302_1492795503?asIframe](http://localhost:9000/#/notebook/2A94M5J1Z/paragraph/20150210-015302_1492795503?asIframe)

\cc @minahlee @corneadoug for a review 