### PR TITLE
Fix 'create' -> 'cancel' -> 'create' in  interpreters page

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -70,7 +70,7 @@ limitations under the License.
         <span class="btn btn-primary" ng-click="addNewInterpreterSetting()">
           Save
         </span>
-        <span class="btn btn-default" ng-click="showAddNewSetting=false">
+        <span class="btn btn-default" ng-click="cancelInterpreterSetting()">
           Cancel
         </span>
       </div>

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -163,6 +163,10 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
     });
   };
 
+  $scope.cancelInterpreterSetting = function() {
+    $scope.showAddNewSetting = false;
+  };
+
   $scope.resetNewInterpreterSetting = function() {
     $scope.newInterpreterSetting = {
       name : undefined,


### PR DESCRIPTION
Fix for the following scenario
1. click 'create' button in interpreters page. Interpreter creation form shows up
2. click 'cancel' button in interpreters page. Interprete creation form is hidden
2.click 'create' button again. Nothiing happens.