### PR TITLE
Fix paragraph actions dropdown styling for Firefox

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -73,7 +73,7 @@
   border: 3px solid #DDDDDD;
 }
 
-.paragraph .paragraphFooter { 
+.paragraph .paragraphFooter {
   height: 9px;
 }
 
@@ -180,6 +180,14 @@
   font-size: 12px;
   margin-bottom: 4px;
   color: #333333;
+}
+
+/*
+  Paragraph Menu
+*/
+
+.dropdown-menu > li > a {
+  cursor: pointer;
 }
 
 /*

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -425,59 +425,50 @@ limitations under the License.
       </span>
       <ul class="dropdown-menu" role="menu" style="width:200px;">
         <li>
-          <a class="fa fa-arrows-h dropdown"> Width
-          <form style="display:inline; margin-left:5px;">
-            <select ng-model="paragraph.config.colWidth"
-                    class="selectpicker"
-                    ng-change="changeColWidth()"
-                    ng-options="col for col in colWidthOption"></select>
-          </form>
+          <a class="dropdown"><span class="fa fa-arrows-h"></span> Width
+            <form style="display:inline; margin-left:5px;">
+              <select ng-model="paragraph.config.colWidth"
+                      class="selectpicker"
+                      ng-change="changeColWidth()"
+                      ng-options="col for col in colWidthOption"></select>
+            </form>
           </a>
         </li>
         <li>
-          <a class="icon-arrow-up" style="cursor:pointer"
-             ng-click="moveUp()"> Move Up</a>
+          <a ng-click="moveUp()"><span class="icon-arrow-up"></span> Move Up</a>
         </li>
         <li>
-          <a class="icon-arrow-down" style="cursor:pointer"
-             ng-click="moveDown()"> Move Down</a>
+          <a ng-click="moveDown()"><span class="icon-arrow-down"></span> Move Down</a>
         </li>
         <li>
-          <a class="icon-plus" style="cursor:pointer"
-             ng-click="insertNew()"> Insert New</a>
+          <a ng-click="insertNew()"><span class="icon-plus"></span> Insert New</a>
         </li>
         <li>
           <!-- paragraph handler -->
-          <a class="fa fa-font" style="cursor:pointer"
-             ng-click="hideTitle()"
-             ng-show="paragraph.config.title"> Hide title</a>
-          <a class="fa fa-font" style="cursor:pointer"
-             ng-click="showTitle()"
-             ng-show="!paragraph.config.title"> Show title</a>
+          <a ng-click="hideTitle()"
+             ng-show="paragraph.config.title"><span class="fa fa-font"></span> Hide title</a>
+          <a ng-click="showTitle()"
+             ng-show="!paragraph.config.title"><span class="fa fa-font"></span> Show title</a>
         </li>
         <li>
-          <a class="fa fa-list-ol" style="cursor:pointer"
-             ng-click="hideLineNumbers()"
-             ng-show="paragraph.config.lineNumbers"> Hide line numbers</a>
-          <a class="fa fa-list-ol" style="cursor:pointer"
-             ng-click="showLineNumbers()"
-             ng-show="!paragraph.config.lineNumbers"> Show line numbers</a>
+          <a ng-click="hideLineNumbers()"
+             ng-show="paragraph.config.lineNumbers"><span class="fa fa-list-ol"></span> Hide line numbers</a>
+          <a ng-click="showLineNumbers()"
+             ng-show="!paragraph.config.lineNumbers"><span class="fa fa-list-ol"></span> Show line numbers</a>
         </li>
         <li>
-          <a class="icon-control-play" style="cursor:pointer"
-             ng-click="toggleEnableDisable()"> {{paragraph.config.enabled ? "Disable" : "Enable"}}  run</a>
-        </li>
-        <li><a class="icon-share-alt" style="cursor:pointer"
-               ng-click="goToSingleParagraph()"> Link this paragraph</a>
+          <a ng-click="toggleEnableDisable()"><span class="icon-control-play"></span>
+            {{paragraph.config.enabled ? "Disable" : "Enable"}} run</a>
         </li>
         <li>
-          <a class="fa fa-eraser" style="cursor:pointer"
-             ng-click="clearParagraphOutput()"> Clear output</a>
+          <a ng-click="goToSingleParagraph()"><span class="icon-share-alt"></span> Link this paragraph</a>
+        </li>
+        <li>
+          <a ng-click="clearParagraphOutput()"><span class="fa fa-eraser"></span> Clear output</a>
         </li>
         <li>
           <!-- remove paragraph -->
-          <a class="fa fa-times" style="cursor:pointer"
-             ng-click="removeParagraph()"> Remove</a>
+          <a ng-click="removeParagraph()"><span class="fa fa-times"></span> Remove</a>
         </li>
       </ul>
     </span>
@@ -487,5 +478,5 @@ limitations under the License.
     <div ng-show="!paragraph.config.tableHide && !viewOnly" id="{{paragraph.id}}_executionTime" class="executionTime" ng-bind-html="getExecutionTime()">
     </div>
   </div>
-  
+
 </div>


### PR DESCRIPTION
Before on Firefox
<img width="235" alt="screen shot 2015-11-26 at 12 39 21 pm" src="https://cloud.githubusercontent.com/assets/2031306/11418764/ff5f1bc6-9448-11e5-9eb6-cf0f6f79be2e.png">

After on Firefox
<img width="233" alt="screen shot 2015-11-26 at 2 18 43 pm" src="https://cloud.githubusercontent.com/assets/2031306/11418763/ff5e8d28-9448-11e5-89fb-4302101d9eb1.png">