### PR TITLE
progressbar is showing on top of header and other interpreter options

### DIFF
--- a/zeppelin-web/src/assets/styles/looknfeel/default.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/default.css
@@ -20,6 +20,7 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   color: #2c3e50;
   border-bottom: 1px solid #E5E5E5;
+  z-index: 300;
 }
 
 .editor,


### PR DESCRIPTION
<img width="1439" alt="screen shot 2015-11-26 at 3 55 12 pm" src="https://cloud.githubusercontent.com/assets/674497/11421489/4d358936-945b-11e5-8588-a71d6bd2b733.png">
<img width="1439" alt="screen shot 2015-11-26 at 4 10 33 pm" src="https://cloud.githubusercontent.com/assets/674497/11421490/4d467df4-945b-11e5-9115-0458a81d6c9e.png">
