### PR TITLE
ZEPPELIN-469 Interpreter process loads unnecessary classes

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -76,8 +76,6 @@ function addJarInDir(){
   fi
 }
 
-export ZEPPELIN_CLASSPATH
-
 # Text encoding for 
 # read/write job into files,
 # receiving/displaying query/result.


### PR DESCRIPTION
Addresses issue https://issues.apache.org/jira/browse/ZEPPELIN-469

This PR fixes problem by remove `export ZEPPELIN_CLASSPATH`, so classpath from bin/zeppelin-daemon.sh is not propagated bin/interpreter.sh.

It can be verified by printing System classloader inside of notebook, like

```scala
val cl = ClassLoader.getSystemClassLoader()
val ucl = cl.asInstanceOf[java.net.URLClassLoader]
ucl.getURLs.foreach(u=>println(u))
```

Result is

Before

```
cl: ClassLoader = sun.misc.Launcher$AppClassLoader@36c51089
ucl: java.net.URLClassLoader = sun.misc.Launcher$AppClassLoader@36c51089
file:/zeppelin/
file:/zeppelin/
file:/zeppelin/interpreter/spark/dep/datanucleus-api-jdo-3.2.6.jar
file:/zeppelin/interpreter/spark/dep/datanucleus-core-3.2.10.jar
file:/zeppelin/interpreter/spark/dep/datanucleus-rdbms-3.2.9.jar
file:/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/interpreter/spark/zeppelin-spark-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/lib/asm-3.1.jar
file:/zeppelin/lib/aws-java-sdk-core-1.10.1.jar
file:/zeppelin/lib/aws-java-sdk-kms-1.10.1.jar
file:/zeppelin/lib/aws-java-sdk-s3-1.10.1.jar
...
...
...
file:/zeppelin/lib/regexp-1.3.jar
file:/zeppelin/lib/scala-library-2.10.4.jar
file:/zeppelin/lib/slf4j-api-1.7.10.jar
file:/zeppelin/lib/slf4j-log4j12-1.7.10.jar
file:/zeppelin/lib/stax2-api-3.1.1.jar
file:/zeppelin/lib/woodstox-core-asl-4.2.0.jar
file:/zeppelin/lib/wsdl4j-1.6.3.jar
file:/zeppelin/lib/xml-apis-1.4.01.jar
file:/zeppelin/lib/xmlschema-core-2.0.3.jar
file:/zeppelin/lib/zeppelin-interpreter-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/lib/zeppelin-zengine-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/zeppelin-server-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/
file:/zeppelin/conf/
file:/zeppelin/conf/
file:/zeppelin/conf/
```

After

```
cl: ClassLoader = sun.misc.Launcher$AppClassLoader@338bd37a
ucl: java.net.URLClassLoader = sun.misc.Launcher$AppClassLoader@338bd37a
file:/zeppelin/
file:/zeppelin/
file:/zeppelin/interpreter/spark/dep/datanucleus-api-jdo-3.2.6.jar
file:/zeppelin/interpreter/spark/dep/datanucleus-core-3.2.10.jar
file:/zeppelin/interpreter/spark/dep/datanucleus-rdbms-3.2.9.jar
file:/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/interpreter/spark/zeppelin-spark-0.6.0-incubating-SNAPSHOT.jar
file:/zeppelin/
file:/zeppelin/conf/
file:/zeppelin/conf/
```
