### PR TITLE
[ZEPPELIN-400] -Pdeb flag fails to create a deb package

### DIFF
--- a/zeppelin-distribution/src/deb/control/control
+++ b/zeppelin-distribution/src/deb/control/control
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 Package: [[deb.pkg.name]]
 Version: [[version]]-[[buildNumber]]
 Section: misc


### PR DESCRIPTION
An empty line in control file for Debian packages breaks the parser.