### PR TITLE
[ZEPPELIN-474] Provide InterpreterContext as ThreadLocal value

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
@@ -27,6 +27,21 @@ import org.apache.zeppelin.display.GUI;
  * Interpreter context
  */
 public class InterpreterContext {
+  private static final ThreadLocal<InterpreterContext> threadIC =
+      new ThreadLocal<InterpreterContext>();
+
+  public static InterpreterContext get() {
+    return threadIC.get();
+  }
+
+  public static void set(InterpreterContext ic) {
+    threadIC.set(ic);
+  }
+
+  public static void remove() {
+    threadIC.remove();
+  }
+
   private final String noteId;
   private final String paragraphTitle;
   private final String paragraphId;
@@ -55,7 +70,7 @@ public class InterpreterContext {
     this.runners = runners;
   }
 
-  
+
   public String getNoteId() {
     return noteId;
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -294,8 +294,13 @@ public class RemoteInterpreterServer
 
     @Override
     protected Object jobRun() throws Throwable {
-      InterpreterResult result = interpreter.interpret(script, context);
-      return result;
+      try {
+        InterpreterContext.set(context);
+        InterpreterResult result = interpreter.interpret(script, context);
+        return result;
+      } finally {
+        InterpreterContext.remove();
+      }
     }
 
     @Override

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterContextTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterContextTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class InterpreterContextTest {
+
+  @Test
+  public void testThreadLocal() {
+    assertNull(InterpreterContext.get());
+
+    InterpreterContext.set(new InterpreterContext(null, null, null, null, null, null, null, null));
+    assertNotNull(InterpreterContext.get());
+
+    InterpreterContext.remove();
+    assertNull(InterpreterContext.get());
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -206,12 +206,18 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       script = Input.getSimpleQuery(settings.getParams(), scriptBody);
     }
     logger().debug("RUN : " + script);
-    InterpreterResult ret = repl.interpret(script, getInterpreterContext());
+    try {
+      InterpreterContext context = getInterpreterContext();
+      InterpreterContext.set(context);
+      InterpreterResult ret = repl.interpret(script, context);
 
-    if (Code.KEEP_PREVIOUS_RESULT == ret.code()) {
-      return getReturn();
+      if (Code.KEEP_PREVIOUS_RESULT == ret.code()) {
+        return getReturn();
+      }
+      return ret;
+    } finally {
+      InterpreterContext.remove();
     }
-    return ret;
   }
 
   @Override


### PR DESCRIPTION
This PR implements ZEPPELIN-474.

Let 3rd party library access InterpreterContext.