### PR TITLE
[ZEPPELIN-314] pyspark is not responding for Python 3

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -52,9 +52,9 @@ class PyZeppelinContext(dict):
   def show(self, obj):
     from pyspark.sql import DataFrame
     if isinstance(obj, DataFrame):
-      print gateway.jvm.org.apache.zeppelin.spark.ZeppelinContext.showDF(self.z, obj._jdf)
+      print(gateway.jvm.org.apache.zeppelin.spark.ZeppelinContext.showDF(self.z, obj._jdf))
     else:
-      print str(obj)
+      print(str(obj))
 
   # By implementing special methods it makes operating on it more Pythonic
   def __setitem__(self, key, item):


### PR DESCRIPTION
This PR fixes https://issues.apache.org/jira/browse/ZEPPELIN-314, by adding parentheses to call 'print'