### PR TITLE
Zeppelin-472 ] Shortcuts execution bugs.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -587,7 +587,10 @@ angular.module('zeppelinWebApp')
         exec: function(editor) {
           var editorValue = editor.getValue();
           if (editorValue) {
-            $scope.runParagraph(editorValue);
+            if (!($scope.paragraph.status === 'RUNNING' || $scope.paragraph.status === 'PENDING'))
+            {
+              $scope.runParagraph(editorValue);
+            }
           }
         },
         readOnly: false

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -587,8 +587,7 @@ angular.module('zeppelinWebApp')
         exec: function(editor) {
           var editorValue = editor.getValue();
           if (editorValue) {
-            if (!($scope.paragraph.status === 'RUNNING' || $scope.paragraph.status === 'PENDING'))
-            {
+            if (!($scope.paragraph.status === 'RUNNING' || $scope.paragraph.status === 'PENDING')) {
               $scope.runParagraph(editorValue);
             }
           }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-472

If you use the Shift + Enter keys to execute the Paragraph,
If you continue to run while Paragraph enter the Shift + Enter key,
Paragraph enter that this is done constantly being requested RUNNING state.

Case)

Pragraph details

Scala) Thread.sleep (1000);
Key press running SHIFT + Enter * 10