### PR TITLE
Minor improvement in RemoteInterpreter.java

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -333,7 +333,7 @@ public class RemoteInterpreter extends Interpreter {
       return null;
     } else {
       return SchedulerFactory.singleton().createOrGetRemoteScheduler(
-          "remoteinterpreter_" + interpreterProcess.hashCode(), getInterpreterProcess(),
+          "remoteinterpreter_" + interpreterProcess.hashCode(), interpreterProcess,
           maxConcurrency);
     }
   }


### PR DESCRIPTION
No need to call `getInterpreterProcess()` again.