### PR TITLE
Fix navbar-brand image margin

### DIFF
--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -15,6 +15,10 @@ body {
   padding-bottom: 10px;
 }
 
+.navbar-brand img {
+  margin: 0;
+}
+
 .navbar {
   background: #3071a9;
   border-bottom: 0px;
@@ -209,13 +213,8 @@ body {
 
 /* Table for property */
 .table-configuration {
-<<<<<<< HEAD
     width : 100%;
     border : 1px solid gray;
-=======
-  width: 800px;
-  border: 1px solid gray;
->>>>>>> PR_TOOL_MERGE_PR_483
 }
 .table-configuration tr td {
   border: 1px solid gray;
@@ -238,7 +237,6 @@ body {
 }
 
 /* Custom container */
-<<<<<<< HEAD
 /* <a> */
 .container a {
     color: #4183C4; }
@@ -359,8 +357,6 @@ a.anchor {
     margin: 12px 0; 
 }
 
-=======
->>>>>>> PR_TOOL_MERGE_PR_483
 .container-narrow {
   margin: 0 auto;
 }


### PR DESCRIPTION
Currently, because of overlapping #483 #469,
http://zeppelin.incubator.apache.org/docs/0.6.0-incubating-SNAPSHOT/ navbar-brand image location is little bit wired. 
![before](https://github.com/AhyoungRyu/Platform-Documentation/blob/master/compared_img/Before_NavbarImg.png?raw=true)

So I fixed this. Additionally, I deleted some traces generated by last merge.
 