### PR TITLE
Fix for ZEPPELIN-478

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -384,6 +384,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
           $scope.note.paragraphs.splice(index, 0, note.paragraphs[index]);
           break;
         }
+        $scope.$broadcast('updateParagraph', {paragraph: note.paragraphs[index]});
       }
     }
 


### PR DESCRIPTION
Steps to repro the issue
The following is in case of FIFO scheduler
1.Run a  para(say para1-> %sh sleep 100). The status of the para is "RUNNING".
 A new last para(say para2) is created
2.Now run some thing from para2.(eg: %sh ls )(para1 should be "RUNNING")
Expected: The status of para2 should be "PENDING"
Current: The status of para2 is "READY"