### PR TITLE
Fix Yaxis cut Number

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -983,6 +983,31 @@ angular.module('zeppelinWebApp')
 
   };
 
+  var integerFormatter = d3.format(',.1d');
+
+  var customAbbrevFormatter = function(x) {
+    var s = d3.format('.3s')(x);
+    switch (s[s.length - 1]) {
+      case 'G': return s.slice(0, -1) + 'B';
+    }
+    return s;
+  };
+
+  var xAxisTickFormat = function(d, xLabels) {
+    if (xLabels[d] && (isNaN(parseFloat(xLabels[d])) || !isFinite(xLabels[d]))) { // to handle string type xlabel
+      return xLabels[d];
+    } else {
+      return d;
+    }
+  };
+
+  var yAxisTickFormat = function(d) {
+    if(d >= Math.pow(10,6)){
+      return customAbbrevFormatter(d);
+    }
+    return integerFormatter(d);
+  };
+
   var setD3Chart = function(type, data, refresh) {
     if (!$scope.chart[type]) {
       var chart = nv.models[type]();
@@ -1000,21 +1025,8 @@ angular.module('zeppelinWebApp')
       yLabels = scatterData.yLabels;
       d3g = scatterData.d3g;
 
-      $scope.chart[type].xAxis.tickFormat(function(d) {
-        if (xLabels[d] && (isNaN(parseFloat(xLabels[d])) || !isFinite(xLabels[d]))) {
-          return xLabels[d];
-        } else {
-          return d;
-        }
-      });
-
-      $scope.chart[type].yAxis.tickFormat(function(d) {
-        if (yLabels[d] && (isNaN(parseFloat(yLabels[d])) || !isFinite(yLabels[d]))) {
-          return yLabels[d];
-        } else {
-          return d;
-        }
-      });
+      $scope.chart[type].xAxis.tickFormat(function(d) {return xAxisTickFormat(d, xLabels);});
+      $scope.chart[type].yAxis.tickFormat(function(d) {return xAxisTickFormat(d, yLabels);});
 
       // configure how the tooltip looks.
       $scope.chart[type].tooltipContent(function(key, x, y, data) {
@@ -1051,17 +1063,13 @@ angular.module('zeppelinWebApp')
       } else if (type === 'multiBarChart') {
         d3g = pivotDataToD3ChartFormat(p, true, false, type).d3g;
         $scope.chart[type].yAxis.axisLabelDistance(50);
+        $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d);});
       } else if (type === 'lineChart' || type === 'stackedAreaChart' || type === 'lineWithFocusChart') {
         var pivotdata = pivotDataToD3ChartFormat(p, false, true);
         xLabels = pivotdata.xLabels;
         d3g = pivotdata.d3g;
-        $scope.chart[type].xAxis.tickFormat(function(d) {
-          if (xLabels[d] && (isNaN(parseFloat(xLabels[d])) || !isFinite(xLabels[d]))) { // to handle string type xlabel
-            return xLabels[d];
-          } else {
-            return d;
-          }
-        });
+        $scope.chart[type].xAxis.tickFormat(function(d) {return xAxisTickFormat(d, xLabels);});
+        $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d);});
         $scope.chart[type].yAxis.axisLabelDistance(50);
         if ($scope.chart[type].useInteractiveGuideline) { // lineWithFocusChart hasn't got useInteractiveGuideline
           $scope.chart[type].useInteractiveGuideline(true); // for better UX and performance issue. (https://github.com/novus/nvd3/issues/691)


### PR DESCRIPTION
This PR fixes https://issues.apache.org/jira/browse/ZEPPELIN-243
By adding a TickFormat to yAxis.
This is using a slightly custom SI-Format:
* k - kilo, 10³
* M - mega, 10⁶
* B - giga, 10⁹ (instead of G)
* T - tera, 10¹²
* P - peta, 10¹⁵
* E - exa, 10¹⁸
* Z - zetta, 10²¹
* Y - yotta, 10²⁴

![screen shot 2015-12-03 at 3 19 29 pm](https://cloud.githubusercontent.com/assets/710411/11553421/e307928a-99d1-11e5-909b-1245b036fba3.png)
