### PR TITLE
ZEPPELIN-480 Enter/return key on create/clone notebook

### DIFF
--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-  <div id="noteNameModal" class="modal fade" role="dialog" modalvisible previsiblecallback="notenamectrl.preVisible" 
+  <div id="noteNameModal" class="modal fade" role="dialog" modalvisible previsiblecallback="notenamectrl.preVisible"
     targetinput="noteName" tabindex='-1'>
     <div class="modal-dialog">
 
@@ -26,7 +26,7 @@ limitations under the License.
           <div class="form-group">
             <label for="noteName">Note Name</label> <input
               placeholder="Note name" type="text" class="form-control"
-              id="noteName" ng-model="note.notename">
+              id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()">
           </div>
         </div>
         <div class="modal-footer">

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -14,7 +14,8 @@
 
 'use strict';
 
-angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, websocketMsgSrv, $location) {
+angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $rootScope, $routeParams, websocketMsgSrv,
+                                                                     $location) {
   var vm = this;
   vm.websocketMsgSrv = websocketMsgSrv;
   $scope.note = {};
@@ -26,6 +27,11 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $ro
        var noteId = $routeParams.noteId;
        vm.websocketMsgSrv.cloneNotebook(noteId, $scope.note.notename);
       }
+  };
+
+  vm.handleNameEnter = function(){
+    angular.element('#noteNameModal').modal('toggle');
+    vm.createNote();
   };
 
   $scope.$on('setNoteContent', function(event, note) {


### PR DESCRIPTION
In current behaviour on pressing enter/return key on create/clone notebook doesn't do anything.

Expected behaviour is it should be equivalent of create/cone.