### PR TITLE
ZEPPELIN-491: Giving fixed height to container when result type is text

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -27,14 +27,15 @@ limitations under the License.
        ng-if="getResultType() == 'TEXT'">
     <div class="fa fa-level-down scroll-paragraph-down"
          ng-show="showScrollDownIcon()"
-         ng-click="scrollParagraphDown()" ></div>
+         ng-click="scrollParagraphDown()"
+         tooltip="Follow Output"></div>
     <div id="p{{paragraph.id}}_text"
          style="max-height: {{paragraph.config.graph.height}}px; overflow: auto"
-         ng-scroll="someFunction()"
          class="text"></div>
     <div class="fa fa-chevron-up scroll-paragraph-up"
          ng-show="showScrollUpIcon()"
-         ng-click="scrollParagraphUp()"></div>
+         ng-click="scrollParagraphUp()"
+         tooltip="Scroll Top"></div>
   </div>
 
   <div id="p{{paragraph.id}}_html"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -25,10 +25,16 @@ limitations under the License.
 
   <div id="{{paragraph.id}}_text"
        ng-if="getResultType() == 'TEXT'">
-    <div class="fa fa-level-down scroll-paragraph-down" ng-show="showScrollDownIcon()" ng-click="scrollParagraphDown()" ></div>
+    <div class="fa fa-level-down scroll-paragraph-down"
+         ng-show="showScrollDownIcon()"
+         ng-click="scrollParagraphDown()" ></div>
     <div id="p{{paragraph.id}}_text"
          style="max-height: {{paragraph.config.graph.height}}px; overflow: auto"
+         ng-scroll="someFunction()"
          class="text"></div>
+    <div class="fa fa-chevron-up scroll-paragraph-up"
+         ng-show="showScrollUpIcon()"
+         ng-click="scrollParagraphUp()"></div>
   </div>
 
   <div id="p{{paragraph.id}}_html"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -25,9 +25,9 @@ limitations under the License.
 
   <div id="{{paragraph.id}}_text"
        ng-if="getResultType() == 'TEXT'">
-    <div class="fa fa-hand-o-down"></div>
+    <div class="fa fa-level-down scroll-paragraph-down" ng-show="showScrollDownIcon()" ng-click="scrollParagraphDown()" ></div>
     <div id="p{{paragraph.id}}_text"
-         ng-style="{'max-height': '{{paragraph.config.graph.height}}px', 'overflow': 'auto'}"
+         style="max-height: {{paragraph.config.graph.height}}px; overflow: auto"
          class="text"></div>
   </div>
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -23,9 +23,13 @@ limitations under the License.
        ng-bind-html="paragraph.result.comment">
   </div>
 
-  <div id="p{{paragraph.id}}_text"
-       class="text"
-       ng-if="getResultType() == 'TEXT'"></div>
+  <div id="{{paragraph.id}}_text"
+       ng-if="getResultType() == 'TEXT'">
+    <div class="fa fa-hand-o-down"></div>
+    <div id="p{{paragraph.id}}_text"
+         ng-style="{'max-height': '{{paragraph.config.graph.height}}px', 'overflow': 'auto'}"
+         class="text"></div>
+  </div>
 
   <div id="p{{paragraph.id}}_html"
        class="resultContained"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2075,4 +2075,15 @@ angular.module('zeppelinWebApp')
     var redirectToUrl = location.protocol + '//' + location.host + location.pathname + '#/notebook/' + noteId + '/paragraph/' + $scope.paragraph.id+'?asIframe';
     $window.open(redirectToUrl);
   };
+
+  $scope.showScrollDownIcon = function(){
+    var doc = angular.element('#p' + $scope.paragraph.id + '_text');
+    return doc[0].scrollHeight > doc.innerHeight();
+  };
+
+  $scope.scrollParagraphDown = function() {
+    var doc = angular.element('#p' + $scope.paragraph.id + '_text');
+    doc.animate({scrollTop: doc[0].scrollHeight}, 500);
+  };
+
 });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -108,6 +108,11 @@ angular.module('zeppelinWebApp')
         if ($scope.paragraph.result && $scope.paragraph.result.msg) {
           $scope.appendTextOutput($scope.paragraph.result.msg);
         }
+
+        angular.element('#p' + $scope.paragraph.id + '_text').bind("mousewheel", function(e) {
+          $scope.keepScrollDown = false;
+        });
+
       } else {
         $timeout(retryRenderer, 10);
       }
@@ -129,6 +134,10 @@ angular.module('zeppelinWebApp')
       for (var i=0; i < lines.length; i++) {
         textEl.append(angular.element('<div></div>').text(lines[i]));
       }
+    }
+    if ($scope.keepScrollDown) {
+      var doc = angular.element('#p' + $scope.paragraph.id + '_text');
+      doc[0].scrollTop = doc[0].scrollHeight;
     }
   };
 
@@ -2080,12 +2089,30 @@ angular.module('zeppelinWebApp')
 
   $scope.showScrollDownIcon = function(){
     var doc = angular.element('#p' + $scope.paragraph.id + '_text');
-    return doc[0].scrollHeight > doc.innerHeight();
+    if(doc[0]){
+      return doc[0].scrollHeight > doc.innerHeight();
+    }
+    return false;
   };
 
   $scope.scrollParagraphDown = function() {
     var doc = angular.element('#p' + $scope.paragraph.id + '_text');
     doc.animate({scrollTop: doc[0].scrollHeight}, 500);
+    $scope.keepScrollDown = true;
+  };
+
+  $scope.showScrollUpIcon = function(){
+    if(angular.element('#p' + $scope.paragraph.id + '_text')[0]){
+      return angular.element('#p' + $scope.paragraph.id + '_text')[0].scrollTop != 0;
+    }
+    return false;
+
+  };
+
+  $scope.scrollParagraphUp = function() {
+    var doc = angular.element('#p' + $scope.paragraph.id + '_text');
+    doc.animate({scrollTop: 0}, 500);
+    $scope.keepScrollDown = false;
   };
 
 });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -420,10 +420,25 @@ table.table-striped {
 
 
 .scroll-paragraph-down:hover:before {
-  content: "Scroll to End of Output";
+  content: "Follow Output";
   padding: .3em;
   cursor: pointer;
   background-color: #777;
   border-radius: 2px;
   color: #f1f1f1;
+}
+
+.scroll-paragraph-up {
+  bottom: 5px;
+  cursor: pointer;
+  position: absolute;
+  right: 15px;
+}
+
+.scroll-paragraph-up:hover:before {
+  background-color: #777;
+  border-radius: 2px;
+  content: "Scroll Top";
+  color: #f1f1f1;
+  padding: 0.3em;
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -411,3 +411,19 @@ table.table-striped {
   border-top: 1px solid #ddd;
   margin-top: 20px;
 }
+
+.scroll-paragraph-down {
+  position: absolute;
+  right: 10px;
+  cursor: pointer;
+}
+
+
+.scroll-paragraph-down:hover:before {
+  content: "Scroll to End of Log";
+  padding: .3em;
+  cursor: pointer;
+  background-color: #777;
+  border-radius: 2px;
+  color: #f1f1f1;
+}

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -419,26 +419,9 @@ table.table-striped {
 }
 
 
-.scroll-paragraph-down:hover:before {
-  content: "Follow Output";
-  padding: .3em;
-  cursor: pointer;
-  background-color: #777;
-  border-radius: 2px;
-  color: #f1f1f1;
-}
-
 .scroll-paragraph-up {
   bottom: 5px;
   cursor: pointer;
   position: absolute;
   right: 15px;
-}
-
-.scroll-paragraph-up:hover:before {
-  background-color: #777;
-  border-radius: 2px;
-  content: "Scroll Top";
-  color: #f1f1f1;
-  padding: 0.3em;
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -420,7 +420,7 @@ table.table-striped {
 
 
 .scroll-paragraph-down:hover:before {
-  content: "Scroll to End of Log";
+  content: "Scroll to End of Output";
   padding: .3em;
   cursor: pointer;
   background-color: #777;

--- a/zeppelin-web/src/components/resizable/resizable.directive.js
+++ b/zeppelin-web/src/components/resizable/resizable.directive.js
@@ -35,7 +35,7 @@ angular.module('zeppelinWebApp').directive('resizable', function() {
           var colStep = window.innerWidth / 12;
           elem.off('resizestop');
           var conf = angular.copy(resizableConfig);
-          if (resize.graphType === 'TABLE') {
+          if (resize.graphType === 'TABLE' || resize.graphType === 'TEXT') {
             conf.grid = [colStep, 10];
             conf.minHeight = 100;
           } else {


### PR DESCRIPTION
In current behaviour we have a fixed height for result container that contains either graph or table, but if type is text then the container expands to infinitely.

When type is text; then this is mostly logs, so we can have scroll around it and have fixed height for this container.

Before
<img width="1440" alt="screen shot 2015-12-07 at 4 11 49 pm" src="https://cloud.githubusercontent.com/assets/674497/11625014/bf2044dc-9cfd-11e5-8b9b-0ac8256671cf.png">

After
<img width="1440" alt="screen shot 2015-12-07 at 4 16 46 pm" src="https://cloud.githubusercontent.com/assets/674497/11625051/f8b1abbe-9cfd-11e5-9001-4794ba10dbf3.png">

