### PR TITLE
[ZEPPELIN-493] Test fails VFSNotebookRepoTest.setUp:58 » IO No such file or directory

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -23,10 +23,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.notebook.JobListenerFactory;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
@@ -50,9 +52,29 @@ public class VFSNotebookRepoTest implements JobListenerFactory{
   private NotebookRepo notebookRepo;
   private InterpreterFactory factory;
 
+  private File mainZepDir;
+
+  private File mainNotebookDir;
+
   @Before
-  public void setUp() throws Exception {    
+  public void setUp() throws Exception {
+    String zpath = System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis();
+    mainZepDir = new File(zpath);
+    mainZepDir.mkdirs();
+    new File(mainZepDir, "conf").mkdirs();
+    String mainNotePath = zpath+"/notebook";
+    mainNotebookDir = new File(mainNotePath);
+    mainNotebookDir.mkdirs();
+
+    System.setProperty(ConfVars.ZEPPELIN_HOME.getVarName(), mainZepDir.getAbsolutePath());
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), mainNotebookDir.getAbsolutePath());
+    System.setProperty(ConfVars.ZEPPELIN_INTERPRETERS.getVarName(), "org.apache.zeppelin.interpreter.mock.MockInterpreter1");
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), "org.apache.zeppelin.notebook.repo.VFSNotebookRepo");
     conf = ZeppelinConfiguration.create();
+
+    this.schedulerFactory = new SchedulerFactory();
+
+    MockInterpreter1.register("mock1", "org.apache.zeppelin.interpreter.mock.MockInterpreter1");
 
     this.schedulerFactory = new SchedulerFactory();
     factory = new InterpreterFactory(conf, new InterpreterOption(false), null);
@@ -63,8 +85,9 @@ public class VFSNotebookRepoTest implements JobListenerFactory{
 
   @After
   public void tearDown() throws Exception {
+    FileUtils.deleteDirectory(mainZepDir);
   }
-  
+
   @Test
   public void testSaveNotebook() throws IOException, InterruptedException {
     Note note = notebook.createNote();
@@ -74,8 +97,8 @@ public class VFSNotebookRepoTest implements JobListenerFactory{
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
-    p1.setText("%md hello world");
-    
+    p1.setText("%mock1 hello world");
+
     note.run(p1.getId());
     int timeout = 1;
     while (!p1.isTerminated()) {
@@ -87,23 +110,23 @@ public class VFSNotebookRepoTest implements JobListenerFactory{
     int i = 0;
     int TEST_COUNT = 10;
     while (i++ < TEST_COUNT) {
-      p1.setText("%md hello zeppelin");
+      p1.setText("%mock1 hello zeppelin");
       new Thread(new NotebookWriter(note)).start();
-      p1.setText("%md hello world");
+      p1.setText("%mock1 hello world");
       new Thread(new NotebookWriter(note)).start();
     }
-  
+
     note.setName("SaveTest");
     notebookRepo.save(note);
     assertEquals(note.getName(), "SaveTest");
   }
-  
+
   class NotebookWriter implements Runnable {
     Note note;
     public NotebookWriter(Note note) {
       this.note = note;
     }
-    
+
     @Override
     public void run() {
       try {


### PR DESCRIPTION
This PR fixes https://issues.apache.org/jira/browse/ZEPPELIN-493.
`VFSNotebookRepoTest` passes on CI without problem, however, it does fail when i run the test on my pc.