### PR TITLE
ZEPPELIN-496 ] Bug fixed Spark scala completion, support other interpreter issue

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -577,8 +577,7 @@ public class SparkInterpreter extends Interpreter {
     }
     return paths;
   }
-
-
+  
   @Override
   public List<String> completion(String buf, int cursor) {
     if (buf.length() < cursor) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -578,11 +578,61 @@ public class SparkInterpreter extends Interpreter {
     return paths;
   }
 
+
   @Override
   public List<String> completion(String buf, int cursor) {
+    if (buf.length() < cursor) {
+      cursor = buf.length();
+    }
+    String completionText = getCompletionTargetString(buf, cursor);
+    if (completionText == null) {
+      return new LinkedList<String>();
+    }
+    cursor = completionText.length() - 1;
     ScalaCompleter c = completor.completer();
-    Candidates ret = c.complete(buf, cursor);
+    Candidates ret = c.complete(completionText, cursor);
     return scala.collection.JavaConversions.asJavaList(ret.candidates());
+  }
+
+  private String getCompletionTargetString(String text, int cursor) {
+    String[] completionSeqCharaters = {" ", "\n", "\t"};
+    int completionEndPosition = cursor;
+    int completionStartPosition = cursor;
+    int indexOfReverseSeqPostion = cursor;
+
+    String resultCompletionText = "";
+    String completionScriptText = "";
+    try {
+      completionScriptText = text.substring(0, cursor);
+    }
+    catch (Exception e) {
+      logger.error(e.toString());
+      return null;
+    }
+    completionEndPosition = completionScriptText.length();
+
+    String tempReverseCompletionText = new StringBuilder(completionScriptText).reverse().toString();
+
+    for (String seqCharacter : completionSeqCharaters) {
+      indexOfReverseSeqPostion = tempReverseCompletionText.indexOf(seqCharacter);
+
+      if (indexOfReverseSeqPostion < completionStartPosition && indexOfReverseSeqPostion > 0) {
+        completionStartPosition = indexOfReverseSeqPostion;
+      }
+
+    }
+
+    if (completionStartPosition == completionEndPosition) {
+      completionStartPosition = 0;
+    }
+    else
+    {
+      completionStartPosition = completionEndPosition - completionStartPosition;
+    }
+    resultCompletionText = completionScriptText.substring(
+            completionStartPosition , completionEndPosition);
+
+    return resultCompletionText;
   }
 
   public Object getValue(String name) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -577,7 +577,7 @@ public class SparkInterpreter extends Interpreter {
     }
     return paths;
   }
-  
+
   @Override
   public List<String> completion(String buf, int cursor) {
     if (buf.length() < cursor) {
@@ -585,9 +585,9 @@ public class SparkInterpreter extends Interpreter {
     }
     String completionText = getCompletionTargetString(buf, cursor);
     if (completionText == null) {
-      return new LinkedList<String>();
+      completionText = "";
+      cursor = completionText.length();
     }
-    cursor = completionText.length() - 1;
     ScalaCompleter c = completor.completer();
     Candidates ret = c.complete(completionText, cursor);
     return scala.collection.JavaConversions.asJavaList(ret.candidates());

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -540,35 +540,8 @@ angular.module('zeppelinWebApp')
 
           pos = session.getTextRange(new Range(0, 0, pos.row, pos.column)).length;
           var buf = session.getValue();
-          var completionString = buf;
 
-          if (pos > 0) {
-            var completionStartPosition = pos;
-            var completionSeqCharaters = [' ', '\n'];
-
-            // replace \r\n or \n\r other to \n
-            var reverseCompletionString = buf.replace(/\r?\n|\r/g, '\n').substr(0, pos).split('').reverse();
-            for (var seqCharacterIndex in completionSeqCharaters) {
-              var indexOfReverseSeqPostion = reverseCompletionString.indexOf(completionSeqCharaters[seqCharacterIndex]);
-
-              if (indexOfReverseSeqPostion < completionStartPosition && indexOfReverseSeqPostion > 0) {
-                completionStartPosition = indexOfReverseSeqPostion;
-              }
-            }
-
-            if (completionStartPosition === pos) {
-              completionStartPosition = 0;
-            }
-            else
-            {
-              completionStartPosition = pos - completionStartPosition;
-            }
-
-            completionString = buf.substr( completionStartPosition , pos);
-            pos = completionString.length -1;
-          }
-
-          websocketMsgSrv.completion($scope.paragraph.id, completionString, pos);
+          websocketMsgSrv.completion($scope.paragraph.id, buf, pos);
 
           $scope.$on('completionList', function(event, data) {
             if (data.completions) {


### PR DESCRIPTION
#514

RE-Fixed ZEPPELIN-485 ] Bug Fixed Paragraph Spark Completion

bug fixed, support other interpreter.
Fixed an issue that only works only on a spark..
Modify has changed in the spark-completion backend part.

For example, when you create a '% pyspark', it has been unconditionally modify the code auto-completion of the '% spark' to act according to its interpreter.

jira-issue : https://issues.apache.org/jira/browse/ZEPPELIN-496