### PR TITLE
ZEPPELIN-500 - Fix leak of output in Firefox

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -32,7 +32,6 @@
 */
 
 .paragraph .text {
-  white-space: pre;
   display: block;
   unicode-bidi: embed;
   display: block !important;


### PR DESCRIPTION
### What is this PR for?
It has been reported in #436 that the output was breaking in the case of ``_text`` container. (long line outside of container instead of multiple lines)
We then realized that it was happening only on Firefox

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix line break on Firefox
* [x] - Test on: Chrome, Firefox, Safari, Opera, IE10

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-500

### How should this be tested?
You can run ``println(1 to 1000)`` and check the result on every web browsers

### Screenshots (if appropriate)

Before:
![cf086616-a245-11e5-9d22-1a46b6d6b8d9](https://cloud.githubusercontent.com/assets/710411/11774306/0d11bcc4-a277-11e5-8163-9f66493b187e.png)

After:
<img width="1353" alt="ce1bcd5e-a256-11e5-9744-a65c02c647c9" src="https://cloud.githubusercontent.com/assets/710411/11774310/13f75422-a277-11e5-9989-9e6bed184ef9.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No