### PR TITLE
Remove unnecessary spaces from docs/manual/dynamicform.md

### DIFF
--- a/docs/manual/dynamicform.md
+++ b/docs/manual/dynamicform.md
@@ -1,4 +1,4 @@
-    ---
+---
 layout: page
 title: "Dynamic Form"
 description: ""


### PR DESCRIPTION
### What is this PR for?
#518 introduces some unnecessary spaces in docs/manual/dynamicform.md which results dynamicform.md is not compiled to dynamicform.html under _site directory after `bundle exec jekyll build --safe` command

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-490

### How should this be tested?
run `bundle exec jekyll build --safe` under /docs and see if /docs/_site/manual/dynamicform.html is generated.




