### PR TITLE
fixing z-index for all modals, backdrop and popups

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -318,6 +318,14 @@ This part should be removed when new version of bootstrap handles this issue.
   float: left;
 }
 
+.modal-backdrop {
+  z-index: 10002 !important;
+}
+
+.modal-dialog, .modal {
+  z-index: 10003 !important;
+}
+
 #noteImportModal .modal-body {
   min-height: 420px;
   overflow: hidden;


### PR DESCRIPTION
### What is this PR for?
This fixes z-index for all modals, backdrop.

### What type of PR is it?
Bug Fix

### Screenshots

Before:

<img width="1440" alt="screen shot 2015-12-15 at 4 46 55 pm" src="https://cloud.githubusercontent.com/assets/674497/11809252/90555846-a34b-11e5-9bcd-76e684379359.png">

<img width="1440" alt="screen shot 2015-12-15 at 4 47 30 pm" src="https://cloud.githubusercontent.com/assets/674497/11809253/90598678-a34b-11e5-9bc8-2da6d175134b.png">


After:

<img width="1440" alt="screen shot 2015-12-15 at 4 47 05 pm" src="https://cloud.githubusercontent.com/assets/674497/11809254/90599230-a34b-11e5-83f6-810f2e246f69.png">

<img width="1440" alt="screen shot 2015-12-15 at 4 47 17 pm" src="https://cloud.githubusercontent.com/assets/674497/11809255/905bc28a-a34b-11e5-9d5f-138efe3be08f.png">
