### PR TITLE
ZEPPELIN-506 Expand "create notebook" of REST API to have initial paragraphs

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -92,7 +92,11 @@ limitations under the License.
       <td> 500 </td>
     </tr>
     <tr>
-      <td> sample JSON input </td>
+      <td> sample JSON input (without paragraphs) </td>
+      <td><pre>{ "name": "name of new notebook" }</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON input (with initial paragraphs) </td>
       <td><pre>
 {
   "name": "name of new notebook", 

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -93,7 +93,21 @@ limitations under the License.
     </tr>
     <tr>
       <td> sample JSON input </td>
-      <td><pre>{"name": "name of new notebook"}</pre></td>
+      <td><pre>
+{
+  "name": "name of new notebook", 
+  "paragraphs": [
+    {
+      "title": "paragraph title1",
+      "text": "paragraph text1"
+    },
+    {
+      "title": "paragraph title2",
+      "text": "paragraph text2"
+    }
+  ]
+}
+      </pre></td>
     </tr>
     <tr>
       <td> sample JSON response </td>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -30,10 +30,7 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
-import org.apache.zeppelin.rest.message.CronRequest;
-import org.apache.zeppelin.rest.message.InterpreterSettingListForNoteBind;
-import org.apache.zeppelin.rest.message.NewInterpreterSettingRequest;
-import org.apache.zeppelin.rest.message.NewNotebookRequest;
+import org.apache.zeppelin.rest.message.*;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.socket.NotebookServer;
@@ -138,7 +135,15 @@ public class NotebookRestApi {
     NewNotebookRequest request = gson.fromJson(message,
         NewNotebookRequest.class);
     Note note = notebook.createNote();
-    note.addParagraph(); // it's an empty note. so add one paragraph
+    List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
+    if (initialParagraphs != null) {
+      for (NewParagraphRequest paragraphRequest : initialParagraphs) {
+        Paragraph p = note.addParagraph();
+        p.setTitle(paragraphRequest.getTitle());
+        p.setText(paragraphRequest.getText());
+      }
+    }
+    note.addParagraph(); // add one paragraph to the last
     String noteName = request.getName();
     if (noteName.isEmpty()) {
       noteName = "Note " + note.getId();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
@@ -17,28 +17,25 @@
 
 package org.apache.zeppelin.rest.message;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.zeppelin.interpreter.InterpreterOption;
-
 /**
- *  NewNotebookRequest rest api request message
+ * NewParagraphRequest rest api request message
+ *
+ * It is used for NewNotebookRequest with initial paragraphs
  *
  */
-public class NewNotebookRequest {
-  String name;
-  List<NewParagraphRequest> paragraphs;
+public class NewParagraphRequest {
+  String title;
+  String text;
 
-  public NewNotebookRequest (){
+  public NewParagraphRequest() {
 
   }
 
-  public String getName() {
-    return name;
+  public String getTitle() {
+    return title;
   }
 
-  public List<NewParagraphRequest> getParagraphs() {
-    return paragraphs;
+  public String getText() {
+    return text;
   }
 }


### PR DESCRIPTION
### What is this PR for?

To provide initial paragraphs when creating new notebook via REST API

### What type of PR is it?

Improvement

### Todos
* [ ] - 

### Is there a relevant Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-506

### How should this be tested?

1. Request ```http://<zeppelin host>:<zeppelin port>/api/notebook``` with POST method including JSON payload, 

```
{
    "name": "Test for initial paragraphs2",
    "paragraphs": [
        {
            "text": "%spark\nvar hello: Int=1"
        },
        {
            "text": "%spark\nhello = hello + 1"
        },
        {
            "text": "%spark\nimport java.util.Date\n\nprintln(hello + \", current time is <\" + new Date + \">\")"
        }
    ]
}
```

2. Check notebook is made with initial paragraphs via UI or REST API or Web socket.

### Screenshots (if appropriate)

### Questions:

* Does the licenses files need update? (No)
* Is there breaking changes for older versions? (No, added parameter is optional.)
* Does this needs documentation? (Yes, I've updated related doc.)