### PR TITLE
Fix when result of paragraph contains carriage return

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -32,17 +32,16 @@
 */
 
 .paragraph .text {
-  display: block;
-  unicode-bidi: embed;
   display: block !important;
-  margin: 0 0 0 !important;
+  font-family: "Monaco","Menlo","Ubuntu Mono","Consolas","source-code-pro",monospace;
+  font-size: 12px !important;
   line-height: 1.42857143 !important;
+  margin: 0 0 5px !important;
+  padding-top: 2px;
+  unicode-bidi: embed;
+  white-space: pre-wrap;
   word-break: break-all !important;
   word-wrap: break-word !important;
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
-  font-size: 12px !important;
-  margin-bottom: 5px !important;
-  padding-top: 2px;
 }
 
 .paragraph table {


### PR DESCRIPTION
### What is this PR for?
When the result in paragraph contains "carriage return" or "line feed", they are getting displayed in single line. The output should be in multiline.

### What type of PR is it?
Bug Fix


### Screenshots 
Before 
<img width="1439" alt="screen shot 2015-12-16 at 11 26 08 am" src="https://cloud.githubusercontent.com/assets/674497/11833440/a48f1980-a3e8-11e5-908b-8d45f2e2290e.png">

After 
<img width="1440" alt="screen shot 2015-12-16 at 11 27 22 am" src="https://cloud.githubusercontent.com/assets/674497/11833441/a4929074-a3e8-11e5-974b-45405cb619be.png">

