### PR TITLE
ZEPPELIN-507 Expand "run paragraph" of REST API to update dynamic form's value

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -291,6 +291,18 @@ limitations under the License.
       <td> 500 </td>
     </tr>
     <tr>
+      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
+      <td><pre>
+{
+  "name": "name of new notebook",
+  "params": {
+    "formLabel1": "value1",
+    "formLabel2": "value2"
+  }
+}
+      </pre></td>
+    </tr>
+    <tr>
       <td> sample JSON response </td>
       <td><pre>{"status":"OK"}</pre></td>
     </tr>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -26,14 +26,13 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.display.Input;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
-import org.apache.zeppelin.rest.message.CronRequest;
-import org.apache.zeppelin.rest.message.InterpreterSettingListForNoteBind;
-import org.apache.zeppelin.rest.message.NewInterpreterSettingRequest;
-import org.apache.zeppelin.rest.message.NewNotebookRequest;
+import org.apache.zeppelin.rest.message.*;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.socket.NotebookServer;
@@ -255,26 +254,41 @@ public class NotebookRestApi {
   
   /**
    * Run paragraph job REST API
-   * @param
+   * @param message - JSON with params if user wants to update dynamic form's value
+   *                null, empty string, empty json if user doesn't want to update
    * @return JSON with status.OK
    * @throws IOException, IllegalArgumentException
    */
   @POST
   @Path("job/{notebookId}/{paragraphId}")
   public Response runParagraph(@PathParam("notebookId") String notebookId, 
-                               @PathParam("paragraphId") String paragraphId) throws
+                               @PathParam("paragraphId") String paragraphId,
+                               String message) throws
                                IOException, IllegalArgumentException {
-    logger.info("run paragraph job {} {} ", notebookId, paragraphId);
+    logger.info("run paragraph job {} {} {}", notebookId, paragraphId, message);
+
     Note note = notebook.getNote(notebookId);
     if (note == null) {
       return new JsonResponse(Status.NOT_FOUND, "note not found.").build();
     }
-    
-    if (note.getParagraph(paragraphId) == null) {
+
+    Paragraph paragraph = note.getParagraph(paragraphId);
+    if (paragraph == null) {
       return new JsonResponse(Status.NOT_FOUND, "paragraph not found.").build();
     }
 
-    note.run(paragraphId);
+    // handle params if presented
+    if (!StringUtils.isEmpty(message)) {
+      RunParagraphWithParametersRequest request = gson.fromJson(message,
+          RunParagraphWithParametersRequest.class);
+      Map<String, Object> paramsForUpdating = request.getParams();
+      if (paramsForUpdating != null) {
+        paragraph.settings.getParams().putAll(paramsForUpdating);
+        note.persist();
+      }
+    }
+
+    note.run(paragraph.getId());
     return new JsonResponse(Status.OK).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/RunParagraphWithParametersRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/RunParagraphWithParametersRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest.message;
+
+import java.util.Map;
+
+/**
+ * RunParagraphWithParametersRequest rest api request message
+ */
+public class RunParagraphWithParametersRequest {
+  Map<String, Object> params;
+
+  public RunParagraphWithParametersRequest() {
+
+  }
+
+  public Map<String, Object> getParams() {
+    return params;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -385,7 +385,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     int timeout = 1;
     while (!paragraph.isTerminated()) {
       Thread.sleep(1000);
-      if (timeout++ > 30) {
+      if (timeout++ > 120) {
         LOG.info("testRunParagraphWithParams timeout job.");
         break;
       }


### PR DESCRIPTION
### What is this PR for?

To update dynamic form's value (via params) when running paragraph via REST API

### What type of PR is it?

Improvement

### Todos

### Is there a relevant Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-507

### How should this be tested?

* Create a new notebook with one paragraph which contains  

```
%spark

val form1 = z.input("form1").toString
```

* Get paragraph ID via websocket (I think we should add a new REST API to get it easily.)

* Request ```http://<zeppelin host>:<zeppelin port>/api/notebook/job/<notebook id>/<paragraph id>``` with POST method including JSON payload,

```
{
    "params": {
        "form1": "value1"
    }
}
```

* Confirm that paragraph has run and input text of form1 is filled with "value1" (from the UI)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? (No)
* Is there breaking changes for older versions? (No, additonal json payload is optional.)
* Does this needs documentation? (Yes, I've addressed it.)