### PR TITLE
Install guide modifications based on recent build attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo apt-get install libfontconfig
 sudo npm -g install grunt-cli
 sudo npm -g install bower
 
-# Optional: If you're behind limited to what ports you can access externally
+# Optional: If you're limited to what ports you can access externally
 # git config --global url."https://".insteadOf git://
 
 # install maven

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ sudo apt-get install git
 sudo apt-get install openjdk-7-jdk
 sudo apt-get install npm
 sudo apt-get install libfontconfig
+sudo npm -g install grunt-cli
+sudo npm -g install bower
+
+# Optional: If you're behind limited to what ports you can access externally
+# git config --global url."https://".insteadOf git://
 
 # install maven
 wget http://www.eu.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz


### PR DESCRIPTION
I found that an install on a fresh VM didn't succeed without a few global npm installations and without telling git to used https instead of git (optional depending on your network).