### PR TITLE
Fix wording in run all paragraphs tooltip

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -21,7 +21,7 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-click="runNote()"
               ng-class="{'disabled':isNoteRunning()}"
-              tooltip-placement="bottom" tooltip="Run all the notes">
+              tooltip-placement="bottom" tooltip="Run all paragraphs">
         <i class="icon-control-play"></i>
       </button>
       <button type="button"


### PR DESCRIPTION
### What is this PR for?
Fix the wording in the run all paragraphs, instead of showing `run all the notes` it should be `run all paragraphs`

### What type of PR is it?
 * Improvement

### Todos
 * none

### Is there a relevant Jira issue?
 * no

### How should this be tested?
Run zeppelin and check the tooltip

### Screenshots (if appropriate)
#### before
<img width="115" alt="screen shot 2015-12-17 at 3 56 14 pm" src="https://cloud.githubusercontent.com/assets/3139557/11863422/111296e2-a4d7-11e5-9c96-22b8bd86676e.png">

#### after
![screen shot 2015-12-17 at 4 06 18 pm](https://cloud.githubusercontent.com/assets/3139557/11863562/34af2fb0-a4d8-11e5-8daf-6d7fe08da6f1.png)


### Questions:
* Does the licenses files need update? NO!!!!
* Is there breaking changes for older versions? NOOOOO!
* Does this needs documentation? NOOOO!


