### PR TITLE
ZEPPELIN-508 Interpreter binding cancel button doesn't work

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -508,8 +508,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
           }
         }
       });
-    }
-    else {
+    } else {
       $scope.showSetting = false;
     }
   };

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -499,8 +499,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     if (isSettingDirty()) {
       BootstrapDialog.confirm({
         title: '',
-        message : 'Changes will be discarded.',
-        callback : function(result) {
+        message: 'Changes will be discarded.',
+        callback: function(result) {
           if (result) {
             $scope.$apply(function () {
               $scope.showSetting = false;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -512,7 +512,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     else {
       BootstrapDialog.confirm({
       title: '',
-      message : 'Notihing is changed.',
+      message : 'Nothing is changed.',
       callback: function(result) {
         if (result) {
           $scope.$apply(function () {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -502,7 +502,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
         message: 'Changes will be discarded.',
         callback: function(result) {
           if (result) {
-            $scope.$apply(function () {
+            $scope.$apply(function() {
               $scope.showSetting = false;
             });
           }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -499,11 +499,24 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     if (isSettingDirty()) {
       BootstrapDialog.confirm({
         title: '',
-        message: 'Changes will be discarded',
+        message : 'Changes will be discarded.',
         callback: function(result) {
           if (result) {
             $scope.$apply(function () {
               $scope.showSetting = false;
+            });
+          }
+        }
+      });
+    }
+    else {
+      BootstrapDialog.confirm({
+      title: '',
+      message : 'Notihing is changed.',
+      callback: function(result) {
+        if (result) {
+          $scope.$apply(function () {
+            $scope.showSetting = false;
             });
           }
         }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -500,7 +500,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       BootstrapDialog.confirm({
         title: '',
         message : 'Changes will be discarded.',
-        callback: function(result) {
+        callback : function(result) {
           if (result) {
             $scope.$apply(function () {
               $scope.showSetting = false;
@@ -510,17 +510,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       });
     }
     else {
-      BootstrapDialog.confirm({
-      title: '',
-      message : 'Nothing is changed.',
-      callback: function(result) {
-        if (result) {
-          $scope.$apply(function () {
-            $scope.showSetting = false;
-            });
-          }
-        }
-      });
+      $scope.showSetting = false;
     }
   };
 


### PR DESCRIPTION
### What is this PR for?
Currently, when there is no change compared with before the interpreter binding setting status, the  cancel button in binding page doesn't work. So I fixed this bug.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix the cancel button in interpreter binding page.

### Is there a relevant Jira issue?
[https://issues.apache.org/jira/browse/ZEPPELIN-508](https://issues.apache.org/jira/browse/ZEPPELIN-508)

### How should this be tested?
Open the Zeppelin any notebook page -> Click the interpreter binding button 
1. Don't change any binding setting and Just click the **cancel** button. 
2. Or just click twice the interpreter binding button.

### Screenshots (if appropriate)
After this PR applied,
![zeppelin508_after 1](https://cloud.githubusercontent.com/assets/10060731/11865265/cadc8dce-a457-11e5-9448-4014e1a9431f.gif)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.