### PR TITLE
[ZEPPELIN-515] Hadoop libraries in ${HADOOP_HOME}/share folder not included in CLASSPATH

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -70,6 +70,15 @@ function addEachJarInDir(){
   fi
 }
 
+function addEachJarInDirRecursive(){
+  if [[ -d "${1}" ]]; then
+    for jar in $(find -L "${1}" -type f -name '*jar'); do
+      ZEPPELIN_CLASSPATH="$jar:$ZEPPELIN_CLASSPATH"
+    done
+  fi
+}
+
+
 function addJarInDir(){
   if [[ -d "${1}" ]]; then
     ZEPPELIN_CLASSPATH="${1}/*:${ZEPPELIN_CLASSPATH}"

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -87,7 +87,7 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
     # add Hadoop jars into classpath
     if [[ -n "${HADOOP_HOME}" ]]; then
       # Apache
-      addEachJarInDir "${HADOOP_HOME}/share"
+      addEachJarInDirRecursive "${HADOOP_HOME}/share"
 
       # CDH
       addJarInDir "${HADOOP_HOME}"


### PR DESCRIPTION
### What is this PR for?
Find and add jar under ${HADOOP_HOME}/share, recursively.

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-515

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no