### PR TITLE
ZEPPELIN-518 ] always top fixed column title for table

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -945,8 +945,8 @@ angular.module('zeppelinWebApp')
       html += '<table class="table table-hover table-condensed" style="top: 0; position: absolute;">';
       html += '  <thead>';
       html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';
-      for (var c in $scope.paragraph.result.columnNames) {
-        html += '<th>'+$scope.paragraph.result.columnNames[c].name+'</th>';
+      for (var titleIndex in $scope.paragraph.result.columnNames) {
+        html += '<th>'+$scope.paragraph.result.columnNames[titleIndex].name+'</th>';
       }
       html += '    </tr>';
       html += '  </thead>';

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -952,14 +952,7 @@ angular.module('zeppelinWebApp')
       html += '  </thead>';
       html += '</table>';
 
-      html += '<table class="table table-hover table-condensed">';
-      html += '  <thead>';
-      html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';
-      for (var c in $scope.paragraph.result.columnNames) {
-        html += '<th>'+$scope.paragraph.result.columnNames[c].name+'</th>';
-      }
-      html += '    </tr>';
-      html += '  </thead>';
+      html += '<table class="table table-hover table-condensed" style="margin-top: 31px;">';
 
       for (var r in $scope.paragraph.result.msgTable) {
         var row = $scope.paragraph.result.msgTable[r];

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -941,6 +941,17 @@ angular.module('zeppelinWebApp')
 
     var renderTable = function() {
       var html = '';
+
+      html += '<table class="table table-hover table-condensed" style="position: absolute;">';
+      html += '  <thead>';
+      html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';
+      for (var c in $scope.paragraph.result.columnNames) {
+        html += '<th>'+$scope.paragraph.result.columnNames[c].name+'</th>';
+      }
+      html += '    </tr>';
+      html += '  </thead>';
+      html += '</table>';
+
       html += '<table class="table table-hover table-condensed">';
       html += '  <thead>';
       html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -942,7 +942,7 @@ angular.module('zeppelinWebApp')
     var renderTable = function() {
       var html = '';
 
-      html += '<table class="table table-hover table-condensed" style="position: absolute;">';
+      html += '<table class="table table-hover table-condensed" style="top: 0; position: absolute;">';
       html += '  <thead>';
       html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';
       for (var c in $scope.paragraph.result.columnNames) {


### PR DESCRIPTION
### What is this PR for?
if you express a lot of table Row of Zeppelin, when the Column Title have to scroll down, it is invisible and inconvenient.

So, I have to change the Zeppelin Table Column Title was modified to always display.

### What type of PR is it?
Improvement

### Todos
- [x] implement Fixed Column Title for table
- [x] Browser Test
  - [x] Safari (9.0.2(11601.3.9)
  - [x] Firefox (43.0)
  - [x] Chrome (47.0.2526.106 (64-bit)

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-518
### How should this be tested?
step 1. many rows table print.
           example query)  
``` python
%pyspark
TABLE = "%table Header1\tHeader2\tHeader3\tHeader4\n"
for x in range(1,101):
    TABLE +=  str(x) + ""
    if (x%4) == 0:
        TABLE += "\n"
    else:
        TABLE += "\t"
z.put("table_context", TABLE)
```
``` scala
%spark
println(z.get("table_context"))
```
step 2. Scroll the mouse over the Table.

### Screenshots (if appropriate)
Animated Gif.
![fixedtable](https://cloud.githubusercontent.com/assets/10525473/11905783/120635f8-a57d-11e5-83b3-ae0ab53a5e5c.gif)

### Questions:
How tables are expressed in browsers that do not support this feature? 
 - As before Header mouse scrolling moves along.