### PR TITLE
[Improve] Add interpreter restart REST API doc

### DIFF
--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -361,3 +361,38 @@ limitations under the License.
       </td>
     </tr>
   </table>
+
+  
+<br/>
+   
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>Restart an interpreter</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method restart the given interpreter id.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/setting/restart/[interpreter ID]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>{"status":"OK"}</pre>
+      </td>
+    </tr>
+  </table>
+

--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -395,4 +395,3 @@ limitations under the License.
       </td>
     </tr>
   </table>
-


### PR DESCRIPTION
### What is this PR for?
Add restarting interpreter REST API information to the document. 
There is no information in the document even though REST API exist.

### What type of PR is it?
Documentation

### Todos
* [x] - add restart REST API document.

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-521

### How should this be tested?
You can get the test information from https://github.com/apache/incubator-zeppelin/tree/master/docs.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no