### PR TITLE
Auto-restart interpreters on cron execution.

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -100,6 +100,12 @@ limitations under the License.
                   {{note.info.cron}}
                 </p>
               </div>
+              <div>
+                <span>- Release resource after cron execution </span>
+                <input type="checkbox"
+                       ng-model="note.config.releaseresource"
+                       ng-click="setReleaseResource(note.config.releaseresource)">
+              </div>
             </div>
           </li>
         </ul>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -101,7 +101,7 @@ limitations under the License.
                 </p>
               </div>
               <div>
-                <span>- Release resource after cron execution </span>
+                <span>- auto-restart interpreter on cron execution </span>
                 <input type="checkbox"
                        ng-model="note.config.releaseresource"
                        ng-click="setReleaseResource(note.config.releaseresource)">

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -226,6 +226,12 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     $scope.setConfig();
   };
 
+  /** Set release resource for this note **/
+  $scope.setReleaseResource = function(value) {
+    $scope.note.config.releaseresource = value;
+    $scope.setConfig();
+  };
+
   /** Update note config **/
   $scope.setConfig = function(config) {
     if(config) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -389,6 +389,21 @@ public class Notebook {
       String noteId = context.getJobDetail().getJobDataMap().getString("noteId");
       Note note = notebook.getNote(noteId);
       note.runAll();
+    
+      while (!note.getLastParagraph().isTerminated()) {
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+      
+      boolean releaseResource = (boolean) note.getConfig().get("releaseresource");
+      if (releaseResource) {
+        for (InterpreterSetting setting : note.getNoteReplLoader().getInterpreterSettings()) {
+          notebook.getInterpreterFactory().restart(setting.id());
+        }
+      }      
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -398,7 +398,12 @@ public class Notebook {
         }
       }
       
-      boolean releaseResource = (boolean) note.getConfig().get("releaseresource");
+      boolean releaseResource = false;
+      try {
+        releaseResource = (boolean) note.getConfig().get("releaseresource");
+      } catch (java.lang.ClassCastException e) {
+        e.printStackTrace();
+      }
       if (releaseResource) {
         for (InterpreterSetting setting : note.getNoteReplLoader().getInterpreterSettings()) {
           notebook.getInterpreterFactory().restart(setting.id());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -50,8 +50,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.quartz.SchedulerException;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
### What is this PR for?
Release resource after cron schedule job.

### What type of PR is it?
Improvement

### Todos
* [x] - add check-box for release resource to the zeppelin-web.
* [x] - add release resource(interpreter restart) function to notebook.

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-524.

### How should this be tested?
please refer to the screenshots.

### Screenshots (if appropriate)
![release_resource](https://cloud.githubusercontent.com/assets/3348133/11922205/9ef86684-a749-11e5-9f88-13a40b7a0b02.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no