### PR TITLE
Prevent server calls when there is no data in paragraphs

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -279,6 +279,9 @@ kbd {
   ngToast Style
 */
 
+.ng-toast {
+  z-index: 10003;
+}
 .ng-toast .alert {
   color: white !important;
   border: none !important;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -115,7 +115,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       callback: function(result) {
         if (result) {
           _.forEach($scope.note.paragraphs, function (n, key) {
-            angular.element('#' + n.id + '_paragraphColumn_main').scope().runParagraph(n.text);
+            if(n.text){
+              angular.element('#' + n.id + '_paragraphColumn_main').scope().runParagraph(n.text);
+            }
           });
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -16,7 +16,7 @@
 
 angular.module('zeppelinWebApp')
   .controller('ParagraphCtrl', function($scope,$rootScope, $route, $window, $element, $routeParams, $location,
-                                         $timeout, $compile, websocketMsgSrv) {
+                                         $timeout, $compile, websocketMsgSrv, ngToast) {
 
   $scope.paragraph = null;
   $scope.originalText = '';
@@ -262,6 +262,11 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.runParagraph = function(data) {
+    if(!data){
+      var paraRef = $scope.paragraph.title ? '"'+$scope.paragraph.title+'"' : '';
+      ngToast.info('Cannot run an empty paragraph ' + paraRef );
+      return;
+    }
     websocketMsgSrv.runParagraph($scope.paragraph.id, $scope.paragraph.title,
                                  data, $scope.paragraph.config, $scope.paragraph.settings.params);
     $scope.originalText = angular.copy(data);


### PR DESCRIPTION
*Whenever there is no text text in para, server call are made to run para. 
With this PR, the paras will be run only where there is text in them.(also in case of "run all paras" option).
*The messages from ngtoast were getting hidden behind navbar. Fixing it in this PR 

Improvement

Need to check for running of individual paras and 'run note' to run all paras
 

