### PR TITLE
adding shadow to navbar if noteActionBar is not present

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -36,6 +36,7 @@ body.asIframe {
 }
 
 body .navbar {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   margin-bottom: 0;
 }
 

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -76,7 +76,7 @@
 
 .navbar-fixed-top,
 .navbar-fixed-top .dropdown-menu {
-  z-index: 10002;
+  z-index: 2000;
 }
 
 .noteAction {


### PR DESCRIPTION
### What is this PR for?
This PR adds shadow to navbar if noteActionBar is not present

### What type of PR is it?
Improvement

### Todos
N/A

### Is there a relevant Jira issue?
N/A


### Screenshots (if appropriate)

Before:
<img width="1440" alt="screen shot 2015-12-22 at 1 05 54 pm" src="https://cloud.githubusercontent.com/assets/674497/11950315/4b033d14-a8ad-11e5-93c1-9be5a72c4718.png">

After:
<img width="1440" alt="screen shot 2015-12-22 at 1 06 17 pm" src="https://cloud.githubusercontent.com/assets/674497/11950314/4b02dcac-a8ad-11e5-869f-7a752f48f050.png">
