### PR TITLE
Zeppelin-523 ] Table Header fixed and scrolling bug fixes.

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -85,6 +85,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) Angular Websocket v1.0.13 (http://angularclass.github.io/angular-websocket/) - https://github.com/AngularClass/angular-websocket/blob/v1.0.13/LICENSE
     (The MIT License) UI.Ace v0.1.1 (http://angularclass.github.io/angular-websocket/) - https://github.com/angular-ui/ui-ace/blob/master/LICENSE
     (The MIT License) jquery.scrollTo v1.4.13 (https://github.com/flesler/jquery.scrollTo) - https://github.com/flesler/jquery.scrollTo/blob/1.4.13/LICENSE
+    (The MIT License) jquery.floatThead v1.3.2 (https://github.com/mkoryak/floatThead) - https://github.com/mkoryak/floatThead/blob/master/license.txt
     (The MIT License) angular-dragdrop v1.0.8 (http://codef0rmer.github.io/angular-dragdrop/#/) - https://github.com/codef0rmer/angular-dragdrop/blob/v1.0.8/LICENSE
     (The MIT License) perfect-scrollbar v0.5.4 (http://noraesae.github.io/perfect-scrollbar/) - https://github.com/noraesae/perfect-scrollbar/tree/0.5.4
     (The MIT License) ng-sortable v1.1.9 (https://github.com/a5hik/ng-sortable) - https://github.com/a5hik/ng-sortable/blob/1.1.9/LICENSE

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -28,7 +28,8 @@
     "angular-filter": "~0.5.4",
     "ngtoast": "~1.5.5",
     "ng-focus-if": "~1.0.2",
-    "bootstrap3-dialog": "bootstrap-dialog#~1.34.7"
+    "bootstrap3-dialog": "bootstrap-dialog#~1.34.7",
+    "floatThead": "~1.3.2"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -38,7 +38,7 @@ limitations under the License.
           data-toggle="dropdown"
           type="button">
     </span>
-    <ul class="dropdown-menu" role="menu" style="width:200px;">
+    <ul class="dropdown-menu" role="menu" style="width:200px; z-index: 1002">
       <li>
         <a ng-click="$event.stopPropagation()" class="dropdown"><span class="fa fa-arrows-h"></span> Width
           <form style="display:inline; margin-left:5px;">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -38,7 +38,7 @@ limitations under the License.
           data-toggle="dropdown"
           type="button">
     </span>
-    <ul class="dropdown-menu" role="menu" style="width:200px; z-index:1002">
+    <ul class="dropdown-menu" role="menu" style="width:200px;z-index:1002">
       <li>
         <a ng-click="$event.stopPropagation()" class="dropdown"><span class="fa fa-arrows-h"></span> Width
           <form style="display:inline; margin-left:5px;">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -38,7 +38,7 @@ limitations under the License.
           data-toggle="dropdown"
           type="button">
     </span>
-    <ul class="dropdown-menu" role="menu" style="width:200px; z-index: 1002">
+    <ul class="dropdown-menu" role="menu" style="width:200px; z-index:1002">
       <li>
         <a ng-click="$event.stopPropagation()" class="dropdown"><span class="fa fa-arrows-h"></span> Width
           <form style="display:inline; margin-left:5px;">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -941,7 +941,6 @@ angular.module('zeppelinWebApp')
 
 
     var renderTable = function() {
-
       var html = '';
       html += '<table class="table table-hover table-condensed">';
       html += '  <thead>';
@@ -982,11 +981,13 @@ angular.module('zeppelinWebApp')
             return angular.element('#p' + $scope.paragraph.id + '_table');
           }
         });
+
         angular.element('#p' + $scope.paragraph.id + '_table').css('position', 'relative');
         angular.element('#p' + $scope.paragraph.id + '_table').css('height', '100%');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('destroy');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
         angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
+        
         // set table height
         var psHeight = $scope.paragraph.config.graph.height;
         angular.element('#p' + $scope.paragraph.id + '_table').css('height', psHeight);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -941,9 +941,9 @@ angular.module('zeppelinWebApp')
 
 
     var renderTable = function() {
-      var html = '';
 
-      html += '<table class="table table-hover table-condensed" style="top: 0; position: absolute;">';
+      var html = '';
+      html += '<table class="table table-hover table-condensed">';
       html += '  <thead>';
       html += '    <tr style="background-color: #F6F6F6; font-weight: bold;">';
       for (var titleIndex in $scope.paragraph.result.columnNames) {
@@ -951,10 +951,7 @@ angular.module('zeppelinWebApp')
       }
       html += '    </tr>';
       html += '  </thead>';
-      html += '</table>';
-
-      html += '<table class="table table-hover table-condensed" style="margin-top: 31px;">';
-
+      html += '  <tbody>';
       for (var r in $scope.paragraph.result.msgTable) {
         var row = $scope.paragraph.result.msgTable[r];
         html += '    <tr>';
@@ -969,19 +966,28 @@ angular.module('zeppelinWebApp')
         }
         html += '    </tr>';
       }
-
+      html += '  </tbody>';
       html += '</table>';
 
       angular.element('#p' + $scope.paragraph.id + '_table').html(html);
       if ($scope.paragraph.result.msgTable.length > 10000) {
         angular.element('#p' + $scope.paragraph.id + '_table').css('overflow', 'scroll');
       } else {
+        var dataTable = angular.element('#p' + $scope.paragraph.id + '_table .table');
+        dataTable.floatThead({
+          scrollContainer: function (dataTable) {
+            return angular.element('#p' + $scope.paragraph.id + '_table');
+          }
+        });
+        angular.element('#p' + $scope.paragraph.id + '_table').css('position', 'relative');
+        angular.element('#p' + $scope.paragraph.id + '_table').css('height', '100%');
+        angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
+        angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('destroy');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
       }
-
       // set table height
       var height = $scope.paragraph.config.graph.height;
-      angular.element('#p' + $scope.paragraph.id + '_table').height(height);
+      angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
     };
 
     var retryRenderer = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -981,13 +981,16 @@ angular.module('zeppelinWebApp')
             return angular.element('#p' + $scope.paragraph.id + '_table');
           }
         });
+        angular.element('#p' + $scope.paragraph.id + '_table .table').on('remove', function () {
+          angular.element('#p' + $scope.paragraph.id + '_table .table').floatThead('destroy');
+        });
 
         angular.element('#p' + $scope.paragraph.id + '_table').css('position', 'relative');
         angular.element('#p' + $scope.paragraph.id + '_table').css('height', '100%');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('destroy');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
         angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
-        
+
         // set table height
         var psHeight = $scope.paragraph.config.graph.height;
         angular.element('#p' + $scope.paragraph.id + '_table').css('height', psHeight);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -972,6 +972,9 @@ angular.module('zeppelinWebApp')
       angular.element('#p' + $scope.paragraph.id + '_table').html(html);
       if ($scope.paragraph.result.msgTable.length > 10000) {
         angular.element('#p' + $scope.paragraph.id + '_table').css('overflow', 'scroll');
+        // set table height
+        var height = $scope.paragraph.config.graph.height;
+        angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
       } else {
         var dataTable = angular.element('#p' + $scope.paragraph.id + '_table .table');
         dataTable.floatThead({
@@ -981,13 +984,15 @@ angular.module('zeppelinWebApp')
         });
         angular.element('#p' + $scope.paragraph.id + '_table').css('position', 'relative');
         angular.element('#p' + $scope.paragraph.id + '_table').css('height', '100%');
-        angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('destroy');
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
+        angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
+        // set table height
+        var height = $scope.paragraph.config.graph.height;
+        angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
+        angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('update');
       }
-      // set table height
-      var height = $scope.paragraph.config.graph.height;
-      angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
+
     };
 
     var retryRenderer = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -988,8 +988,8 @@ angular.module('zeppelinWebApp')
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar();
         angular.element('.ps-scrollbar-y-rail').css('z-index', '1002');
         // set table height
-        var height = $scope.paragraph.config.graph.height;
-        angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
+        var psHeight = $scope.paragraph.config.graph.height;
+        angular.element('#p' + $scope.paragraph.id + '_table').css('height', psHeight);
         angular.element('#p' + $scope.paragraph.id + '_table').perfectScrollbar('update');
       }
 

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -122,6 +122,8 @@ limitations under the License.
     <script src="bower_components/ngtoast/dist/ngToast.js"></script>
     <script src="bower_components/ng-focus-if/focusIf.js"></script>
     <script src="bower_components/bootstrap3-dialog/dist/js/bootstrap-dialog.min.js"></script>
+    <script src="bower_components/floatThead/dist/jquery.floatThead.js"></script>
+    <script src="bower_components/floatThead/dist/jquery.floatThead.min.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:js({.tmp,src}) scripts/scripts.js -->

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -56,6 +56,8 @@ module.exports = function(config) {
       'bower_components/ngtoast/dist/ngToast.js',
       'bower_components/ng-focus-if/focusIf.js',
       'bower_components/bootstrap3-dialog/dist/js/bootstrap-dialog.min.js',
+      'bower_components/floatThead/dist/jquery.floatThead.js',
+      'bower_components/floatThead/dist/jquery.floatThead.min.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
       'src/app/app.js',


### PR DESCRIPTION
### What is this PR for?
For Table, reimplemented, scrolling, deleting a bug in the Table Header, Scrolling area expressed bugs have been fixed.

### What type of PR is it?
Bug Fix

### Todos
- [x] \(Re-modification\) always top fixed column title for table
- [x] table scrolling bug fixed. out of area scroll 
       https://github.com/apache/incubator-zeppelin/pull/556
- [x] After the re-run, remove the scroll bar
- [x] License Infomation
  - [x] record the license information of jquery.floatThead.
- [x] Browser Test
  - [x] Safari (9.0.2(11601.3.9)
  - [x] Firefox (43.0)
  - [x] Chrome (47.0.2526.106 (64-bit)

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-523
### How should this be tested?
Step 1. create table on zeppelin
           example query) 
``` python
%pyspark
TABLE = "%table Header1\tHeader2\n"
for x in range(1,51):
    #TABLE +=  "scroll";
    TABLE +=  str(x);
    if (x%2) == 0:
        TABLE += "\n"
    else:
        TABLE += "\t"
z.put("table_context", TABLE)

```
``` scala
println(z.get("table_context"))
```

Step 2. 
Scroll the mouse over the Table.

Step 3.
re Run Paragraph.

Step 4.
Scroll the mouse over the Table.

### Screenshots (if appropriate)

#### Before
![before](https://cloud.githubusercontent.com/assets/10525473/11911933/4cf27744-a5dc-11e5-8f45-e1e15e532de9.gif)

#### After
![bug_fix_table_sc](https://cloud.githubusercontent.com/assets/10525473/11952384/a05a8238-a84c-11e5-9706-3412f96a81ea.gif)

### Questions:
You are using an external source?
\- I used jquery.floatThead (MIT) Libraries.
  It helps to secure the Table Header.
Why did this problem occur?
\- ref. https://github.com/noraesae/perfect-scrollbar#how-to-use perfect scrollbar library. 
  height calculation miss.
Why it has created a new PR?
\- A problem with a private Git Repository to my mistakes.
  Please previous PR, see the following URL.
  https://github.com/apache/incubator-zeppelin/pull/556
In the ScreenShot, it seems to have changed color table. What changed things?
\- no. It's Animated Gif color problems.
  Changes that do not exist.