### PR TITLE
Keep paragraph height unchanged when progress bar is shown

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-progressBar.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-progressBar.html
@@ -12,8 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div id="{{paragraph.id}}_runControl" class="runControl" ng-show="paragraph.status=='RUNNING'">
-  <div id="{{paragraph.id}}_progress" class="progress">
+<div id="{{paragraph.id}}_runControl" class="runControl">
+  <div id="{{paragraph.id}}_progress" class="progress" ng-show="paragraph.status=='RUNNING'">
       <div ng-if="getProgress()>0 && getProgress()<100 && paragraph.status=='RUNNING'"
         class="progress-bar" role="progressbar" style="width:{{getProgress()}}%;"></div>
       <div ng-if="(getProgress()<=0 || getProgress()>=100) && (paragraph.status=='RUNNING' )"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -140,7 +140,7 @@
   font-size: 1px;
   color: #AAAAAA;
   height:4px;
-  margin: 0px 0px 3px 0px;
+  margin: 0px 0px 0px 0px;
 }
 
 .paragraph .runControl .progress {
@@ -297,6 +297,7 @@
 */
 
 .tableDisplay {
+  margin-top: 2px;
 }
 
 .tableDisplay div {


### PR DESCRIPTION
### What is this PR for?
Paragraph height is changing depends on progress bar.
This PR make paragraph height unchanged whether progress bar is shown or not.

### What type of PR is it?
Bug Fix

### How should this be tested?
Run paragraph and see progress bar change it's height.

### Screenshots (if appropriate)

before
![paragraph_height_master](https://cloud.githubusercontent.com/assets/1540981/11990227/df7c7e1e-aa4d-11e5-8026-6d9eccac6500.gif)

after
![paragraph_height](https://cloud.githubusercontent.com/assets/1540981/11990228/e1960ad0-aa4d-11e5-89bb-52cb56686267.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no