### PR TITLE
[ZEPPELIN-535] "Scheduler already terminated" occurs when RemoteInterpreter.close() doesn't succeed

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -24,6 +24,7 @@ import java.util.Random;
 
 import org.apache.log4j.Logger;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 
 /**
  * InterpreterGroup is list of interpreters in the same group.
@@ -33,6 +34,7 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
   String id;
 
   AngularObjectRegistry angularObjectRegistry;
+  RemoteInterpreterProcess remoteInterpreterProcess;    // attached remote interpreter process
 
   public InterpreterGroup(String id) {
     this.id = id;
@@ -70,6 +72,14 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
 
   public void setAngularObjectRegistry(AngularObjectRegistry angularObjectRegistry) {
     this.angularObjectRegistry = angularObjectRegistry;
+  }
+
+  public RemoteInterpreterProcess getRemoteInterpreterProcess() {
+    return remoteInterpreterProcess;
+  }
+
+  public void setRemoteInterpreterProcess(RemoteInterpreterProcess remoteInterpreterProcess) {
+    this.remoteInterpreterProcess = remoteInterpreterProcess;
   }
 
   public void close() {
@@ -116,6 +126,13 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
       } catch (InterruptedException e) {
         Logger logger = Logger.getLogger(InterpreterGroup.class);
         logger.error("Can't close interpreter", e);
+      }
+    }
+
+    // make sure remote interpreter process terminates
+    if (remoteInterpreterProcess != null) {
+      while (remoteInterpreterProcess.referenceCount() > 0) {
+        remoteInterpreterProcess.dereference();
       }
     }
   }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -219,9 +219,6 @@ public class RemoteInterpreterTest {
 
     intpA.close();
     intpB.close();
-
-    RemoteInterpreterProcess process = intpA.getInterpreterProcess();
-    assertNull(process);
   }
 
   @Test
@@ -337,9 +334,6 @@ public class RemoteInterpreterTest {
 
     intpA.close();
     intpB.close();
-
-    RemoteInterpreterProcess process = intpA.getInterpreterProcess();
-    assertNull(process);
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
Fix the exception "Scheduler already terminated" when remove interpreter close() fails

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-535

### How should this be tested?
Modify any interpreter to throw exception on close() call.
And try to use it after restart the interpreter.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no