### PR TITLE
ZEPPELIN-542 ] Paragraph running, the page move is not possible.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -401,7 +401,8 @@ public class NotebookServer extends WebSocketServlet implements
 
     return cronUpdated;
   }
-  private void createNote(WebSocket conn, Notebook notebook, Message message) throws IOException {
+  private void createNote(NotebookSocket conn, Notebook notebook, Message message)
+      throws IOException {
     Note note = notebook.createNote();
     note.addParagraph(); // it's an empty note. so add one paragraph
     if (message != null) {
@@ -414,7 +415,7 @@ public class NotebookServer extends WebSocketServlet implements
 
     note.persist();
     addConnectionToNote(note.id(), (NotebookSocket) conn);
-    broadcastNote(note);
+    conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", note)));
     broadcastNoteList();
   }
 
@@ -458,7 +459,7 @@ public class NotebookServer extends WebSocketServlet implements
     String name = (String) fromMessage.get("name");
     Note newNote = notebook.cloneNote(noteId, name);
     addConnectionToNote(newNote.id(), (NotebookSocket) conn);
-    broadcastNote(newNote);
+    conn.send(serializeMessage(new Message(OP.CLONE_NOTE).put("note", newNote)));
     broadcastNoteList();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -459,7 +459,7 @@ public class NotebookServer extends WebSocketServlet implements
     String name = (String) fromMessage.get("name");
     Note newNote = notebook.cloneNote(noteId, name);
     addConnectionToNote(newNote.id(), (NotebookSocket) conn);
-    conn.send(serializeMessage(new Message(OP.CLONE_NOTE).put("note", newNote)));
+    conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", newNote)));
     broadcastNoteList();
   }
 

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -34,14 +34,6 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $ro
     vm.createNote();
   };
 
-  $scope.$on('createNoteContent', function(event, note) {
-    //a hack, to make it run only after notebook creation
-    //it should not run i.e in case of linking to the paragraph
-    if (note && $location.path().indexOf(note.id) < 0) {
-      $location.path('notebook/' + note.id);
-    }
-  });
-
   vm.preVisible = function(clone) {
     var generatedName = vm.generateName();
     $scope.note.notename = 'Note ' + generatedName;

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -34,7 +34,7 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, $ro
     vm.createNote();
   };
 
-  $scope.$on('setNoteContent', function(event, note) {
+  $scope.$on('createNoteContent', function(event, note) {
     //a hack, to make it run only after notebook creation
     //it should not run i.e in case of linking to the paragraph
     if (note && $location.path().indexOf(note.id) < 0) {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -13,7 +13,7 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope, $websocket, baseUrlSrv) {
+angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope, $websocket, $location, baseUrlSrv) {
   var websocketCalls = {};
 
   websocketCalls.ws = $websocket(baseUrlSrv.getWebsocketUrl());
@@ -46,9 +46,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
     var data = payload.data;
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
-    } else if (op === 'NEW_NOTE' || op === 'CLONE_NOTE') {
-      $rootScope.$broadcast('createNoteContent', data.note);
-      $rootScope.$broadcast('setNoteContent', data.note);
+    } else if (op === 'NEW_NOTE') {
+      $location.path('notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'PARAGRAPH') {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -46,6 +46,9 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
     var data = payload.data;
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
+    } else if (op === 'NEW_NOTE' || op === 'CLONE_NOTE') {
+      $rootScope.$broadcast('createNoteContent', data.note);
+      $rootScope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'PARAGRAPH') {


### PR DESCRIPTION
### What is this PR for?
Paragraph running, the page move is not possible.
If this Paragraph is running, you can not move to another page, such as the Interpreter Page.
Please check the Animated GIF.

The cause was due to 'NEW_NOTE' event and the 'CLONE NOTE' event to use enclosed in setNoteContent.
Therefore, I solved the problem by separating them.
### What type of PR is it?
Bug Fix

### Todos
- [x]  NEW_NOTE / CLONE_NOTE generated events on front-web
- [x]  NEW / CLONE NOTE Event Response separation backend-server.

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-542
### How should this be tested?
Step 1. Write more than each x10 Paragraph as follows
``` scala
Thread.sleep(2000); 
```
Step 2. Run All Paragraph (or Run Notebook)

Step 3. Go to another page, except for the Notebook.

### Screenshots (if appropriate)
#### before (bug)
![bug_fix_before](https://cloud.githubusercontent.com/assets/10525473/12030339/1fd4a650-adb2-11e5-949b-f2dbf63fb055.gif)

#### after (fixed)
![bug_fix_after](https://cloud.githubusercontent.com/assets/10525473/12030342/24093ccc-adb2-11e5-816d-e1ff8be5ca1b.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no