### PR TITLE
ZEPPELIN-544 ] After the restart when setting bug fixes interpreters note paragraphs state.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -520,19 +520,7 @@ public class InterpreterFactory {
       InterpreterSetting intpsetting = interpreterSettings.get(id);
       if (intpsetting != null) {
 
-        for (Interpreter intp : intpsetting.getInterpreterGroup()) {
-          for (Job job : intp.getScheduler().getJobsRunning()) {
-            job.abort();
-            job.setStatus(Status.ABORT);
-            logger.info("Job " + job.getJobName() + " aborted ");
-          }
-
-          for (Job job : intp.getScheduler().getJobsWaiting()) {
-            job.abort();
-            job.setStatus(Status.ABORT);
-            logger.info("Job " + job.getJobName() + " aborted ");
-          }
-        }
+        stopJobAllInterpreter(intpsetting);
 
         intpsetting.getInterpreterGroup().close();
         intpsetting.getInterpreterGroup().destroy();
@@ -556,20 +544,7 @@ public class InterpreterFactory {
       InterpreterSetting intpsetting = interpreterSettings.get(id);
       if (intpsetting != null) {
 
-        for (Interpreter intp : intpsetting.getInterpreterGroup()) {
-          for (Job job : intp.getScheduler().getJobsRunning()) {
-            job.abort();
-            job.setStatus(Status.ABORT);
-            logger.info("Job " + job.getJobName() + " aborted ");
-          }
-              
-          for (Job job : intp.getScheduler().getJobsWaiting()) {
-            job.abort();
-            job.setStatus(Status.ABORT);
-            logger.info("Job " + job.getJobName() + " aborted ");
-          }
-        }
-
+        stopJobAllInterpreter(intpsetting);
 
         intpsetting.getInterpreterGroup().close();
         intpsetting.getInterpreterGroup().destroy();
@@ -585,6 +560,22 @@ public class InterpreterFactory {
     }
   }
 
+  private void stopJobAllInterpreter(InterpreterSetting intpsetting) {
+    if (intpsetting != null) {
+      for (Interpreter intp : intpsetting.getInterpreterGroup()) {
+        for (Job job : intp.getScheduler().getJobsRunning()) {
+          job.abort();
+          job.setStatus(Status.ABORT);
+          logger.info("Job " + job.getJobName() + " aborted ");
+        }
+        for (Job job : intp.getScheduler().getJobsWaiting()) {
+          job.abort();
+          job.setStatus(Status.ABORT);
+          logger.info("Job " + job.getJobName() + " aborted ");
+        }
+      }
+    }
+  }
 
   public void close() {
     List<Thread> closeThreads = new LinkedList<Thread>();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -519,6 +519,21 @@ public class InterpreterFactory {
     synchronized (interpreterSettings) {
       InterpreterSetting intpsetting = interpreterSettings.get(id);
       if (intpsetting != null) {
+
+        for (Interpreter intp : intpsetting.getInterpreterGroup()) {
+          for (Job job : intp.getScheduler().getJobsRunning()) {
+            job.abort();
+            job.setStatus(Status.ABORT);
+            logger.info("Job " + job.getJobName() + " aborted ");
+          }
+
+          for (Job job : intp.getScheduler().getJobsWaiting()) {
+            job.abort();
+            job.setStatus(Status.ABORT);
+            logger.info("Job " + job.getJobName() + " aborted ");
+          }
+        }
+
         intpsetting.getInterpreterGroup().close();
         intpsetting.getInterpreterGroup().destroy();
 


### PR DESCRIPTION
### What is this PR for?
Restful api - call upon the setting / interpreter id type,
The problem occurs in the status of running Paragraphs.

- Paragraphs status code changes and restart missing

### What type of PR is it?
Bug Fix

### Todos


### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-544
### How should this be tested?
Paragraphs running after interpreter config change, save -> click okay on restart dialog

### Screenshots (if appropriate)
#### before
![bug_fix_before](https://cloud.githubusercontent.com/assets/10525473/12031890/e7708f6c-adc6-11e5-929e-369cabddb84f.gif)

#### after
![bug_fix_after](https://cloud.githubusercontent.com/assets/10525473/12031892/eacbcf8c-adc6-11e5-9c2c-971db02da00e.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no