### PR TITLE
ZEPPELIN-547: Cannot select output of the paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -40,9 +40,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
   $scope.interpreterBindings = [];
   $scope.isNoteDirty = null;
   $scope.saveTimer = null;
-  $scope.paragraphClickFlag = 0;
-  $scope.alreadyclicked = false;
-  $scope.alreadyclickedTimeout = null;
 
   var angularObjectRegistry = {};
   var connectedOnce = false;
@@ -111,35 +108,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     }
   };
 
-  var doc = angular.element(document);
-
-  $scope.mouseDownHandler = function(evt) {
-    doc.on('mouseup mousemove', function handler(evt) {
-      if (evt.type === 'mouseup') {
-        if ($scope.alreadyclicked) {
-          // double
-          if ($scope.alreadyclickedTimeout) {
-            clearTimeout($scope.alreadyclickedTimeout);
-            setTimeout(function() {
-              // can be a tripple click
-              $scope.alreadyclicked = false;
-            }, 300);
-          }
-        } else {
-          // single
-          $scope.alreadyclicked = true;
-          $scope.alreadyclickedTimeout = setTimeout(function() {
-            $scope.alreadyclicked = false;
-            $scope.focusParagraphOnClick(evt);
-          }, 300);
-        }
-      }
-      doc.off('mouseup mousemove', handler);
-    });
-  };
-
-  doc.on('mousedown', $scope.mouseDownHandler);
-
+  document.addEventListener('click', $scope.focusParagraphOnClick);
 
   $scope.keyboardShortcut = function(keyEvent) {
     // handle keyevent
@@ -300,7 +269,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     $scope.killSaveTimer();
     $scope.saveNote();
 
-    doc.off('mousedown');
+    document.removeEventListener('click', $scope.focusParagraphOnClick);
     document.removeEventListener('keydown', $scope.keyboardShortcut);
   });
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -95,19 +95,16 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     if (!$scope.note) {
       return;
     }
-    try {
-      for (var i = 0; i < $scope.note.paragraphs.length; i++) {
-        var paragraphId = $scope.note.paragraphs[i].id;
-        if (jQuery.contains(angular.element('#' + paragraphId + '_container')[0], clickEvent.target)) {
-          $scope.$broadcast('focusParagraph', paragraphId, 0, true);
-          break;
-        }
+    for (var i=0; i<$scope.note.paragraphs.length; i++) {
+      var paragraphId = $scope.note.paragraphs[i].id;
+      if (jQuery.contains(angular.element('#' + paragraphId + '_container')[0], clickEvent.target)) {
+        $scope.$broadcast('focusParagraph', paragraphId, 0, true);
+        break;
       }
-    } catch (e) {
-      //nothing to worry. page changed.
     }
   };
 
+  // register mouseevent handler for focus paragraph
   document.addEventListener('click', $scope.focusParagraphOnClick);
 
   $scope.keyboardShortcut = function(keyEvent) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -841,9 +841,8 @@ angular.module('zeppelinWebApp')
     if ($scope.paragraph.id === paragraphId) {
       // focus editor
       if (!$scope.paragraph.config.editorHide) {
-        $scope.editor.focus();
-
         if (!mouseEvent) {
+          $scope.editor.focus();
           // move cursor to the first row (or the last row)
           var row;
           if (cursorPos >= 0) {


### PR DESCRIPTION
### What is this PR for?
Cannot select error/output of the paragraph.
Whenever there is a click on output the focus is set to editor.


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - keep scope for mouse drag, doulble/multiple clicks

### Is there a relevant Jira issue?
[ZEPPELIN-547](https://issues.apache.org/jira/browse/ZEPPELIN-547)

### How should this be tested?
 - Try single click on output, focus should be set to editor.
 - but if there is a mouse drag or double/triple click on output, it should select output.


### Screenshots (if appropriate)
Single click, double click, triple click
![click test](https://cloud.githubusercontent.com/assets/674497/12062140/fc61473e-afbc-11e5-9f1f-dce76540c006.gif)
