### PR TITLE
Add a link for interpreter.md to navbar menu

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -36,6 +36,8 @@
             <li>
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Interpreter <b class="caret"></b></a>
               <ul class="dropdown-menu">
+                <li><a href="{{BASE_PATH}}/manual/interpreters.html">Overview</a></li>
+                <li role="separator" class="divider"></li>
                 <li><a href="{{BASE_PATH}}/interpreter/cassandra.html">Cassandra</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/elasticsearch.html">Elasticsearch</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/flink.html">Flink</a></li>


### PR DESCRIPTION
### What is this PR for?
Currently, `/docs/manual/interpreters.md` file can not be found in anywhere. So I add a link for this file to the navbar menu. 

### What type of PR is it?
Improvement

### Todos
* [x] - Add a link for interpreter.md to navbar menu.

### Is there a relevant Jira issue?
No

### How should this be tested?
We don't have link for interpreter.md yet, so can not reproduce it  : (

### Screenshots (if appropriate)
 - Before
![screen shot 2016-01-01 at 9 49 30 pm](https://cloud.githubusercontent.com/assets/10060731/12073375/6f5c2c5c-b0d2-11e5-9014-5ddfac734dc2.png)
 
 - After
![screen shot 2016-01-01 at 9 49 15 pm](https://cloud.githubusercontent.com/assets/10060731/12073376/7583dcec-b0d2-11e5-8f34-c873299a264a.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No