### PR TITLE
[ZEPPELIN-552] Shadow on focused paragraph in default looknfeel

### DIFF
--- a/zeppelin-web/src/assets/styles/looknfeel/default.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/default.css
@@ -27,3 +27,8 @@ body {
 .nv-controlsWrap {
   display: block;
 }
+
+.paragraph-col .focused {
+  box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.3);
+  border-color: white;
+}


### PR DESCRIPTION
### What is this PR for?
Add visual indication of focused paragraph by adding shadow in 'default' looknfeel.

### What type of PR is it?
Improvement

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-552

### How should this be tested?
focus paragraph by click editor or output of paragraph

### Screenshots (if appropriate)
![focus_new](https://cloud.githubusercontent.com/assets/1540981/12076866/70de1e08-b174-11e5-88d2-d51772befef7.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no