### PR TITLE
Add -Pscalding flag to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,17 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - mvn package -DskipTests -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
+  - mvn package -DskipTests -Pspark-1.5 -Phadoop-2.3 -Ppyspark -Pscalding -B
 
 before_script:
   -
 
 script:
  # spark 1.5
-  - mvn package -Pbuild-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
+  - mvn package -Pbuild-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -Pscalding -B
   - ./testing/startSparkCluster.sh 1.5.2 2.3
   - echo "export SPARK_HOME=`pwd`/spark-1.5.2-bin-hadoop2.3" > conf/zeppelin-env.sh
-  - mvn verify -Pusing-packaged-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -B
+  - mvn verify -Pusing-packaged-distr -Pspark-1.5 -Phadoop-2.3 -Ppyspark -Pscalding -B
   - ./testing/stopSparkCluster.sh 1.5.2 2.3
  # spark 1.4
   - rm -rf `pwd`/interpreter/spark


### PR DESCRIPTION
### What is this PR for?
Since we avoid publish official binary package built with 3rd party maven repository, currently we can not include [Scalding](https://github.com/apache/incubator-zeppelin/pull/561) dependency in binary package of Zeppelin. But the test for Scalding interpreter should be done in travis. So I just added `-Pscalding` flag to `.travis.yml` file.

### What type of PR is it?
Improvement

### Todos
* [x] - Add -Pscalding flag to .travis.yml.

### Is there a relevant Jira issue?
No. But you may checkout [here](https://github.com/apache/incubator-zeppelin/pull/561/files#r48471634).

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No