### PR TITLE
ZEPPELIN-314 + ZEPPELIN-562 ]  support  pyspark completion for python3

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -147,7 +147,7 @@ class PySparkCompletion:
         for completionItem in list(objectCompletionList):
           completionList.add(completionItem)
     if len(completionList) <= 0:
-      print ""
+      print ("")
     else:
       print json.dumps(filter(lambda x : not re.match("^__.*", x), list(completionList)))
 

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -111,7 +111,7 @@ class PySparkCompletion:
   def getGlobalCompletion(self):
     objectDefList = []
     try:
-      for completionItem in list(globals().iterkeys()):
+      for completionItem in list(globals().keys()):
         objectDefList.append(completionItem)
     except:
       return None
@@ -119,18 +119,20 @@ class PySparkCompletion:
       return objectDefList
 
   def getMethodCompletion(self, text_value):
-    objectDefList = []
+    execResult = locals()
+    if text_value == None:
+      return None
     completion_target = text_value
     try:
       if len(completion_target) <= 0:
         return None
       if text_value[-1] == ".":
         completion_target = text_value[:-1]
-      exec("%s = %s(%s)" % ("objectDefList", "dir", completion_target))
+      exec("{} = dir({})".format("objectDefList", completion_target), globals(), execResult)
     except:
       return None
     else:
-      return objectDefList
+      return list(execResult['objectDefList'])
 
 
   def getCompletion(self, text_value):
@@ -147,9 +149,9 @@ class PySparkCompletion:
         for completionItem in list(objectCompletionList):
           completionList.add(completionItem)
     if len(completionList) <= 0:
-      print ("")
+      print("")
     else:
-      print json.dumps(filter(lambda x : not re.match("^__.*", x), list(completionList)))
+      print(json.dumps(list(filter(lambda x : not re.match("^__.*", x), list(completionList)))))
 
 
 output = Logger()


### PR DESCRIPTION
### What is this PR for?
pyspark- completion function has been modified to work in python3 environment.

### What type of PR is it?
bug-fix, enhanced.

### Todos
* [x] - Change the code python3 support.

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-314
https://issues.apache.org/jira/browse/ZEPPELIN-562
(comment)
### How should this be tested?
pyspark - in python3 environment.
ex) Zeppelin interpreter page -> spark property -> zeppelin.pyspark.python = /usr/bin/python3
Use completion function (Shift + control + space).

### Screenshots (if appropriate)
![py3completion](https://cloud.githubusercontent.com/assets/10525473/12133185/8a921470-b3d7-11e5-82e0-554d9f51f4bc.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no