### PR TITLE
ZEPPELIN-563 ] revert add shadow nav. (invisible nav dropdown menu issue)

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -36,7 +36,6 @@ body.asIframe {
 }
 
 body .navbar {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   margin-bottom: 0;
 }
 

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -76,7 +76,7 @@
 
 .navbar-fixed-top,
 .navbar-fixed-top .dropdown-menu {
-  z-index: 2000;
+  z-index: 10002;
 }
 
 .noteAction {


### PR DESCRIPTION
### What is this PR for?
The nav Dropdown menu of Zeppelin invisible.
"You can not choose the create note reports, including in situations where the notebook.

Cause is due to having been lowered by the z-index 2000.

### What type of PR is it?
Hot Fix

### Todos
* [x] - Revert code (https://github.com/apache/incubator-zeppelin/pull/564)

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-563?jql=project%20%3D%20ZEPPELIN
### How should this be tested?
Outline the steps to test the PR here.
click to nav dropdown menu in notebook page.
### Screenshots (if appropriate)
<img width="233" alt="dropdown" src="https://cloud.githubusercontent.com/assets/10525473/12134100/bda5b476-b3e0-11e5-9121-f019e9021686.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no