### PR TITLE
[ZEPPELIN-572] pyspark interpreter doesn't work on yarn-client

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -334,6 +334,10 @@ public class SparkInterpreter extends Interpreter {
       conf.set("spark.submit.pyArchives", Joiner.on(":").join(pythonLibs));
     }
 
+    // Distributes needed libraries to workers.
+    if (getProperty("master").equals("yarn-client")) {
+      conf.set("spark.yarn.isPython", "true");
+    }
 
     SparkContext sparkContext = new SparkContext(conf);
     return sparkContext;


### PR DESCRIPTION
### What is this PR for?
Set `spark.yarn.isPython` to be `true` to distribute pyspark libraries to workers when master is `yarn-client`

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
[ZEPPELIN-572](https://issues.apache.org/jira/browse/ZEPPELIN-572)

### How should this be tested?
You need yarn cluster to test this PR.
Simple way to test this PR would be running below code in paragraph and see if it throws error.
```
%pyspark
print(sc.parallelize([1, 2]).count())
```
And you should be able to see that `spark.yarn.isPython` is set to `true` in **Spark UI > Environment > Spark Properties** only when you set spark.master as `yarn-client`.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No