### PR TITLE
Hotfix: Update maven-gpg-plugin and remove things failing deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -694,7 +694,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.4</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -709,15 +709,5 @@
       </build>
     </profile>
   </profiles>
-  <distributionManagement>
-    <site>
-      <id>Website</id>
-      <url>${site_url}</url>
-    </site>
-    <repository>
-      <id>${repoid}</id>
-      <name>${reponame}</name>
-      <url>${repourl}</url>
-    </repository>
-  </distributionManagement>
+
 </project>


### PR DESCRIPTION
This PR updates plugin GPG version as well as fix `mvn deploy` to play nice again with the release plugin.

This will enable to make a release again, using the [doc on wiki](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61335169)
