### PR TITLE
fix + paragraph appearing in link

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -66,7 +66,7 @@ limitations under the License.
        ng-Init="init(currentParagraph)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
        class="paragraph-col">
-    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly">
+    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe">
       <h4 class="plus-sign">&#43;</h4>
     </div>
     <div id="{{currentParagraph.id}}_paragraphColumn"
@@ -75,7 +75,7 @@ limitations under the License.
                     'lastEmptyParagraph': !paragraph.text && !paragraph.result}"
          ng-hide="currentParagraph.config.tableHide && viewOnly">
     </div>
-    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly">
+    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || asIframe ">
       <h4 class="plus-sign">&#43;</h4>
     </div>
   </div>


### PR DESCRIPTION
### What is this PR for?
Fix a bug where the + paragraph appears in link paragraph

### What type of PR is it?
Bug Fix

### Todos

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-591

### How should this be tested?
Click link paragraph in a paragraph and move mouse below paragraph.

### Screenshots (if appropriate)

Before: 
<img width="1424" alt="before" src="https://cloud.githubusercontent.com/assets/6380209/12211555/8c4ea0ce-b627-11e5-83fb-4d9273542bc8.png">

After: 
<img width="1416" alt="after" src="https://cloud.githubusercontent.com/assets/6380209/12211560/96642fa2-b627-11e5-90d0-f2381f1b3c24.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No