### PR TITLE
Change build profile in release script for binary package

### DIFF
--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -125,7 +125,7 @@ function make_binary_release() {
     rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
 }
 
-make_binary_release all "-Pspark-1.5 -Phadoop-2.4 -Pyarn -Ppyspark"
+make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
 
 # remove non release files and dirs
 rm -rf ${WORKING_DIR}/zeppelin


### PR DESCRIPTION
### What is this PR for?
Change embedded Spark dependency in binary package for the release from 1.5 to 1.6.

### What type of PR is it?
Improvement

### Todos

### Is there a relevant Jira issue?

### How should this be tested?
build package using dev/create_release.sh and run created package with default configuration. And see output of 'sc.version' if it is based on spark 1.6

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no