### PR TITLE
fix for "The git-clone command failed."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -717,6 +717,18 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.2.2</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-plugin</artifactId>
+                <version>1.8.1</version>
+              </dependency>
+            </dependencies>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
### What is this PR for?
This PR is fix for https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61335169#PreparingZeppelinRelease(Draft)-Bumpupversion,createtaganduploadmavenartifacttostagingrepo
`mvn -DperformRelease=true release:perform -Darguments="-DskipTests -Dgpg.passphrase=..." -Dtag=v0.6.0 -DreleaseVersion=0.6.0-incubating -DdevelopmentVersion=0.6.1-incubating-SNAPSHOT -DpushChanges=false -DconnectionUrl=scm:git:https://github.com/[your forked repo]/incubator-zeppelin.git` 

https://github.com/apache/incubator-zeppelin/pull/612 where the above command fails with following error.
    
    [INFO] Checking out the project to perform the release ...
    [INFO] Executing: /bin/sh -c cd /Users/[user-directory]/incubator-zeppelin/target && git clone --branch https://github.com/[your forked repo]/incubator-zeppelin.git /Users/[user-directory]/incubator-zeppelin/target/checkout
    [INFO] Working directory: /Users/[user-directory]/incubator-zeppelin/target
    [ERROR] The git-clone command failed.

### What type of PR is it?
Fix 

### Is there a relevant Jira issue?
N/A

