### PR TITLE
ZEPPELIN-558 ] that is missing on geode travis build test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - mvn package -DskipTests -Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding -B
+  - mvn package -DskipTests -Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding -Pgeode -B
 
 before_script:
   -
 
 script:
  # spark 1.6
-  - mvn package -Pbuild-distr -Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding -B
+  - mvn package -Pbuild-distr -Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding -Pgeode -B
   - ./testing/startSparkCluster.sh 1.6.0 2.3
   - echo "export SPARK_HOME=`pwd`/spark-1.6.0-bin-hadoop2.3" > conf/zeppelin-env.sh
   - mvn verify -Pusing-packaged-distr -Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding -B


### PR DESCRIPTION
The newly created PR for the previous pr.
https://github.com/apache/incubator-zeppelin/pull/599

### What is this PR for?
Zeppelin supports geode interpreter.
However, for this test environment it is not reflected in Travis.

I added a geode for travis test environment. (only build test)

### What type of PR is it?
Improvement

### Todos
* [x] - Add geode build on .travis

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-558
### How should this be tested?
only travis.
and 
added geode interpreter for travis.

### Screenshots (if appropriate)
no
### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no