### PR TITLE
[ZEPPELIN-489] Getting a java.lang.OutOfMemoryError: PermGen space in maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ sudo ln -s /usr/local/apache-maven-3.3.3/bin/mvn /usr/local/bin/mvn
 _Notes:_ 
  - Ensure node is installed by running `node --version`  
  - Ensure maven is running version 3.1.x or higher with `mvn -version`
+ - Configure maven to use more memory than usual by ```export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=1024m"```
 
 ### Build
 If you want to build Zeppelin from the source, please first clone this repository, then:


### PR DESCRIPTION
### What is this PR for?
Add note for configuring maven memory setting to prevent the lack of PermGen space

### What type of PR is it?
[Documentation]


### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-489

### How should this be tested?
Just check the ```README.md```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No