### PR TITLE
Pass defaultValue parameter to z.select

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -220,7 +220,7 @@ public class ZeppelinContext extends HashMap<String, Object> {
       paramOptions[i++] = new ParamOption(valueAndDisplayValue._1(), valueAndDisplayValue._2());
     }
 
-    return gui.select(name, "", paramOptions);
+    return gui.select(name, defaultValue, paramOptions);
   }
 
   public void setGui(GUI o) {


### PR DESCRIPTION
### What is this PR for?
This PR is to fix the `z.select()` defaultValue

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-581

### How should this be tested?
If you run:
```
val selected = z.select("formName", "option1", Seq(("option1", "option1DisplayName"), ("option2", "option2DisplayName")))
println(selected)
```
you should see: `res27: Object = option1`

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No