### PR TITLE
Remove paragraph title capitalization style from css

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -202,7 +202,6 @@
   font-weight: bold;
   font-family: 'Roboto', sans-serif;
   font-size: 17px !important;
-  text-transform: capitalize;
 }
 
 .paragraph .title input {
@@ -215,7 +214,6 @@
   border-radius: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-  text-transform: capitalize;
   font-family: 'Roboto', sans-serif;
   font-size: 17px !important;
   font-weight: bold;


### PR DESCRIPTION
### What is this PR for?
Remove paragraph title font capitalization style from css.

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
No but there is relavant mail in [user mailing list](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/201601.mbox/%3CCAC-WUu3on2mtf1jE1QZL%3D48PP4eNrsvQp2TxRrRMhg6net0AFw%40mail.gmail.com%3E)

### How should this be tested?
Open notebook, click 'show title' in paragraph control panel dropdown menu, type any paragraph title, and check if the title is capitalized by itself

### Screenshots (if appropriate)
**Before**
<img width="734" alt="screen shot 2016-01-12 at 3 02 55 pm" src="https://cloud.githubusercontent.com/assets/8503346/12279772/0b8306d2-b93e-11e5-80e1-e618f14774a2.png">

**After**
<img width="734" alt="screen shot 2016-01-12 at 3 02 58 pm" src="https://cloud.githubusercontent.com/assets/8503346/12279780/16d605ac-b93e-11e5-9671-aca8ab5f8783.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No