### PR TITLE
Restore Navbar connection status for websocket only

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -184,7 +184,7 @@ a.navbar-brand:hover {
 
 .server-status {
   font-size: 12px;
-  margin-top: 6px;
+  margin-top: 8px;
 }
 
 .server-connected {

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -23,7 +23,6 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   vm.connected = websocketMsgSrv.isConnected();
   vm.websocketMsgSrv = websocketMsgSrv;
   vm.arrayOrderingSrv = arrayOrderingSrv;
-  vm.authenticated = $rootScope.ticket.principal !== 'anonymous';
 
   angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
@@ -51,8 +50,6 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   function loadNotes() {
     websocketMsgSrv.getNotebookList();
   }
-
-  vm.authenticated = $rootScope.ticket.principal !== 'anonymous';
 
   function isActive(noteId) {
     return ($routeParams.noteId === noteId);

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -73,8 +73,8 @@ limitations under the License.
         </li>
         <li class="server-status">
           <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-          <span ng-show="navbar.authenticated">{{ticket.principal}} connected</span>
-          <span ng-show="!navbar.authenticated">Disconnected</span>
+          <span ng-show="navbar.connected">Connected</span>
+          <span ng-show="!navbar.connected">Disconnected</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
### What is this PR for?
After the Shiro PR was merged, the Navbar status was changed to include the token status/name, however that part is reserved to show the Websocket status. Because of that it usually show a green circle with Disconnected next to it.
This PR sets the status to Websocket only.

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
No

### How should this be tested?
You shouldn't see see Disconnected next to a green round in the navbar anymore

### Screenshots (if appropriate)
Bug:
<img width="386" alt="screen shot 2016-01-13 at 12 02 24 pm" src="https://cloud.githubusercontent.com/assets/6766992/12283801/927d05e8-b9ed-11e5-8911-9725b4a7c94a.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No