### PR TITLE
fix logging to informative one

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -78,7 +78,7 @@ public class NotebookRepoSync implements NotebookRepo {
       } catch (ClassNotFoundException | NoSuchMethodException | SecurityException |
           InstantiationException | IllegalAccessException | IllegalArgumentException |
           InvocationTargetException e) {
-        LOG.warn("Failed to initialize {} notebook storage class {}", storageClassNames[i], e);
+        LOG.warn("Failed to initialize {} notebook storage class", storageClassNames[i], e);
       }
     }
     // couldn't initialize any storage, use default


### PR DESCRIPTION
### What is this PR for?
Improving logging information on error

### What type of PR is it?
Fix/Improvement

### Todos
* [x] - fix logging 

### Is there a relevant Jira issue?
May not require issue

### How should this be tested?
Can be tested with any error for storage initialization
For example:
1. in `conf/zeppelin-env.sh` add the following line
    ```
    export ZEPPELIN_NOTEBOOK_STORAGE="org.apache.zeppelin.notebook.repo.VFSNotebookRepo,org.apache.zeppelin.notebook.repo.DummyNotebookRepo"
    ```
2. Start Zeppelin
3. Previously you would see one line warning, now you would see more detailed trace-back as well.

### Screenshots (if appropriate)
Before: 
```
Failed to initialize com.nflabs.zeppelinhub.notebook.repo.DummyNotebookRepo notebook storage class java.lang.reflect.InvocationTargetException
```
After:
```
WARN [2016-01-13 22:43:05,557] ({main} NotebookRepoSync.java[<init>]:81) - Failed to initialize com.nflabs.zeppelinhub.notebook.repo.DummyNotebookRepo notebook storage class
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
```
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No