### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
       </dependency>
 
       <dependency>
+        <groupId>sqlline</groupId>
+        <artifactId>sqlline</artifactId>
+        <version>1.1.9</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.3.6</version>


### PR DESCRIPTION
### What is this PR for?
improving pom.xml

### What type of PR is it
Improvement

### Todos
* [x] - Update pom.xml

### Is there a relevant Jira issue?
May not require issue

### How should this be tested?
I use ```mvn clean package -Pspark-1.4 -Phadoop-2.6 -DskipTests``` can cause error and I think this should not appear. Reason about this issue is sqlline:sqlline:jar:1.1.8 is served from conjar repo. But sqlline:sqlline:jar:1.1.9 is served from maven repo. So add the dependency of sqlline1.1.9 can solve it.

### Screenshots (if appropriate)
Before
```BUILD FAILURE```

When you add this dependency
After 
```
[INFO] Zeppelin: Kylin interpreter ........................ SUCCESS [  0.511 s]
[INFO] Zeppelin: Lens interpreter ......................... SUCCESS [  1.303 s]
[INFO] Zeppelin: Cassandra ................................ SUCCESS [ 33.777 s]
[INFO] Zeppelin: Elasticsearch interpreter ................ SUCCESS [  1.631 s]
[INFO] Zeppelin: web Application .......................... SUCCESS [ 55.796 s]
[INFO] Zeppelin: Server ................................... SUCCESS [ 11.737 s]
[INFO] Zeppelin: Packaging distribution ................... SUCCESS [  0.665 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No