### PR TITLE
small change to have error in multiline

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -45,7 +45,7 @@ limitations under the License.
   </img>
 
   <div id="{{paragraph.id}}_error"
-       class="error"
+       class="error text"
        ng-if="paragraph.status == 'ERROR'"
        ng-bind="paragraph.errorMessage">
   </div>


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Have error output in multiline

### Is there a relevant Jira issue?
N/A

### How should this be tested?
Run something that will output in error, for example try running "asdf" with spark interpreter

### Screenshots (if appropriate)
Before:
<img width="1439" alt="screen shot 2016-01-15 at 12 52 24 pm" src="https://cloud.githubusercontent.com/assets/674497/12349221/f7ca1f4c-bb93-11e5-8fc9-04c06abf62ea.png">


After:
<img width="1429" alt="screen shot 2016-01-15 at 12 52 10 pm" src="https://cloud.githubusercontent.com/assets/674497/12349220/f7c834ca-bb93-11e5-8823-e316152f64b4.png">
