### PR TITLE
Travis build fix

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteInterpreterLoaderTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteInterpreterLoaderTest.java
@@ -64,6 +64,7 @@ public class NoteInterpreterLoaderTest {
   @After
   public void tearDown() throws Exception {
     delete(tmpDir);
+    Interpreter.registeredInterpreters.clear();
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -71,7 +71,7 @@ public class NotebookTest implements JobListenerFactory{
     tmpDir = new File(System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis());
     tmpDir.mkdirs();
     new File(tmpDir, "conf").mkdirs();
-    notebookDir = new File(System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis()+"/notebook");
+    notebookDir = new File(tmpDir + "/notebook");
     notebookDir.mkdirs();
 
     System.setProperty(ConfVars.ZEPPELIN_HOME.getVarName(), tmpDir.getAbsolutePath());


### PR DESCRIPTION
### What is this PR for?
A lot of time travis fails with 

    Tests run: 11, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 4.77 sec <<< FAILURE! - in org.apache.zeppelin.notebook.NotebookTest
    testSelectingReplImplementation(org.apache.zeppelin.notebook.NotebookTest)  Time elapsed: 0.025 sec  <<< ERROR!
    org.apache.zeppelin.interpreter.InterpreterException: mock2 interpreter not found
    	at org.apache.zeppelin.notebook.NoteInterpreterLoader.get(NoteInterpreterLoader.java:148)
    	at org.apache.zeppelin.notebook.Note.run(Note.java:365)
    	at org.apache.zeppelin.notebook.NotebookTest.testSelectingReplImplementation(NotebookTest.java:119)
    
    .
    .
    .
    .
    
    Tests in error: 
      NotebookTest.testSelectingReplImplementation:119 Â» Interpreter mock2 interpret...


This is fix for that error, this doesn't happens always. But here is a lot when this failed last time. https://s3.amazonaws.com/archive.travis-ci.org/jobs/102172625/log.txt

### What type of PR is it?
Improvement

### Todos
* [x] - Clear registered interpreters after a test case is executed.

### Is there a relevant Jira issue?
N/A

