### PR TITLE
keyboard shortcut to add above

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -796,8 +796,10 @@ angular.module('zeppelinWebApp')
         $scope.moveUp();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 74) { // Ctrl + Alt + j
         $scope.moveDown();
+      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 78) { // Ctrl + Alt + n
+        $scope.insertNew('above');
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 66) { // Ctrl + Alt + b
-        $scope.insertNew();
+        $scope.insertNew('below');
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 79) { // Ctrl + Alt + o
         $scope.toggleOutput();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 69) { // Ctrl + Alt + e

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -796,7 +796,7 @@ angular.module('zeppelinWebApp')
         $scope.moveUp();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 74) { // Ctrl + Alt + j
         $scope.moveDown();
-      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 78) { // Ctrl + Alt + n
+      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 65) { // Ctrl + Alt + a
         $scope.insertNew('above');
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 66) { // Ctrl + Alt + b
         $scope.insertNew('below');

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -81,6 +81,17 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">n</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Insert new paragraph above
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">b</kbd>
             </div>
           </div>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -81,7 +81,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">n</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">a</kbd>
             </div>
           </div>
           <div class="col-md-8">


### PR DESCRIPTION
### What is this PR for?
add a keyboard shortcut to add paragraph above to keep difference with previous add paragraph below

### What type of PR is it?
Improvement

### Todos

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-611

### How should this be tested?
click into a paragraph and press ctrl+alt+n

### Screenshots (if appropriate)
![after](https://cloud.githubusercontent.com/assets/6380209/12357983/aa3be418-bb70-11e5-966d-1d63317c42bf.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no