### PR TITLE
ZEPPELIN-612 Introduce 'Configuration' page with WebSocket API / REST API

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -76,6 +76,7 @@
                 <!-- li><span><b>REST API</b><span></li -->
                 <li><a href="{{BASE_PATH}}/rest-api/rest-interpreter.html">Interpreter API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-notebook.html">Notebook API</a></li>
+                <li><a href="{{BASE_PATH}}/rest-api/rest-configuration.html">Configuration API</a></li>
                 <li role="separator" class="divider"></li>
                 <!-- li><span><b>Development</b><span></li -->
                 <li><a href="{{BASE_PATH}}/development/writingzeppelininterpreter.html">Writing Zeppelin Interpreter</a></li>

--- a/docs/rest-api/rest-configuration.md
+++ b/docs/rest-api/rest-configuration.md
@@ -24,7 +24,7 @@ limitations under the License.
  
  All REST API are available starting with the following endpoint ```http://[zeppelin-server]:[zeppelin-port]/api```
  
- Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON view such as 
+ Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON viewers such as 
  [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)
  
  

--- a/docs/rest-api/rest-configuration.md
+++ b/docs/rest-api/rest-configuration.md
@@ -1,0 +1,143 @@
+---
+layout: page
+title: "Configuration REST API"
+description: ""
+group: rest-api
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+## Zeppelin REST API
+ Zeppelin provides several REST API's for interaction and remote activation of zeppelin functionality.
+ 
+ All REST API are available starting with the following endpoint ```http://[zeppelin-server]:[zeppelin-port]/api```
+ 
+ Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON view such as 
+ [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)
+ 
+ 
+ If you work with zeppelin and find a need for an additional REST API please [file an issue or send us mail](../../community.html) 
+
+ <br />
+### Configuration REST API list
+  
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>List configurations</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method return all key/value pair of configurations on the server. 
+      Note: For security reason, some pairs would not be shown.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/configurations/all```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{  
+   "status":"OK",
+   "message":"",
+   "body":{  
+      "zeppelin.war.tempdir":"webapps",
+      "zeppelin.notebook.homescreen.hide":"false",
+      "zeppelin.interpreter.remoterunner":"bin/interpreter.sh",
+      "zeppelin.notebook.s3.user":"user",
+      "zeppelin.server.port":"8089",
+      "zeppelin.dep.localrepo":"local-repo",
+      "zeppelin.ssl.truststore.type":"JKS",
+      "zeppelin.ssl.keystore.path":"keystore",
+      "zeppelin.notebook.s3.bucket":"zeppelin",
+      "zeppelin.server.addr":"0.0.0.0",
+      "zeppelin.ssl.client.auth":"false",
+      "zeppelin.server.context.path":"/",
+      "zeppelin.ssl.keystore.type":"JKS",
+      "zeppelin.ssl.truststore.path":"truststore",
+      "zeppelin.interpreters":"org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter,org.apache.zeppelin.phoenix.PhoenixInterpreter,org.apache.zeppelin.kylin.KylinInterpreter,org.apache.zeppelin.elasticsearch.ElasticsearchInterpreter,org.apache.zeppelin.scalding.ScaldingInterpreter",
+      "zeppelin.ssl":"false",
+      "zeppelin.notebook.autoInterpreterBinding":"true",
+      "zeppelin.notebook.homescreen":"",
+      "zeppelin.notebook.storage":"org.apache.zeppelin.notebook.repo.VFSNotebookRepo",
+      "zeppelin.interpreter.connect.timeout":"30000",
+      "zeppelin.anonymous.allowed":"true",
+      "zeppelin.server.allowed.origins":"*",
+      "zeppelin.encoding":"UTF-8"
+   }
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+  
+<br/>
+   
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <th>List configurations (prefix match)</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method return all prefix matched key/value pair of configurations on the server. 
+      Note: For security reason, some pairs would not be shown.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/configurations/prefix/[prefix]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{  
+   "status":"OK",
+   "message":"",
+   "body":{  
+      "zeppelin.ssl.keystore.type":"JKS",
+      "zeppelin.ssl.truststore.path":"truststore",
+      "zeppelin.ssl.truststore.type":"JKS",
+      "zeppelin.ssl.keystore.path":"keystore",
+      "zeppelin.ssl":"false",
+      "zeppelin.ssl.client.auth":"false"
+   }
+}
+        </pre>
+      </td>
+    </tr>
+  </table>

--- a/docs/rest-api/rest-configuration.md
+++ b/docs/rest-api/rest-configuration.md
@@ -41,7 +41,7 @@ limitations under the License.
     </tr>
     <tr>
       <td>Description</td>
-      <td>This ```GET``` method return all key/value pair of configurations on the server. 
+      <td>This ```GET``` method return all key/value pair of configurations on the server.<br/> 
       Note: For security reason, some pairs would not be shown.</td>
     </tr>
     <tr>
@@ -105,7 +105,7 @@ limitations under the License.
     </tr>
     <tr>
       <td>Description</td>
-      <td>This ```GET``` method return all prefix matched key/value pair of configurations on the server. 
+      <td>This ```GET``` method return all prefix matched key/value pair of configurations on the server.<br/> 
       Note: For security reason, some pairs would not be shown.</td>
     </tr>
     <tr>

--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -23,9 +23,8 @@ limitations under the License.
  Zeppelin provides several REST API's for interaction and remote activation of zeppelin functionality.
  
  All REST API are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`.
- Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON view such as 
+ Note that zeppein REST API receive or return JSON objects, it it recommended you install some JSON viewers such as 
  [JSON View](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
- 
  
  If you work with zeppelin and find a need for an additional REST API, please [file an issue or send us mail](http://zeppelin.incubator.apache.org/community.html). 
 

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -24,7 +24,7 @@ limitations under the License.
  
  All REST APIs are available starting with the following endpoint ```http://[zeppelin-server]:[zeppelin-port]/api```
  
- Note that zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewer
+ Note that zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers
   such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc)
  
  

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.server.JsonResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.Map;
+
+/**
+ * Configurations Rest API Endpoint
+ */
+@Path("/configurations")
+@Produces("application/json")
+public class ConfigurationsRestApi {
+
+  private Notebook notebook;
+
+  public ConfigurationsRestApi() {}
+
+  public ConfigurationsRestApi(Notebook notebook) {
+    this.notebook = notebook;
+  }
+
+  @GET
+  @Path("all")
+  public Response getAll() {
+    ZeppelinConfiguration conf = notebook.getConf();
+
+    Map<String, String> configurations = conf.dumpConfigurations(conf,
+        new ZeppelinConfiguration.ConfigurationKeyPredicate() {
+        @Override
+        public boolean apply(String key) {
+          return !key.contains("password");
+        }
+      }
+    );
+
+    return new JsonResponse(Status.OK, "", configurations).build();
+  }
+
+  @GET
+  @Path("prefix/{prefix}")
+  public Response getByPrefix(@PathParam("prefix") final String prefix) {
+    ZeppelinConfiguration conf = notebook.getConf();
+
+    Map<String, String> configurations = conf.dumpConfigurations(conf,
+        new ZeppelinConfiguration.ConfigurationKeyPredicate() {
+        @Override
+        public boolean apply(String key) {
+          return !key.contains("password") && key.startsWith(prefix);
+        }
+      }
+    );
+
+    return new JsonResponse(Status.OK, "", configurations).build();
+  }
+
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -35,10 +35,7 @@ import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
-import org.apache.zeppelin.rest.InterpreterRestApi;
-import org.apache.zeppelin.rest.NotebookRestApi;
-import org.apache.zeppelin.rest.SecurityRestApi;
-import org.apache.zeppelin.rest.ZeppelinRestApi;
+import org.apache.zeppelin.rest.*;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.search.LuceneSearch;
@@ -287,6 +284,9 @@ public class ZeppelinServer extends Application {
 
     SecurityRestApi securityApi = new SecurityRestApi();
     singletons.add(securityApi);
+
+    ConfigurationsRestApi settingsApi = new ConfigurationsRestApi(notebook);
+    singletons.add(settingsApi);
 
     return singletons;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
@@ -100,7 +100,11 @@ public class Message {
     ANGULAR_OBJECT_UPDATE,  // [s-c] add/update angular object
     ANGULAR_OBJECT_REMOVE,  // [s-c] add angular object del
 
-    ANGULAR_OBJECT_UPDATED  // [c-s] angular object value updated
+    ANGULAR_OBJECT_UPDATED,  // [c-s] angular object value updated,
+
+    LIST_CONFIGURATIONS, // [c-s] ask all key/value pairs of configurations
+    CONFIGURATIONS_INFO // [s-c] all key/value pairs of configurations
+                  // @param settings serialized Map<String, String> object
   }
 
   public OP op;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -168,6 +168,9 @@ public class NotebookServer extends WebSocketServlet implements
           case ANGULAR_OBJECT_UPDATED:
             angularObjectUpdated(conn, notebook, messagereceived);
             break;
+          case LIST_CONFIGURATIONS:
+            sendAllConfigurations(conn, notebook);
+            break;
           default:
             broadcastNoteList();
             break;
@@ -746,6 +749,22 @@ public class NotebookServer extends WebSocketServlet implements
         p.setStatus(Status.ERROR);
       }
     }
+  }
+
+  private void sendAllConfigurations(NotebookSocket conn, Notebook notebook)
+      throws IOException {
+    ZeppelinConfiguration conf = notebook.getConf();
+
+    Map<String, String> configurations = conf.dumpConfigurations(conf,
+        new ZeppelinConfiguration.ConfigurationKeyPredicate() {
+          @Override
+          public boolean apply(String key) {
+            return !key.contains("password");
+          }
+        });
+
+    conn.send(serializeMessage(new Message(OP.CONFIGURATIONS_INFO)
+        .put("configurations", configurations)));
   }
 
   /**

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.rest;
 
 import com.google.common.base.Predicate;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
@@ -1,0 +1,63 @@
+package org.apache.zeppelin.rest;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationsRestApiTest extends AbstractTestRestApi {
+  Gson gson = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    AbstractTestRestApi.startUp();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+
+  @Test
+  public void testGetAll() throws IOException {
+    GetMethod get = httpGet("/configurations/all");
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+        new TypeToken<Map<String, Object>>(){}.getType());
+    Map<String, String> body = (Map<String, String>) resp.get("body");
+    assertTrue(body.size() > 0);
+    // it shouldn't have key/value pair which key contains "password"
+    assertTrue(Iterators.all(body.keySet().iterator(), new Predicate<String>() {
+        @Override
+        public boolean apply(String key) {
+          return !key.contains("password");
+        }
+      }
+    ));
+  }
+
+  @Test
+  public void testGetViaPrefix() throws IOException {
+    final String prefix = "zeppelin.server";
+    GetMethod get = httpGet("/configurations/prefix/" + prefix);
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+        new TypeToken<Map<String, Object>>(){}.getType());
+    Map<String, String> body = (Map<String, String>) resp.get("body");
+    assertTrue(body.size() > 0);
+    assertTrue(Iterators.all(body.keySet().iterator(), new Predicate<String>() {
+          @Override
+          public boolean apply(String key) {
+            return !key.contains("password") && key.startsWith(prefix);
+          }
+        }
+    ));
+  }
+}

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -66,6 +66,10 @@
                     templateUrl: 'app/interpreter/interpreter.html',
                     controller: 'InterpreterCtrl'
                 })
+                .when('/configuration', {
+                  templateUrl: 'app/configuration/configuration.html',
+                  controller: 'ConfigurationCtrl'
+                })
                 .when('/search/:searchTerm', {
                     templateUrl: 'app/search/result-list.html',
                     controller: 'SearchResultCtrl'

--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('zeppelinWebApp').controller('ConfigurationCtrl', function($scope, $route, $routeParams, $location,
+                                                                          $rootScope, $http, baseUrlSrv) {
+  $scope.configrations = [];
+  $scope._ = _;
+
+  var getConfigurations = function() {
+    $http.get(baseUrlSrv.getRestApiBase()+'/configurations/all').
+    success(function(data, status, headers, config) {
+      $scope.configurations = data.body;
+    }).
+    error(function(data, status, headers, config) {
+      console.log('Error %o %o', status, data.message);
+    });
+  };
+
+  var init = function() {
+    getConfigurations();
+  };
+
+  init();
+});

--- a/zeppelin-web/src/app/configuration/configuration.css
+++ b/zeppelin-web/src/app/configuration/configuration.css
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.configurationHead {
+  margin: -10px -10px 20px;
+  padding: 10px 15px 15px 15px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  border-bottom: 1px solid #E5E5E5;
+}
+
+.configurationHead .header {
+  font-family: 'Roboto', sans-serif;
+}
+
+.configuration .configuration-title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #3071a9;
+  float: left;
+  margin-top: 0;
+}
+
+.configuration ul {
+  margin: 0;
+  padding: 0;
+}
+
+.configuration .configurationInfo {
+  list-style-type: none;
+}
+
+.configuration table tr .configurationPropertyKey {
+  padding : 5px 5px 5px 5px;
+}
+
+.configuration table tr .configurationPropertyValue {
+  padding : 5px 5px 5px 5px;
+  display: block;
+  max-height: 100px;
+  overflow-y: auto;
+}
+
+.configuration h5 {
+  font-weight: bold;
+}
+
+.new_h3 {
+  margin-top: 1px;
+  padding-top: 7px;
+  float: left;
+}

--- a/zeppelin-web/src/app/configuration/configuration.css
+++ b/zeppelin-web/src/app/configuration/configuration.css
@@ -43,7 +43,6 @@
 
 .configuration table {
   table-layout: fixed;
-  width: 100%;
 }
 
 .configuration table tr .configurationPropertyKey {
@@ -68,7 +67,5 @@
 }
 
 .hiding_overflow {
-  overflow:hidden;
-  white-space:nowrap;
-  text-overflow:ellipsis;
+  overflow:auto;
 }

--- a/zeppelin-web/src/app/configuration/configuration.css
+++ b/zeppelin-web/src/app/configuration/configuration.css
@@ -41,6 +41,11 @@
   list-style-type: none;
 }
 
+.configuration table {
+  table-layout: fixed;
+  width: 100%;
+}
+
 .configuration table tr .configurationPropertyKey {
   padding : 5px 5px 5px 5px;
 }
@@ -60,4 +65,10 @@
   margin-top: 1px;
   padding-top: 7px;
   float: left;
+}
+
+.hiding_overflow {
+  overflow:hidden;
+  white-space:nowrap;
+  text-overflow:ellipsis;
 }

--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -1,0 +1,50 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div class="configurationHead">
+  <div class="header">
+    <div class="row">
+      <div class="col-md-12">
+        <h3 class="new_h3">
+          Configurations
+        </h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        Shows current configurations for Zeppelin Server.
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="box width-full home">
+  <div>
+    <div class="row configuration">
+      <div class="col-md-12">
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th style="width:30%">name</th>
+            <th>value</th>
+          </tr>
+          </thead>
+          <tr ng-repeat="(key, value) in configurations" >
+            <td>{{key}}</td>
+            <td>{{value}}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -22,7 +22,8 @@ limitations under the License.
     </div>
     <div class="row">
       <div class="col-md-12">
-        Shows current configurations for Zeppelin Server.
+        Shows current configurations for Zeppelin Server.<br/>
+        Note: For security reasons, some key/value pairs including passwords would not be shown.
       </div>
     </div>
   </div>

--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -36,12 +36,16 @@ limitations under the License.
           <thead>
           <tr>
             <th style="width:30%">name</th>
-            <th>value</th>
+            <th style="width:70%">value</th>
           </tr>
           </thead>
           <tr ng-repeat="(key, value) in configurations" >
             <td>{{key}}</td>
-            <td>{{value}}</td>
+            <td>
+              <div class="hiding_overflow">
+                {{value}}
+              </div>
+            </td>
           </tr>
         </table>
       </div>

--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -36,7 +36,7 @@ limitations under the License.
           <thead>
           <tr>
             <th style="width:30%">name</th>
-            <th style="width:70%">value</th>
+            <th>value</th>
           </tr>
           </thead>
           <tr ng-repeat="(key, value) in configurations" >

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -42,6 +42,9 @@ limitations under the License.
         <li>
           <a href="#/interpreter">Interpreter</a>
         </li>
+        <li>
+          <a href="#/configuration">Configuration</a>
+        </li>
       </ul>
 
 

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -134,6 +134,7 @@ limitations under the License.
     <script src="app/home/home.controller.js"></script>
     <script src="app/notebook/notebook.controller.js"></script>
     <script src="app/interpreter/interpreter.controller.js"></script>
+    <script src="app/configuration/configuration.controller.js"></script>
     <script src="app/notebook/paragraph/paragraph.controller.js"></script>
     <script src="app/search/result-list.controller.js"></script>
     <script src="components/arrayOrderingSrv/arrayOrdering.service.js"></script>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -53,6 +53,7 @@ limitations under the License.
     <link rel="stylesheet" href="app/notebook/notebook.css">
     <link rel="stylesheet" href="app/notebook/paragraph/paragraph.css">
     <link rel="stylesheet" href="app/interpreter/interpreter.css">
+    <link rel="stylesheet" href="app/configuration/configuration.css">
     <link rel="stylesheet" href="fonts/font-awesome.min.css">
     <link rel="stylesheet" href="fonts/simple-line-icons.css">
     <link rel="stylesheet" href="fonts/custom-font.css">

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ConfigurationKeyPredicate.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ConfigurationKeyPredicate.java
@@ -1,2 +1,0 @@
-package org.apache.zeppelin.conf;
-

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ConfigurationKeyPredicate.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ConfigurationKeyPredicate.java
@@ -1,0 +1,2 @@
+package org.apache.zeppelin.conf;
+

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -19,7 +19,9 @@ package org.apache.zeppelin.conf;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
@@ -373,6 +375,44 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return Arrays.asList(getString(ConfVars.ZEPPELIN_ALLOWED_ORIGINS).toLowerCase().split(","));
   }
 
+  public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
+                                                ConfigurationKeyPredicate predicate) {
+    Map<String, String> configurations = new HashMap<>();
+
+    for (ZeppelinConfiguration.ConfVars v : ZeppelinConfiguration.ConfVars.values()) {
+      String key = v.getVarName();
+
+      if (!predicate.apply(key)) {
+        continue;
+      }
+
+      ConfVars.VarType type = v.getType();
+      Object value = null;
+      if (type == ConfVars.VarType.BOOLEAN) {
+        value = conf.getBoolean(v);
+      } else if (type == ConfVars.VarType.LONG) {
+        value = conf.getLong(v);
+      } else if (type == ConfVars.VarType.INT) {
+        value = conf.getInt(v);
+      } else if (type == ConfVars.VarType.FLOAT) {
+        value = conf.getFloat(v);
+      } else if (type == ConfVars.VarType.STRING) {
+        value = conf.getString(v);
+      }
+
+      if (value != null) {
+        configurations.put(key, value.toString());
+      }
+    }
+    return configurations;
+  }
+
+  /**
+   * Predication whether key/value pair should be included or not
+   */
+  public interface ConfigurationKeyPredicate {
+    boolean apply(String key);
+  }
 
   /**
    * Wrapper class.


### PR DESCRIPTION
### What is this PR for?

To introduce 'Configuration' page to Zeppelin GUI. Also introduce REST API / WebSocket operation.

### What type of PR is it?

Feature

### Todos

### Is there a relevant Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-612

### How should this be tested?

- apply this PR
- build and start Zeppelin
- open UI and confirm Configuration tab is shown
- open Configuration page and confirm every configurations (properties) except password are shown

### Screenshots (if appropriate)

![configuration-screenshot](https://cloud.githubusercontent.com/assets/1317309/12372880/e679a282-bca9-11e5-97ee-8ab18e03a864.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, I've address it regarding REST API.