### PR TITLE
ZEPPELIN-602 elasticsearch throws ArrayIndexOutOfBoundsException 

### DIFF
--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -141,6 +141,10 @@ public class ElasticsearchInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext interpreterContext) {
     logger.info("Run Elasticsearch command '" + cmd + "'");
+    
+    if (StringUtils.isEmpty(cmd)) {
+      return new InterpreterResult(Code.SUCCESS);
+    }
 
     int currentResultSize = resultSize;
 

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -141,8 +141,8 @@ public class ElasticsearchInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext interpreterContext) {
     logger.info("Run Elasticsearch command '" + cmd + "'");
-    
-    if (StringUtils.isEmpty(cmd)) {
+ 
+    if (StringUtils.isEmpty(cmd) || StringUtils.isEmpty(cmd.trim())) {
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     }
 

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -143,7 +143,7 @@ public class ElasticsearchInterpreter extends Interpreter {
     logger.info("Run Elasticsearch command '" + cmd + "'");
     
     if (StringUtils.isEmpty(cmd)) {
-      return new InterpreterResult(Code.SUCCESS);
+      return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     }
 
     int currentResultSize = resultSize;

--- a/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
+++ b/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
@@ -198,4 +198,14 @@ public class ElasticsearchInterpreterTest {
     assertEquals("11", res.message());
   }
 
+  @Test
+  public void testMisc() {
+
+    InterpreterResult res = interpreter.interpret(null, null);
+    assertEquals(Code.SUCCESS, res.code());
+
+    res = interpreter.interpret("   \n \n ", null);
+    assertEquals(Code.SUCCESS, res.code());
+  }
+
 }


### PR DESCRIPTION
### What is this PR for?
Fix for https://issues.apache.org/jira/browse/ZEPPELIN-602
"elasticsearch throws ArrayIndexOutOfBoundsException for interpreting an empty paragraph"

### What type of PR is it?
Bug Fix

### Todos
* [X] - Code : check cmd parameter 

### Is there a relevant Jira issue?
ZEPPELIN-602

### How should this be tested?
Start elasticsearch interpreter with an empty paragraph

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO