### PR TITLE
Fix a Link for 'User Guide' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Zeppelin 
 
-**Documentation:** [User Guide](http://zeppelin.incubator.apache.org/docs/index.html)<br/>
+**Documentation:** [User Guide](http://zeppelin.incubator.apache.org/docs/latest/index.html)<br/>
 **Mailing Lists:** [User and Dev mailing list](http://zeppelin.incubator.apache.org/community.html)<br/>
 **Continuous Integration:** [![Build Status](https://secure.travis-ci.org/apache/incubator-zeppelin.png?branch=master)](https://travis-ci.org/apache/incubator-zeppelin) <br/>
 **Contributing:** [Contribution Guide](https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md)<br/>


### PR DESCRIPTION
### What is this PR for?
Just fixed a dead link in Zeppelin `README.md` file.

### What type of PR is it?
Documentation

### Todos
* [x] - Change a link `http://zeppelin.incubator.apache.org/docs/index.html` to `http://zeppelin.incubator.apache.org/docs/latest/index.html`.

### Is there a relevant Jira issue?
No

### How should this be tested?
Just click the <code> **Documentation:** User Guide </code> in Zeppelin `README.md`.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No