### PR TITLE
ZEPPELIN-598 ] Dynamic loading for Interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -428,6 +428,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     // Decide when new note is created, interpreter settings will be binded automatically or not.
     ZEPPELIN_NOTEBOOK_AUTO_INTERPRETER_BINDING("zeppelin.notebook.autoInterpreterBinding", true),
     ZEPPELIN_CONF_DIR("zeppelin.conf.dir", "conf"),
+    ZEPPELIN_INTERPRETER_REPO_DIR("zeppelin.user.interpreter.dir", "interpreter"),
     ZEPPELIN_DEP_LOCALREPO("zeppelin.dep.localrepo", "local-repo"),
     // Allows a way to specify a ',' separated list of allowed origins for rest and websockets
     // i.e. http://localhost:8080

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -122,7 +122,7 @@ public class InterpreterFactory {
       if (repositoryUrl != null) {
         depResolver.addRepo("dyInterpreterRepo", repositoryUrl, isSnapShotRepo);
       }
-      logger.info("interpreter- path {}", interpreterLoadPath);
+      logger.info("interpreter path : {}", interpreterLoadPath);
       depResolver.load(artifact, interpreterDesPath);
       setDynamicInterpreter(intpClassName, interpreterLoadPath);
     } catch (Exception e) {
@@ -136,7 +136,7 @@ public class InterpreterFactory {
     try {
       remove(intpName);
     } catch (Exception e) {
-      logger.error(e.getMessage());
+      logger.error("Faild Unload Dynaminc Interpreter", e);
       return false;
     }
     return true;
@@ -144,7 +144,8 @@ public class InterpreterFactory {
 
   protected void setDynamicInterpreter(String interpreterClassName, String fileDirPath)
       throws InterpreterException, IOException {
-    logger.info("load Dynamic Interpreter : ", interpreterClassName);
+    logger.info("load Dynamic Interpreter ClassName : {}", interpreterClassName);
+    logger.info("load Dynamic Interpreter FilePath : {}", interpreterClassName);
 
     ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
     interpreterClassList.add(interpreterClassName);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -53,7 +53,7 @@ public class InterpreterFactory {
       .synchronizedMap(new HashMap<String, URLClassLoader>());
 
   private ZeppelinConfiguration conf;
-  String[] interpreterClassList;
+  List<String> interpreterClassList;
 
   private Map<String, InterpreterSetting> interpreterSettings =
       new HashMap<String, InterpreterSetting>();
@@ -85,7 +85,10 @@ public class InterpreterFactory {
     this.angularObjectRegistryListener = angularObjectRegistryListener;
     this.depResolver = depResolver;
     String replsConf = conf.getString(ConfVars.ZEPPELIN_INTERPRETERS);
-    interpreterClassList = replsConf.split(",");
+    interpreterClassList = new ArrayList<String>();
+    for (String className : replsConf.split(",")) {
+      interpreterClassList.add(className);
+    }
 
     GsonBuilder builder = new GsonBuilder();
     builder.setPrettyPrinting();
@@ -93,6 +96,94 @@ public class InterpreterFactory {
     gson = builder.create();
 
     init();
+  }
+
+  public boolean loadDynamicInterpreter(String intpGroupName, String intpName, String artifact,
+      String intpClassName) {
+    return loadDynamicInterpreter(intpGroupName, intpName, artifact, intpClassName, null, false);
+  }
+
+  public boolean loadDynamicInterpreter(String intpGroupName, String intpName, String artifact,
+      String intpClassName, String repositoryUrl, boolean isSnapShotRepo) {
+    String[] artifactItem = artifact.split(":");
+    String zepInterpreterRepoDir = conf.getString(ConfVars.ZEPPELIN_INTERPRETER_REPO_DIR);
+    String zepInterpreterRepoFullPath = conf.getRelativeDir(ConfVars.ZEPPELIN_INTERPRETER_REPO_DIR);
+    String interpreterDesPath = String.format("%s/%s/%s/", zepInterpreterRepoDir,
+      intpGroupName, intpName);
+    String interpreterLoadPath = String.format("%s/%s/%s", zepInterpreterRepoFullPath,
+      intpGroupName, intpName);
+
+    if (artifactItem.length <= 0) {
+      logger.error("Failed load dynamic interpreter - invalid artifact : {}", artifact);
+      return false;
+    }
+
+    try {
+      if (repositoryUrl != null) {
+        depResolver.addRepo("dyInterpreterRepo", repositoryUrl, isSnapShotRepo);
+      }
+      logger.info("interpreter- path {}", interpreterLoadPath);
+      depResolver.load(artifact, interpreterDesPath);
+      setDynamicInterpreter(intpClassName, interpreterLoadPath);
+    } catch (Exception e) {
+      logger.error("Failed load dynamic interpreter : ", e);
+      return false;
+    }
+    return true;
+  }
+
+  public boolean unloadDynamicInterpreter(String intpGorupName, String intpName) {
+    try {
+      remove(intpName);
+    } catch (Exception e) {
+      logger.error(e.getMessage());
+      return false;
+    }
+    return true;
+  }
+
+  protected void setDynamicInterpreter(String interpreterClassName, String fileDirPath)
+      throws InterpreterException, IOException {
+    logger.info("load Dynamic Interpreter : ", interpreterClassName);
+
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    interpreterClassList.add(interpreterClassName);
+    // Load classes
+    File interpreterDir = new File(fileDirPath);
+
+    if (interpreterDir != null) {
+      URL[] urls = null;
+      try {
+        urls = recursiveBuildLibList(interpreterDir);
+      } catch (MalformedURLException e1) {
+        logger.error("Can't load jars ", e1);
+      }
+      URLClassLoader ccl = new URLClassLoader(urls, oldcl);
+
+      try {
+        Class.forName(interpreterClassName, true, ccl);
+        Set<String> keys = Interpreter.registeredInterpreters.keySet();
+        for (String intName : keys) {
+          if (interpreterClassName.equals(
+                  Interpreter.registeredInterpreters.get(intName).getClassName())) {
+            Interpreter.registeredInterpreters.get(intName).setPath(fileDirPath);
+            logger.info("Interpreter {} found. class={}", intName, fileDirPath);
+            cleanCl.put(fileDirPath, ccl);
+          }
+        }
+      } catch (ClassNotFoundException e) {
+        logger.error("Load error : ", e);
+      }
+    }
+
+    for (String settingId : interpreterSettings.keySet()) {
+      InterpreterSetting setting = interpreterSettings.get(settingId);
+      logger.info("Interpreter setting group {} : id={}, name={}",
+              setting.getGroup(), settingId, setting.getName());
+      for (Interpreter interpreter : setting.getInterpreterGroup()) {
+        logger.info("  className = {}", interpreter.getClassName());
+      }
+    }
   }
 
   private void init() throws InterpreterException, IOException {


### PR DESCRIPTION
### What is this PR for?
Use of external libraries that are included in the Roadmap,
The interpreter needs related to dynamic loading capabilities.

***It has been re-written from the first newly created PR.***
https://github.com/apache/incubator-zeppelin/pull/631


### What type of PR is it?
Feature

### Todos
* [x] - Dynamic load
* [x] - Modified according to feedback (https://github.com/apache/incubator-zeppelin/pull/631)

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-598
### How should this be tested?
By annotating the interpreter setting items below, try using the loadDynamicInterpreter method.
Or create a new interpreter loads created in the local Maven repository.
incubator-zeppelin/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
``` java 
    ZEPPELIN_INTERPRETERS("zeppelin.interpreters", "org.apache.zeppelin.spark.SparkInterpreter,"
        + "org.apache.zeppelin.spark.PySparkInterpreter,"
        + "org.apache.zeppelin.spark.SparkSqlInterpreter,"
        + "org.apache.zeppelin.spark.DepInterpreter,"
        + "org.apache.zeppelin.markdown.Markdown,"
...
```
### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no