### PR TITLE
Update cassandra-spark-1.5 profile to use Guava 16.0.1 and connector 1.5.0-RC1

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -494,13 +494,14 @@
         <akka.group>com.typesafe.akka</akka.group>
         <akka.version>2.3.11</akka.version>
         <protobuf.version>2.5.0</protobuf.version>
+        <guava.version>16.0.1</guava.version>
       </properties>
 
       <dependencies>
         <dependency>
           <groupId>com.datastax.spark</groupId>
           <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-          <version>1.5.0-M2</version>
+          <version>1.5.0-RC1</version>
           <exclusions>
             <exclusion>
               <groupId>org.joda</groupId>


### PR DESCRIPTION
### What is this PR for?
Right now, the Maven profile **cassandra-spark-1.5** is broken because an older version of Guava is used (**15.0** to be exact). This PR addresses this issue and also update the version of the Spark/Cassandra connector:

* Guava version set to **16.0.1** because the spark-cassandra connector is pulling the Java driver **3.0.0-rc1** which requires Guava 16.0.1
* spark-cassandra connector set to **1.5.0-RC1**

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Test by the community

### Is there a relevant Jira issue?
**[ZEPPELIN-620]**

### How should this be tested?
* Build Zeppelin with `mvn clean package -Pcassandra-spark-1.5 -DskipTests`
* Download **Cassandra 3.2** here: http://cassandra.apache.org/download/
* Unzip the archive somewhere
* Edit the $CASSANDRA_HOME/conf/cassandra.yaml file to set
    * listen_address: 127.0.0.1
    * rpc_address: 127.0.0.1  
* Start Cassandra with the command `$CASSANDRA_HOME/bin/cassandra`
* Wait 10 seconds for **Cassandra** to start
* Connect to the CQL client with `$CASSANDRA_HOME/bin/cqlsh` (if it fails, re-try after a few time because Cassandra may have not finished bootstrapping)
* Create the following dataset in Cassandra:
    * `CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};`
    * `CREATE TABLE test.data(id int PRIMARY KEY, val text);`
    * `INSERT INTO test.data(id,val) VALUES(1, 'one');`
    * `INSERT INTO test.data(id,val) VALUES(2, 'two');`
    * `INSERT INTO test.data(id,val) VALUES(3, 'three');`
* Edit the Spark interpreter to add this property
    * spark.cassandra.connection.host: 127.0.0.1
* Create a new notebook **Spark/Cassandra**
* Create a first paragraph to register the **Cassandra** table: 
```
%sql
CREATE TEMPORARY TABLE data USING org.apache.spark.sql.cassandra OPTIONS(cluster "Test Cluster", keyspace "test", table "data")
```
* Create a second paragraph to request data using SparkSQL
```
%sql
SELECT * FROM data
```
### Screenshots (if appropriate)
Spark interpreter config
![image](https://cloud.githubusercontent.com/assets/1532977/12419074/07c8ee32-beb4-11e5-809c-8a52224cf6ca.png)

Cassandra data set
![image](https://cloud.githubusercontent.com/assets/1532977/12419011/9e1575a0-beb3-11e5-8d56-49fc2ace8138.png)

SparkSQL using Cassandra data
![image](https://cloud.githubusercontent.com/assets/1532977/12419022/ab4886c2-beb3-11e5-92d9-78f2d8b1a6ee.png)


### Questions:
* Does the licenses files need update? --> No
* Is there breaking changes for older versions? --> No
* Does this needs documentation? --> No

[ZEPPELIN-620]: https://issues.apache.org/jira/browse/ZEPPELIN-620