### PR TITLE
ZEPPELIN-625 ] Notebook Storage module dynamic loading

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -82,7 +82,7 @@ public class ZeppelinServer extends Application {
     this.depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     this.schedulerFactory = new SchedulerFactory();
     this.replFactory = new InterpreterFactory(conf, notebookWsServer, depResolver);
-    this.notebookRepo = new NotebookRepoSync(conf);
+    this.notebookRepo = new NotebookRepoSync(conf, depResolver);
     this.notebookIndex = new LuceneSearch();
 
     notebook = new Notebook(conf, 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/ClassloaderNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/ClassloaderNotebookRepo.java
@@ -1,0 +1,103 @@
+package org.apache.zeppelin.notebook.repo;
+
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Created by ringo on 2016. 1. 4..
+ */
+public class ClassloaderNotebookRepo implements NotebookRepo{
+  private static final Logger LOG = LoggerFactory.getLogger(ClassloaderNotebookRepo.class);
+  private NotebookRepo repo;
+  private ClassLoader cl;
+
+  public ClassloaderNotebookRepo(NotebookRepo repo, ClassLoader cl) {
+    this.repo = repo;
+    this.cl = cl;
+  }
+
+  @Override
+  public List<NoteInfo> list() throws IOException {
+
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(cl);
+    try {
+      return repo.list();
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new IOException(e);
+    } finally {
+      cl = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(oldcl);
+    }
+  }
+
+  @Override
+  public Note get(String noteId) throws IOException {
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(cl);
+    try {
+      return repo.get(noteId);
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new IOException(e);
+    } finally {
+      cl = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(oldcl);
+    }
+  }
+
+  @Override
+  public void save(Note note) throws IOException {
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(cl);
+    try {
+      repo.save(note);
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new IOException(e);
+    } finally {
+      cl = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(oldcl);
+    }
+  }
+
+  @Override
+  public void remove(String noteId) throws IOException {
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(cl);
+    try {
+      repo.remove(noteId);
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw new IOException(e);
+    } finally {
+      cl = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(oldcl);
+    }
+  }
+
+  @Override
+  public void close() {
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(cl);
+    try {
+      repo.close();
+    } catch (Throwable e) {
+      LOG.error("Close ERROR : ", e);
+    }
+
+    cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(oldcl);
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/ClassloaderNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/ClassloaderNotebookRepo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.notebook.repo;
 
 import org.apache.zeppelin.notebook.Note;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -17,9 +17,12 @@
 
 package org.apache.zeppelin.notebook.repo;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,6 +31,7 @@ import java.util.Map;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -44,6 +48,7 @@ public class NotebookRepoSync implements NotebookRepo {
   private static final String pullKey = "pullNoteIDs";
 
   private static ZeppelinConfiguration config;
+  private DependencyResolver depResolver;
   private static final String defaultStorage = "org.apache.zeppelin.notebook.repo.VFSNotebookRepo";
 
   private List<NotebookRepo> repos = new ArrayList<NotebookRepo>();
@@ -54,8 +59,10 @@ public class NotebookRepoSync implements NotebookRepo {
    * @throws - Exception
    */
   @SuppressWarnings("static-access")
-  public NotebookRepoSync(ZeppelinConfiguration conf) {
+  public NotebookRepoSync(ZeppelinConfiguration conf, DependencyResolver depResolver) {
     config = conf;
+    this.depResolver = depResolver;
+
     String allStorageClassNames = conf.getString(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE).trim();
     if (allStorageClassNames.isEmpty()) {
       allStorageClassNames = defaultStorage;
@@ -109,6 +116,55 @@ public class NotebookRepoSync implements NotebookRepo {
       LOG.warn("Failed to initialize {} notebook storage class {}", defaultStorage, e);
     }
   }
+
+
+  public void loadDynamicNoteBookStoreage(String className, String artifact) throws Exception {
+    loadDynamicNoteBookStoreage(className, artifact, null, false);
+  }
+
+  //org.apache.zeppelin.notebook.repo.S3NotebookRepo
+  public void loadDynamicNoteBookStoreage(String className, String artifact, String repositoryUrl,
+                                          boolean isSnapShotRepo) throws Exception {
+
+    if (repositoryUrl != null) {
+      depResolver.addRepo("dyNotebookRepo", repositoryUrl, isSnapShotRepo);
+    }
+    List<File> files = depResolver.load(artifact);
+
+    URL[] urls = new URL[files.size()];
+    for (int index = 0; index < urls.length; index++) {
+      urls[index] = files.get(index).toURI().toURL();
+    }
+
+    ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+    URLClassLoader classLoaderForNotebookStorage = URLClassLoader.newInstance(urls, oldcl);
+
+
+    try {
+      try {
+        Class cls = classLoaderForNotebookStorage.loadClass(className);
+      } catch (Exception e) {
+        LOG.error("exception checking server classloader driver" , e);
+      }
+
+      URLClassLoader cl;
+      cl = URLClassLoader.newInstance(new URL[] {}, classLoaderForNotebookStorage);
+
+      Thread.currentThread().setContextClassLoader(cl);
+      Class<NotebookRepo> replClass = (Class<NotebookRepo>) cl.loadClass(className);
+      Constructor<NotebookRepo> constructor =
+              replClass.getConstructor(new Class[] {ZeppelinConfiguration.class});
+      NotebookRepo repl = constructor.newInstance(config);
+      ClassloaderNotebookRepo clNR = new ClassloaderNotebookRepo(repl, cl);
+
+      if (this.repos.add(clNR) == false) {
+        LOG.error("Loading {} NotebookRepo failed", className);
+      }
+    } finally {
+      Thread.currentThread().setContextClassLoader(oldcl);
+    }
+  }
+
 
   /**
    *  Lists Notebooks from the first repository

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncInitializationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncInitializationTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.notebook.repo.mock.VFSNotebookRepoMock;
 import org.junit.After;
 import org.junit.Before;
@@ -59,8 +60,9 @@ public class NotebookRepoSyncInitializationTest {
     // set confs
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), validOneStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check proper initialization of one storage
     assertEquals(notebookRepoSync.getRepoCount(), 1);
     assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);
@@ -85,8 +87,9 @@ public class NotebookRepoSyncInitializationTest {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), mainNotebookDir.getAbsolutePath());
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), validTwoStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check that both initialized
     assertEquals(notebookRepoSync.getRepoCount(), 2);
     assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);
@@ -98,8 +101,9 @@ public class NotebookRepoSyncInitializationTest {
     // set confs
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), invalidTwoStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check that second didn't initialize
     LOG.info(" " + notebookRepoSync.getRepoCount());
     assertEquals(notebookRepoSync.getRepoCount(), 1);
@@ -125,8 +129,9 @@ public class NotebookRepoSyncInitializationTest {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), mainNotebookDir.getAbsolutePath());
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), unsupportedStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check that first two storages initialized instead of three 
     assertEquals(notebookRepoSync.getRepoCount(), 2);
     assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);
@@ -138,8 +143,9 @@ public class NotebookRepoSyncInitializationTest {
     // set confs
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), emptyStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check initialization of one default storage
     assertEquals(notebookRepoSync.getRepoCount(), 1);
     assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);
@@ -150,8 +156,9 @@ public class NotebookRepoSyncInitializationTest {
  // set confs
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), invalidStorageClass);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     // check initialization of one default storage instead of invalid one
     assertEquals(notebookRepoSync.getRepoCount(), 1);
     assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
@@ -90,7 +91,8 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     factory = new InterpreterFactory(conf, new InterpreterOption(false), null, null);
     
     SearchService search = mock(SearchService.class);
-    notebookRepoSync = new NotebookRepoSync(conf);
+    DependencyResolver depResolver = new DependencyResolver(conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO));
+    notebookRepoSync = new NotebookRepoSync(conf, depResolver);
     notebookSync = new Notebook(conf, notebookRepoSync, schedulerFactory, factory, this, search);
   }
 


### PR DESCRIPTION
### What is this PR for?
Features developed for dynamic loads Notebook Storage Module.
In addition to the current Local Storage S3, it is possible to manage the notebook with Git.
But, at the same time you can not use another Notebook Storage Module, always include the Zeppelin Project shall be developed and downloaded.

To Solved, getting down the Notebook Storage Module from the Maven repository, and configure it so that you can dynamically load.

https://issues.apache.org/jira/browse/ZEPPELIN-546

```
params:
   artifact - maven artifact (groupId:artifactId:version)
   className - Interpreter class
   repository (optional) - additional maven repository address
```



### What type of PR is it?
Improvement

### Todos
* [x] - Implement dynamic load notebook storage module in notebooksync.java

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-625
https://issues.apache.org/jira/browse/ZEPPELIN-546

### How should this be tested?
1. Create a new Notebook storage module for testing.
example
```
myNotebookStorage/org/apache/zeppelin/myNotebookStorage/MyNotebookStorage.java

public class MyNotebookStorage implements NotebookRepo {
    ...implement interface method.
}
```

2. maven local repository build.
incubator-zeppelin root directory path.
```
mvn install -pl '!spark-dependencies,!spark,!flink,!ignite,!lens,!hive,!phoenix,!postgresql,!tajo,!cassandra,!kylin,!elasticsearch,!zeppelin-distribution' -DskipTests
```
then execute normal build.
```
mvn clean package -Pspark-1.6 -Phadoop-2.4 -Ppyspark -DskipTests
```

3. It calls for the implementation of the method.
(This is an example)
```
loadDynamicNoteBookStorage("org.apache.zeppelin.myNotebookStorage.MyNotebookStorage", "org.apache.zeppelin:myNotebookModuleID:0.6.0-incubating-SNAPSHOT")
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes