### PR TITLE
WIP: Add env var support to spark properties

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -42,6 +42,7 @@
 ##
 # export SPARK_HOME                             # (required) When it is defined, load it instead of Zeppelin embedded Spark libraries
 # export SPARK_SUBMIT_OPTIONS                   # (optional) extra options to pass to spark submit. eg) "--driver-memory 512M --executor-memory 1G".
+# export SPARK_APP_NAME                         # (optional) The name of spark application.
 
 ## Use embedded spark binaries ##
 ## without SPARK_HOME defined, Zeppelin still able to run spark interpreter process using embedded spark binaries.

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -87,7 +87,9 @@ public class SparkInterpreter extends Interpreter {
         "spark",
         SparkInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
-            .add("spark.app.name", "Zeppelin", "The name of spark application.")
+            .add("spark.app.name",
+                getSystemDefault("SPARK_APP_NAME", "spark.app.name", "Zeppelin"),
+                "The name of spark application.")
             .add("master",
                 getSystemDefault("MASTER", "spark.master", "local[*]"),
                 "Spark master uri. ex) spark://masterhost:7077")


### PR DESCRIPTION
Add env var support to set defaults:
- `spark.app.name` => `SPARK_APP_NAME`
- `spark.executor.memory` => `SPARK_EXECUTOR_MEMORY`
- `spark.cores.max` => `SPARK_CORES_MAX`