### PR TITLE
Keyboard Shortcut - Map Alt or Opt Based on Device

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -574,9 +574,11 @@ angular.module('zeppelinWebApp')
 
       if (navigator.appVersion.indexOf('Mac') !== -1 ) {
         $scope.editor.setKeyboardHandler('ace/keyboard/emacs');
+        $rootScope.isMac = true;
       } else if (navigator.appVersion.indexOf('Win') !== -1 ||
                  navigator.appVersion.indexOf('X11') !== -1 ||
                  navigator.appVersion.indexOf('Linux') !== -1) {
+        $rootScope.isMac = false;
         // not applying emacs key binding while the binding override Ctrl-v. default behavior of paste text on windows.
       }
 

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -37,7 +37,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">c</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">c</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -70,7 +70,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">d</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">d</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -81,7 +81,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">a</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">a</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -92,7 +92,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">b</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">b</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -103,7 +103,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">k</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">k</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -114,7 +114,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">j</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">j</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -125,7 +125,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">o</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">o</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -136,7 +136,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">e</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">e</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -147,7 +147,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">m</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">m</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -158,7 +158,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">t</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">t</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -169,7 +169,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">1</kbd>~<kbd class="kbd-dark">0</kbd>,<kbd class="kbd-dark">-</kbd>,<kbd class="kbd-dark">+</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">1</kbd>~<kbd class="kbd-dark">0</kbd>,<kbd class="kbd-dark">-</kbd>,<kbd class="kbd-dark">+</kbd>
             </div>
           </div>
           <div class="col-md-8">

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -21,7 +21,7 @@ limitations under the License.
       </div>
       <div class="modal-body">
 
-        <h4>Control in Note</h4>
+        <h4>Note Shortcuts</h4>
 
         <div class="row">
           <div class="col-md-4">
@@ -37,7 +37,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">c</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">c</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -70,7 +70,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">d</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">d</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -81,7 +81,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">a</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">a</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -92,7 +92,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">b</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">b</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -103,7 +103,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">k</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">k</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -114,7 +114,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">j</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">j</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -125,7 +125,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">o</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">o</kbd>
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">r</kbd>
             </div>
           </div>
@@ -137,7 +137,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">o</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">o</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -148,7 +148,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">e</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">e</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -159,7 +159,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">m</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">m</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -170,7 +170,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">t</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">t</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -181,7 +181,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Opt' : 'Alt'}}</kbd> + <kbd class="kbd-dark">1</kbd>~<kbd class="kbd-dark">0</kbd>,<kbd class="kbd-dark">-</kbd>,<kbd class="kbd-dark">+</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">1</kbd>~<kbd class="kbd-dark">0</kbd>,<kbd class="kbd-dark">-</kbd>,<kbd class="kbd-dark">+</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -189,7 +189,7 @@ limitations under the License.
           </div>
         </div>
 
-        <h4>Control in Note Editor</h4>
+        <h4>Editor Shortcuts</h4>
 
       <div class="row">
           <div class="col-md-4">


### PR DESCRIPTION
### What is this PR for?
Right now the keyboard shortcut modal shows 'alt' but on macs 'alt' maps to 'opt'. Could be confusing to some people who don't see 'alt' on the keyboard on their macs.

There are many way to achieve this mapping. I used this to minimize code change and take advantage of when paragraphs check for appVersion to set keyboard shortcuts. 

Open to suggestions on best approach to solve this problem. 

### What type of PR is it?
Improvement

### Todos

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-626
### How should this be tested?
1. Emulate browser to be Mac and open keyboard shortcut
2. Emulate browser to be Windows and open keyboard shortcut

### Screenshots (if appropriate)
Macs:
![mac](https://cloud.githubusercontent.com/assets/6380209/12488153/d6559440-c02f-11e5-8b0b-ebade3026d90.png)

Windows:
![others](https://cloud.githubusercontent.com/assets/6380209/12488160/dc4d406e-c02f-11e5-9e11-b0c79ae568c9.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no