### PR TITLE
[Zeppelin-628 ] Fix parse propertyKey in interpreter name for JDBC

### DIFF
--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -74,18 +74,14 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   public void testForParsePropertyKey() throws IOException {
     JDBCInterpreter t = new JDBCInterpreter(new Properties());
     
-    // if return null is that prefix not found
     assertEquals(t.getPropertyKey("(fake) select max(cant) from test_table where id >= 2452640"),
-        null);
+        "fake");
     
     assertEquals(t.getPropertyKey("() select max(cant) from test_table where id >= 2452640"),
-        null);
-    
-    assertEquals(t.getPropertyKey("(\nfake) select max(cant) from test_table where id >= 2452640"),
-        null);
+        "");
     
     assertEquals(t.getPropertyKey(")fake( select max(cant) from test_table where id >= 2452640"),
-        null);
+        "default");
         
     // when you use a %jdbc(prefix1), prefix1 is the propertyKey as form part of the cmd string
     assertEquals(t.getPropertyKey("(prefix1)\n select max(cant) from test_table where id >= 2452640"),
@@ -97,6 +93,27 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     // when you use a %jdbc, prefix is the default
     assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
             "default");
+  }
+  
+  @Test
+  public void testForMapPrefix() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "(fake) select * from test_table";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, new InterpreterContext("", "1", "","", null,null,null,null,null,null));
+
+    // if prefix not found return ERROR and Prefix not found.
+    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+    assertEquals("Prefix not found.", interpreterResult.message());
   }
   
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -69,6 +69,20 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     );
   }
 
+
+  @Test
+  public void testForParsePropertyKey() throws IOException {
+    JDBCInterpreter t = new JDBCInterpreter(new Properties());
+    
+    // if return null is that propertyKey is the default
+    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
+        null);
+    
+    // when you use a %jdbc(redshift), redshift is the propertyKey as form part of the cmd string
+    assertEquals(t.getPropertyKey("(redshift)\n select max(cant) from test_table where id >= 2452640"),
+        "redshift");
+  }
+  
   @Test
   public void testDefaultProperties() throws SQLException {
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(new Properties());

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -74,13 +74,29 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   public void testForParsePropertyKey() throws IOException {
     JDBCInterpreter t = new JDBCInterpreter(new Properties());
     
-    // if return null is that propertyKey is the default
-    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
+    // if return null is that prefix not found
+    assertEquals(t.getPropertyKey("(fake) select max(cant) from test_table where id >= 2452640"),
         null);
     
-    // when you use a %jdbc(redshift), redshift is the propertyKey as form part of the cmd string
-    assertEquals(t.getPropertyKey("(redshift)\n select max(cant) from test_table where id >= 2452640"),
-        "redshift");
+    assertEquals(t.getPropertyKey("() select max(cant) from test_table where id >= 2452640"),
+        null);
+    
+    assertEquals(t.getPropertyKey("(\nfake) select max(cant) from test_table where id >= 2452640"),
+        null);
+    
+    assertEquals(t.getPropertyKey(")fake( select max(cant) from test_table where id >= 2452640"),
+        null);
+        
+    // when you use a %jdbc(prefix1), prefix1 is the propertyKey as form part of the cmd string
+    assertEquals(t.getPropertyKey("(prefix1)\n select max(cant) from test_table where id >= 2452640"),
+        "prefix1");
+    
+    assertEquals(t.getPropertyKey("(prefix2) select max(cant) from test_table where id >= 2452640"),
+            "prefix2");
+    
+    // when you use a %jdbc, prefix is the default
+    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
+            "default");
   }
   
   @Test


### PR DESCRIPTION
### What is this PR for?
Fix bug
https://issues.apache.org/jira/browse/ZEPPELIN-628

### Todos

### How should this be tested?
run a query that contains (something)...eg
```
%jdbc
select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group by ss_customer_sk
```
It is ok if the **propertyKey** is default:
```
PropertyKey: default, SQL command: 'select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group by ss_customer_sk'
```
### Questions:

Does the licenses files need update? no
Is there breaking changes for older versions? no
Does this needs documentation? no