### PR TITLE
[Zeppelin-628 ] Fix parse propertyKey in interpreter name for Hive

### DIFF
--- a/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
+++ b/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
@@ -169,6 +169,9 @@ public class HiveInterpreter extends Interpreter {
 
   public Connection getConnection(String propertyKey) throws ClassNotFoundException, SQLException {
     Connection connection = null;
+    if (propertyKey == null || propertiesMap.get(propertyKey) == null) {
+      return null;
+    }
     if (propertyKeyUnusedConnectionListMap.containsKey(propertyKey)) {
       ArrayList<Connection> connectionList = propertyKeyUnusedConnectionListMap.get(propertyKey);
       if (0 != connectionList.size()) {
@@ -203,6 +206,10 @@ public class HiveInterpreter extends Interpreter {
     } else {
       connection = getConnection(propertyKey);
     }
+    
+    if (connection == null) {
+      return null;
+    }
 
     Statement statement = connection.createStatement();
     if (isStatementClosed(statement)) {
@@ -231,6 +238,10 @@ public class HiveInterpreter extends Interpreter {
     try {
 
       Statement statement = getStatement(propertyKey, paragraphId);
+
+      if (statement == null) {
+        return new InterpreterResult(Code.ERROR, "Prefix not found.");
+      }
 
       statement.setMaxRows(getMaxResult());
 
@@ -344,8 +355,9 @@ public class HiveInterpreter extends Interpreter {
       } else {
         return null;
       }
+    } else {
+      return DEFAULT_KEY;
     }
-    return null;
   }
 
   @Override

--- a/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
+++ b/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
@@ -326,10 +326,8 @@ public class HiveInterpreter extends Interpreter {
   public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
     String propertyKey = getPropertyKey(cmd);
 
-    if (null != propertyKey) {
+    if (null != propertyKey && !propertyKey.equals(DEFAULT_KEY)) {
       cmd = cmd.substring(propertyKey.length() + 2);
-    } else {
-      propertyKey = DEFAULT_KEY;
     }
 
     cmd = cmd.trim();

--- a/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
+++ b/hive/src/main/java/org/apache/zeppelin/hive/HiveInterpreter.java
@@ -334,15 +334,16 @@ public class HiveInterpreter extends Interpreter {
   }
 
   public String getPropertyKey(String cmd) {
-    int firstLineIndex = cmd.indexOf("\n");
-    if (-1 == firstLineIndex) {
-      firstLineIndex = cmd.length();
-    }
-    int configStartIndex = cmd.indexOf("(");
-    int configLastIndex = cmd.indexOf(")");
-    if (configStartIndex != -1 && configLastIndex != -1
-        && configLastIndex < firstLineIndex && configLastIndex < firstLineIndex) {
-      return cmd.substring(configStartIndex + 1, configLastIndex);
+    boolean firstLineIndex = cmd.startsWith("(");
+
+    if (firstLineIndex) {
+      int configStartIndex = cmd.indexOf("(");
+      int configLastIndex = cmd.indexOf(")");
+      if (configStartIndex != -1 && configLastIndex != -1) {
+        return cmd.substring(configStartIndex + 1, configLastIndex);
+      } else {
+        return null;
+      }
     }
     return null;
   }

--- a/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
+++ b/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
@@ -68,6 +68,19 @@ public class HiveInterpreterTest {
   }
 
   @Test
+  public void testForParsePropertyKey() throws IOException {
+    HiveInterpreter t = new HiveInterpreter(new Properties());
+    
+    // if return null is that propertyKey is the default
+    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
+        null);
+    
+    // when you use a %hive(production), production is the propertyKey as form part of the cmd string
+    assertEquals(t.getPropertyKey("(production)\n select max(cant) from test_table where id >= 2452640"),
+        "production");
+  }
+  
+  @Test
   public void readTest() throws IOException {
     Properties properties = new Properties();
     properties.setProperty("common.max_count", "1000");

--- a/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
+++ b/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
@@ -87,7 +87,7 @@ public class HiveInterpreterTest {
     assertEquals(t.getPropertyKey("(prefix2) select max(cant) from test_table where id >= 2452640"),
             "prefix2");
     
-    // when you use a %jdbc, prefix is the default
+    // when you use a %hive, prefix is the default
     assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
             "default");
   }

--- a/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
+++ b/hive/src/test/java/org/apache/zeppelin/hive/HiveInterpreterTest.java
@@ -66,18 +66,51 @@ public class HiveInterpreterTest {
   @After
   public void tearDown() throws Exception {
   }
-
+  
   @Test
   public void testForParsePropertyKey() throws IOException {
     HiveInterpreter t = new HiveInterpreter(new Properties());
     
-    // if return null is that propertyKey is the default
-    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
-        null);
+    assertEquals(t.getPropertyKey("(fake) select max(cant) from test_table where id >= 2452640"),
+        "fake");
     
-    // when you use a %hive(production), production is the propertyKey as form part of the cmd string
-    assertEquals(t.getPropertyKey("(production)\n select max(cant) from test_table where id >= 2452640"),
-        "production");
+    assertEquals(t.getPropertyKey("() select max(cant) from test_table where id >= 2452640"),
+        "");
+    
+    assertEquals(t.getPropertyKey(")fake( select max(cant) from test_table where id >= 2452640"),
+        "default");
+        
+    // when you use a %hive(prefix1), prefix1 is the propertyKey as form part of the cmd string
+    assertEquals(t.getPropertyKey("(prefix1)\n select max(cant) from test_table where id >= 2452640"),
+        "prefix1");
+    
+    assertEquals(t.getPropertyKey("(prefix2) select max(cant) from test_table where id >= 2452640"),
+            "prefix2");
+    
+    // when you use a %jdbc, prefix is the default
+    assertEquals(t.getPropertyKey("select max(cant) from test_table where id >= 2452640"),
+            "default");
+  }
+  
+  @Test
+  public void testForMapPrefix() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    HiveInterpreter t = new HiveInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "(fake) select * from test_table";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, new InterpreterContext("", "1", "","", null,null,null,null,null,null));
+
+    // if prefix not found return ERROR and Prefix not found.
+    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+    assertEquals("Prefix not found.", interpreterResult.message());
   }
   
   @Test


### PR DESCRIPTION
### What is this PR for?
Fix bug
https://issues.apache.org/jira/browse/ZEPPELIN-628

### Todos

### How should this be tested?
run a query that contains (something)...eg:
```
%hive
select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group by ss_customer_sk
```
It is ok if the **propertyKey** is default:
```
PropertyKey: default, SQL command: 'select max(ss_promo_sk), ss_customer_sk from qhive.tpcds_orc_500.store_sales where ss_sold_date_sk >= 2452640 and ss_customer_sk > 3 and ss_customer_sk < 20 group by ss_customer_sk'
```
### Questions:

Does the licenses files need update? no
Is there breaking changes for older versions? no
Does this needs documentation? no