### PR TITLE
ZEPPELIN-569 - website update for release 0.5.6-incubating 

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -28,6 +28,7 @@
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Docs<b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <li><span><b>Release</b><span></li>
+                <li><a href="docs/0.5.6-incubating">0.5.6-incubating</a></li>
                 <li><a href="docs/0.5.5-incubating">0.5.5-incubating</a></li>
                 <li><a href="docs/0.5.0-incubating">0.5.0-incubating</a></li>
                 <li role="separator" class="divider"></li>

--- a/doap.rdf
+++ b/doap.rdf
@@ -36,6 +36,21 @@
     <programming-language>JavaScript</programming-language>
     <programming-language>Scala</programming-language>
     <category rdf:resource="http://projects.apache.org/category/big-data" />
+
+    <release>
+      <Version>
+        <name>0.5.6-incubating</name>
+        <created>2016-01-22</created>
+        <revision>0.5.6-incubating</revision>
+      </Version>
+    </release>
+    <release>
+      <Version>
+        <name>0.5.5-incubating</name>
+        <created>2015-11-18</created>
+        <revision>0.5.5-incubating</revision>
+      </Version>
+    </release>
     <release>
       <Version>
         <name>0.5.0-incubating</name>
@@ -43,6 +58,7 @@
         <revision>0.5.0-incubating</revision>
       </Version>
     </release>
+
     <repository>
       <GitRepository>
         <location rdf:resource="https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git"/>

--- a/download.md
+++ b/download.md
@@ -21,21 +21,21 @@ limitations under the License.
 
 ### Download Zeppelin
 
-The latest release of Apache Zeppelin (incubating) is **0.5.5-incubating**.
+The latest release of Apache Zeppelin (incubating) is **0.5.6-incubating**.
 
-  - 0.5.5-incubating released on Nov 18, 2015 ([release notes](./releases/zeppelin-release-0.5.5-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.5))
+  - 0.5.6-incubating released on Jan 22, 2015 ([release notes](./releases/zeppelin-release-0.5.6-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.6))
 
     * Source:
-    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-src', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz'">zeppelin-0.5.5-incubating.tgz</a>
-    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.asc),
-     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.md5),
-     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.sha))
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-src', '0.5.6-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating.tgz'">zeppelin-0.5.6-incubating.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating.tgz.sha))
 
     * Binary package:
-    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-bin', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz'">zeppelin-0.5.5-incubating-bin-all.tgz</a>
-    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.asc),
-     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.md5),
-     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.sha))
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-bin', '0.5.6-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz'">zeppelin-0.5.6-incubating-bin-all.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz.sha))
 
 
 
@@ -52,6 +52,21 @@ For developers, to get latest *0.6.0-incubating-SNAPSHOT* check [README](https:/
 
 
 ### Old releases
+
+  - 0.5.5-incubating released on Nov 18, 2015 ([release notes](./releases/zeppelin-release-0.5.5-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.5))
+
+    * Source:
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-src', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz'">zeppelin-0.5.5-incubating.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating.tgz.sha))
+
+    * Binary package:
+    <a style="cursor:pointer" onclick="ga('send', 'event', 'download', 'zeppelin-bin', '0.5.5-incubating'); window.location.href='http://www.apache.org/dyn/closer.cgi/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz'">zeppelin-0.5.5-incubating-bin-all.tgz</a>
+    ([pgp](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.asc),
+     [md5](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.md5),
+     [sha](https://www.apache.org/dist/incubator/zeppelin/0.5.5-incubating/zeppelin-0.5.5-incubating-bin-all.tgz.sha))
+
 
   - 0.5.0-incubating released on July 23, 2015 ([release notes](./releases/zeppelin-release-0.5.0-incubating.html)) ([git tag](https://git-wip-us.apache.org/repos/asf?p=incubator-zeppelin.git;a=tag;h=refs/tags/v0.5.0))
 

--- a/releases/zeppelin-release-0.5.6-incubating.md
+++ b/releases/zeppelin-release-0.5.6-incubating.md
@@ -1,0 +1,123 @@
+---
+layout: page
+title: "Zeppelin Release 0.5.6-incubating"
+description: ""
+group: release
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+## Zeppelin Release 0.5.6-incubating
+
+The Apache Zeppelin (incubating) community is pleased to announce the availability of the 0.5.6-incubating release.
+
+The community puts significant effort into improving Apache Zeppelin since the last release, focusing on having new backend support, improvements on stability and simplifying the configuration. 
+More than 38 contributors provided new features, improvements and verifying release.
+More than 110 issues has been resolved.
+
+We encourage [download](../../download.html) the latest release. Feedback through the [mailing lists](../../community.html) is very welcome.
+
+<br />
+
+### Backend support
+
+This release includes new backend support for
+
+   * Spark up to 1.6.0 support
+   * Elasticsearch
+   * HiveInterpreter (with multiple configurations)
+   * Scalding (Local mode only, not included in binary package)
+
+
+<br />
+### Improvements
+
+Some notable improvements are
+
+ - New features (Import/export notebook, read only server, search, Git notebook storage)
+ - Improvements (Autoscrolling, direct to new note, auto save on navigation, better REST api, better complition, pyspark and YARN support, improved documentation)
+ - Fixes (Cassandra, MapR profile)
+
+
+You can visit [issue tracker](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316221&version=12334165) for full list of issues being resolved.
+
+
+<br />
+### Contributors
+
+This release would not be possible without the following community members's contributions:
+
+ * Lee Moon Soo
+ * Prabhjyot Singh
+ * Alexander Bezzubov
+ * Damien CORNEAU
+ * Renjith Kamath
+ * Mina Lee
+ * CloverHearts
+ * Jungtaek Lim
+ * Ryu Ah young
+ * astroshim
+ * Felix Cheung
+ * Jongyoul Lee
+ * Khalid Huseynov
+ * Jeff Steinmetz
+ * Michael Chen
+ * Bruno Bonnin
+ * Chae-Sung Lim
+ * DuyHai DOAN
+ * Eric Charles
+ * Estail7s
+ * karuppayya
+ * Anthony Corbacho
+ * Cos
+ * eranwitkon
+ * JaeHwa Jung
+ * Jürgen Thomann
+ * Luciano Resende
+ * Minwoo Kang
+ * Patrick Ethier
+ * Paul Curtis
+ * Rick Moritz
+ * Rohit Agarwal
+ * Sriram Krishnan
+ * Till Rohrmann
+ * tog
+ * Tomas
+ * Tsuyoshi Miyake
+ * Victor
+
+
+The following people helped verifying this release:
+
+* Alexander Bezzubov
+* Jongyoul Lee
+* Jesang Yoon
+* DuyHai Doan
+* Hyung Sung Shim
+* Moon soo Lee
+* Corneau Damien
+* Felix Cheung
+* Mina Lee
+* Anthony Corbacho
+* Jungtaek Lim
+* Victor Manuel Garcia
+* Jeff Steinmetz
+* Jian Zhong
+* Khalid Huseynov
+* Jian Zhong
+* Justin Mclean
+* Henry Saputra
+* John D. Ament
+* Konstantin Boudnik


### PR DESCRIPTION
Vote for release 0.5.6-incubating has passed.

Dev list vote result : [dev@zeppelin.i.a.o](http://markmail.org/thread/i54nabcx5wa2kt5j)
IPMC vote result: [general@i.a.o](http://markmail.org/thread/xczosjtzjxpne262)

This is a last step of release process, before the public announcement - updating website with release notes and new version information.

