### PR TITLE
ZEPPELIN-375

### DIFF
--- a/docs/interpreter/geode.md
+++ b/docs/interpreter/geode.md
@@ -6,6 +6,16 @@ group: manual
 ---
 {% include JB/setup %}
 
+> **Note**: The Geode jar dependencies are compiled with `JDK8` ([ZEPPELIN-375](https://issues.apache.org/jira/browse/ZEPPELIN-375) and [GEODE-479](https://issues.apache.org/jira/browse/GEODE-479)). The Geode module is `disabled for JDK7` environments. It is `automatically enabled for JDK8+` environment. Geode will be enabled event if the java source/target parameters are set to 1.7 as long as the compiler is JDK8+. You can enable the Geode module manually by activating the `geode` profile:
+```
+mvn clean package -Pgeode -Pbuild-distr
+```
+
+> Also you can use the `maven.compiler.source` and `maven.compiler.source` properties to override the default (1.7) source/target java compilation settings:
+```
+mvn .... -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8
+```
+
 ## Geode/Gemfire OQL Interpreter for Apache Zeppelin
 <table class="table-configuration">
   <tr>
@@ -33,12 +43,6 @@ This interpreter supports the [Geode](http://geode.incubator.apache.org/) [Objec
 
 This [Video Tutorial](https://www.youtube.com/watch?v=zvzzA9GXu3Q) illustrates some of the features provided by the `Geode Interpreter`.
 
-### Build Zeppelin with Geode Interpreter
-
-> Note: Due to [ZEPPELIN-375](https://issues.apache.org/jira/browse/ZEPPELIN-375) and [GEODE-479](https://issues.apache.org/jira/browse/GEODE-479) the Geode interpreter is disabled by default! To enable it you have to (re)compile the Zeppelin binaries with `Java 1.8` and activated `geode` profile like this:
-```
-mvn clean package -Pgeode -Pbuild-distr -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8
-```
 
 ### Create Interpreter
 By default Zeppelin creates one `Geode/OQL` instance. You can remove it or create more instances.

--- a/docs/interpreter/geode.md
+++ b/docs/interpreter/geode.md
@@ -33,6 +33,13 @@ This interpreter supports the [Geode](http://geode.incubator.apache.org/) [Objec
 
 This [Video Tutorial](https://www.youtube.com/watch?v=zvzzA9GXu3Q) illustrates some of the features provided by the `Geode Interpreter`.
 
+### Build Zeppelin with Geode Interpreter
+
+> Note: Due to [ZEPPELIN-375](https://issues.apache.org/jira/browse/ZEPPELIN-375) and [GEODE-479](https://issues.apache.org/jira/browse/GEODE-479) the Geode interpreter is disabled by default! To enable it you have to (re)compile the Zeppelin binaries with `Java 1.8` and activated `geode` profile like this:
+```
+mvn clean package -Pgeode -Pbuild-distr -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8
+```
+
 ### Create Interpreter
 By default Zeppelin creates one `Geode/OQL` instance. You can remove it or create more instances.
 

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,9 @@
     <!-- Geode can be enabled by -Pgeode. see https://issues.apache.org/jira/browse/ZEPPELIN-375 -->
     <profile>
       <id>geode</id>
+      <activation>
+        <jdk>[1.8,1.9]</jdk>
+      </activation>      
       <modules>
         <module>geode</module>
       </modules>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -95,7 +95,7 @@
   </build>
 
   <profiles>
-    <!-- To enable Geode binary generation, activate the -Pgeode profile and build Zeppelin with Java 8: -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8     
+    <!-- Enable the Geode binary generation. Activated automatically if Java8 is used or the -Pgeode profile is set.
     See https://issues.apache.org/jira/browse/ZEPPELIN-375 -->
     <profile>
       <id>geode</id>
@@ -114,7 +114,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>1.3.1</version>
             <executions>
               <execution>
                 <id>enforce</id>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -100,7 +100,7 @@
     <profile>
       <id>geode</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <jdk>[1.8,1.9]</jdk>
       </activation>
       <dependencies>
         <dependency>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -95,6 +95,35 @@
   </build>
 
   <profiles>
+    <!-- To enable Geode binary generation, activate the -Pgeode profile and build Zeppelin with Java 8: -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8     
+    See https://issues.apache.org/jira/browse/ZEPPELIN-375 -->
+    <profile>
+      <id>geode</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>zeppelin-geode</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.3.1</version>
+            <executions>
+              <execution>
+                <id>enforce</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>publish-distr</id>
       <activation>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -107,6 +107,7 @@
           <groupId>org.apache.zeppelin</groupId>
           <artifactId>zeppelin-geode</artifactId>
           <version>${project.version}</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
Hot Fix to allow using Zeppelin with the latest (Java 8 based) Geode see: [ZEPPELIN-375](https://issues.apache.org/jira/browse/ZEPPELIN-375)

#### Changes:

* Make sure the that the `zeppelin-distribution` is build after the `geode` module. By default if you activate the geode profile (`-Pgeode`) the maven reactor will order the geode after the zeppelin-distribution. In result the geode is never added to the zeppelin binary distro. 
* Document how to build Zeppelin with Geode. Note that the only way to use Zeppelin with Geode is to build Zeppelin with `Java8`