### PR TITLE
[Hot Fix] Fix build failure due to latest bower (1.7.5)

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.1.0",
-    "bower": "",
+    "bower": "1.7.2",
     "grunt": "^0.4.1",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
### What is this PR for?
Build fails due to new bower version 1.7.5. This PR tries to fix this issue by adding the previous version (1.7.2) in package.json instead of npm auto updating bower to latest.

### What type of PR is it?
Hot Fix

### Is there a relevant Jira issue?
ZEPPELIN-634

### How should this be tested?
delete `zeppelin-web/node_modules/*` and run `mvn clean install` in zeppelin-web