### PR TITLE
Fix dead link and add table tab to Zeppelin Configuration section: docs/install/install.md

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -39,262 +39,161 @@ You can also build Zeppelin from the source. Please check instructions of `READM
 
 You can configure Zeppelin with both environment variables in `conf/zeppelin-env.sh` and java properties in `conf/zeppelin-site.xml`. If both are defined, then the environment variable will be used priorly.
 
-<ul class="nav nav-tabs">
-  <li class="active"><a data-toggle="tab" href="#zeppelin-env"><b>zeppelin-env.sh</b></a></li>
-  <li><a data-toggle="tab" href="#zeppelin-site"><b>zeppelin-site.xml</b></a></li>
-</ul>
-
-<div class="tab-content">
-  <div id="zeppelin-env" class="tab-pane fade in active">
-    <table class="table-configuration">
-      <tr>
-        <th>zepplin-env.sh</th>
-        <th>Default Value</th>
-        <th>Description</th>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_PORT</td>
-        <td>8080</td>
-        <td>Zeppelin server port</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_MEM</td>
-        <td>-Xmx1024m -XX:MaxPermSize=512m</td>
-        <td>JVM mem options</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_INTP_MEM</td>
-        <td>ZEPPELIN_MEM</td>
-        <td>JVM mem options for interpreter process</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_JAVA_OPTS</td>
-        <td></td>
-        <td>JVM Options</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_ALLOWED_ORIGINS</td>
-        <td>*</td>
-        <td>Enables a way to specify a ',' separated list of allowed origins for rest and websockets. <br /> i.e. http://localhost:8080 </td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SERVER_CONTEXT_PATH</td>
-        <td>/</td>
-        <td>The context path of the web application</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_CLIENT_AUTH</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_KEYSTORE_PATH</td>
-        <td>keystore</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_KEYSTORE_TYPE</td>
-        <td>JKS</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_KEYSTORE_PASSWORD</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_KEY_MANAGER_PASSWORD</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_TRUSTSTORE_PATH</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_TRUSTSTORE_TYPE</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_SSL_TRUSTSTORE_PASSWORD</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
-        <td></td>
-        <td>A notebook id displayed in homescreen <br />i.e. 2A94M5J1Z</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
-        <td>false</td>
-        <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_WAR_TEMPDIR</td>
-        <td>webapps</td>
-        <td>Jetty temporary directory location</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_DIR</td>
-        <td>notebook</td>
-        <td>A directory path of Zeppelin notebook files</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
-        <td>zeppelin</td>
-        <td>S3 Bucket where Zeppelin notebook files will be saved</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
-        <td>user</td>
-        <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_NOTEBOOK_STORAGE</td>
-        <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
-        <td>Comma separated list of notebook storage</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_INTERPRETERS</td>
-      <description></description>
-        <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
-        ...
-        </td>
-        <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default.</td>
-      </tr>
-      <tr>
-        <td>ZEPPELIN_INTERPRETER_DIR</td>
-        <td>interpreter</td>
-        <td>Zeppelin interpreter directory</td>
-      </tr>
-    </table>
-  </div>
-  <div id="zeppelin-site" class="tab-pane fade">
-    <table class="table-configuration">
-      <tr>
-        <th>zepplin-site.xml</th>
-        <th>Default value</th>
-        <th>Description</th>
-      </tr>
-      <tr>
-        <td>zeppelin.server.port</td>
-        <td>8080</td>
-        <td>Zeppelin server port</td>
-      </tr>
-      <tr>
-        <td>zeppelin.server.allowed.origins</td>
-        <td>*</td>
-        <td>Enables a way to specify a ',' separated list of allowed origins for rest and websockets. <br /> i.e. http://localhost:8080 </td>
-      </tr>
-      <tr>
-        <td>zeppelin.server.context.path</td>
-        <td>/</td>
-        <td>The context path of the web application</td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.client.auth</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.keystore.path</td>
-        <td>keystore</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.keystore.type</td>
-        <td>JKS</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.keystore.password</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.key.manager.password</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.truststore.path</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.truststore.type</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.ssl.truststore.password</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.homescreen</td>
-        <td></td>
-        <td>A notebook id displayed in homescreen <br />i.e. 2A94M5J1Z</td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.homescreen.hide</td>
-        <td>false</td>
-        <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
-      </tr>
-      <tr>
-        <td>zeppelin.war.tempdir</td>
-        <td>webapps</td>
-        <td>Jetty temporary directory location</td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.dir</td>
-        <td>notebook</td>
-        <td>A directory path of Zeppelin notebook files</td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.s3.bucket</td>
-        <td>zeppelin</td>
-        <td>S3 Bucket where Zeppelin notebook files will be saved</td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.s3.user</td>
-        <td>user</td>
-        <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
-      </tr>
-      <tr>
-        <td>zeppelin.notebook.storage</td>
-        <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
-        <td>Comma separated list of notebook storage</td>
-      </tr>
-      <tr>
-        <td>zeppelin.interpreters</td>
-      <description></description>
-        <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
-        ...
-        </td>
-        <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default.</td>
-      </tr>
-      <tr>
-        <td>zeppelin.interpreter.dir</td>
-        <td>interpreter</td>
-        <td>Zeppelin interpreter directory</td>
-      </tr>
-    </table>
-  </div>
-</div>
+<table class="table-configuration">
+  <tr>
+    <th>zepplin-env.sh</th>
+    <th>zepplin-site.xml</th>
+    <th>Default value</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_PORT</td>
+    <td>zeppelin.server.port</td>
+    <td>8080</td>
+    <td>Zeppelin server port</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_MEM</td>
+    <td>N/A</td>
+    <td>-Xmx1024m -XX:MaxPermSize=512m</td>
+    <td>JVM mem options</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_INTP_MEM</td>
+    <td>N/A</td>
+    <td>ZEPPELIN_MEM</td>
+    <td>JVM mem options for interpreter process</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_JAVA_OPTS</td>
+    <td>N/A</td>
+    <td></td>
+    <td>JVM options</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_ALLOWED_ORIGINS</td>
+    <td>zeppelin.server.allowed.origins</td>
+    <td>*</td>
+    <td>Enables a way to specify a ',' separated list of allowed origins for rest and websockets. <br /> i.e. http://localhost:8080 </td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SERVER_CONTEXT_PATH</td>
+    <td>zeppelin.server.context.path</td>
+    <td>/</td>
+    <td>A context path of the web application</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL</td>
+    <td>zeppelin.ssl</td>
+    <td>false</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_CLIENT_AUTH</td>
+    <td>zeppelin.ssl.client.auth</td>
+    <td>false</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_KEYSTORE_PATH</td>
+    <td>zeppelin.ssl.keystore.path</td>
+    <td>keystore</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_KEYSTORE_TYPE</td>
+    <td>zeppelin.ssl.keystore.type</td>
+    <td>JKS</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_KEYSTORE_PASSWORD</td>
+    <td>zeppelin.ssl.keystore.password</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_KEY_MANAGER_PASSWORD</td>
+    <td>zeppelin.ssl.key.manager.password</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_TRUSTSTORE_PATH</td>
+    <td>zeppelin.ssl.truststore.path</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_TRUSTSTORE_TYPE</td>
+    <td>zeppelin.ssl.truststore.type</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_SSL_TRUSTSTORE_PASSWORD</td>
+    <td>zeppelin.ssl.truststore.password</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
+    <td>zeppelin.notebook.homescreen</td>
+    <td></td>
+    <td>A notebook id displayed in Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
+    <td>zeppelin.notebook.homescreen.hide</td>
+    <td>false</td>
+    <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_WAR_TEMPDIR</td>
+    <td>zeppelin.war.tempdir</td>
+    <td>webapps</td>
+    <td>A location of jetty temporary directory</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_DIR</td>
+    <td>zeppelin.notebook.dir</td>
+    <td>notebook</td>
+    <td>A directory path of Zeppelin notebook files</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
+    <td>zeppelin.notebook.s3.bucket</td>
+    <td>zeppelin</td>
+    <td>S3 Bucket where Zeppelin notebook files will be saved</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
+    <td>zeppelin.notebook.s3.user</td>
+    <td>user</td>
+    <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_STORAGE</td>
+    <td>zeppelin.notebook.storage</td>
+    <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
+    <td>Comma separated list of notebook storage</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_INTERPRETERS</td>
+    <td>zeppelin.interpreters</td>
+  <description></description>
+    <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
+    ...
+    </td>
+    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value.</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_INTERPRETER_DIR</td>
+    <td>zeppelin.interpreter.dir</td>
+    <td>interpreter</td>
+    <td>Zeppelin interpreter directory</td>
+  </tr>
+</table>
 
 Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.
 [Spark Interpreter for Apache Zeppelin](../interpreter/spark.html) will be a good example. 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -30,9 +30,9 @@ In this documentation, we will guide you how you can install Zeppelin from **Bin
 
 If you want to install Zeppelin with latest binary package, please visit [this page](http://zeppelin.incubator.apache.org/download.html).
 
-### Build from  Zeppelin Source
+### Build from Zeppelin Source
 
-You can also build Zeppelin from the source. Please check instructions of `README.md` in [Zeppelin github](https://github.com/apache/incubator-zeppelin/blob/master/README.md). 
+You can also build Zeppelin from the source. Please check instructions in `README.md` in [Zeppelin github](https://github.com/apache/incubator-zeppelin/blob/master/README.md). 
 
 
 ## Zeppelin Configuration
@@ -146,7 +146,7 @@ You can configure Zeppelin with both environment variables in `conf/zeppelin-env
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
     <td>zeppelin.notebook.homescreen.hide</td>
     <td>false</td>
-    <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
+    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. For the further information, please read [Customize your Zeppelin homepage](../manual/notebookashomepage.html).</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WAR_TEMPDIR</td>
@@ -158,7 +158,7 @@ You can configure Zeppelin with both environment variables in `conf/zeppelin-env
     <td>ZEPPELIN_NOTEBOOK_DIR</td>
     <td>zeppelin.notebook.dir</td>
     <td>notebook</td>
-    <td>A directory path of Zeppelin notebook files</td>
+    <td>The root directory where Zeppelin notebook directories are saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
@@ -185,7 +185,7 @@ You can configure Zeppelin with both environment variables in `conf/zeppelin-env
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value.</td>
+    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in Zeppelin notebook paragraph. </td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>
@@ -211,5 +211,3 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 ```
 bin/zeppelin-daemon.sh stop
 ```
-
-

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -146,7 +146,7 @@ You can configure Zeppelin with both environment variables in `conf/zeppelin-env
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
     <td>zeppelin.notebook.homescreen.hide</td>
     <td>false</td>
-    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. For the further information, please read [Customize your Zeppelin homepage](../manual/notebookashomepage.html).</td>
+    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WAR_TEMPDIR</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -37,7 +37,7 @@ You can also build Zeppelin from the source. Please check instructions in `READM
 
 ## Zeppelin Configuration
 
-You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` and **java properties** in `conf/zeppelin-site.xml`. If both are defined, then the environment variable will be used priorly.
+You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` and **java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will be used priorly.
 
 <table class="table-configuration">
   <tr>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -24,7 +24,7 @@ limitations under the License.
 ## Zeppelin Installation
 Welcome to your first trial to explore Zeppelin ! 
 
-In this documentation, we will guide you how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can get a specific infomation about Zeppelin configurations at the below **Zeppelin Configuration** section.
+In this documentation, we will explain how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can see all of Zeppelin's configurations in the **Zeppelin Configuration** section below.
 
 ### Install with Binary Package
 
@@ -37,7 +37,7 @@ You can also build Zeppelin from the source. Please check instructions in `READM
 
 ## Zeppelin Configuration
 
-You can configure Zeppelin with both environment variables in `conf/zeppelin-env.sh` and java properties in `conf/zeppelin-site.xml`. If both are defined, then the environment variable will be used priorly.
+You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` and **java properties** in `conf/zeppelin-site.xml`. If both are defined, then the environment variable will be used priorly.
 
 <table class="table-configuration">
   <tr>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Install Zeppelin"
+title: "Zeppelin Installation"
 description: ""
 group: install
 ---
@@ -21,191 +21,291 @@ limitations under the License.
 
 
 
-## From binary package
+## Zeppelin Installation
+Welcome to your first trial to explore Zeppelin ! 
 
-   Download latest binary package from [Download](../download.html).
+In this documentation, we will guide you how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can get a specific infomation about Zeppelin configurations at the below **Zeppelin Configuration** section.
 
+### Install with Binary Package
 
-## Build from source
+If you want to install Zeppelin with latest binary package, please visit [this page](http://zeppelin.incubator.apache.org/download.html).
 
-   Check instructions in [README](https://github.com/apache/incubator-zeppelin/blob/master/README.md) to build from source.
+### Build from  Zeppelin Source
 
-
-
-## Configure
-
-Configuration can be done by both environment variable(conf/zeppelin-env.sh) and java properties(conf/zeppelin-site.xml). If both defined, environment vaiable is used.
+You can also build Zeppelin from the source. Please check instructions of `README.md` in [Zeppelin github](https://github.com/apache/incubator-zeppelin/blob/master/README.md). 
 
 
-<table class="table-configuration">
-  <tr>
-    <th>zepplin-env.sh</th>
-    <th>zepplin-site.xml</th>
-    <th>Default value</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_PORT</td>
-    <td>zeppelin.server.port</td>
-    <td>8080</td>
-    <td>Zeppelin server port.</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_MEM</td>
-    <td>N/A</td>
-    <td>-Xmx1024m -XX:MaxPermSize=512m</td>
-    <td>JVM mem options</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_INTP_MEM</td>
-    <td>N/A</td>
-    <td>ZEPPELIN_MEM</td>
-    <td>JVM mem options for interpreter process</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_JAVA_OPTS</td>
-    <td>N/A</td>
-    <td></td>
-    <td>JVM Options</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_ALLOWED_ORIGINS</td>
-    <td>zeppelin.server.allowed.origins</td>
-    <td>*</td>
-    <td>Allows a way to specify a ',' separated list of allowed origins for rest and websockets. i.e. http://localhost:8080</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SERVER_CONTEXT_PATH</td>
-    <td>zeppelin.server.context.path</td>
-    <td>/</td>
-    <td>Context Path of the Web Application</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL</td>
-    <td>zeppelin.ssl</td>
-    <td>false</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_CLIENT_AUTH</td>
-    <td>zeppelin.ssl.client.auth</td>
-    <td>false</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_KEYSTORE_PATH</td>
-    <td>zeppelin.ssl.keystore.path</td>
-    <td>keystore</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_KEYSTORE_TYPE</td>
-    <td>zeppelin.ssl.keystore.type</td>
-    <td>JKS</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_KEYSTORE_PASSWORD</td>
-    <td>zeppelin.ssl.keystore.password</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_KEY_MANAGER_PASSWORD</td>
-    <td>zeppelin.ssl.key.manager.password</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_TRUSTSTORE_PATH</td>
-    <td>zeppelin.ssl.truststore.path</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_TRUSTSTORE_TYPE</td>
-    <td>zeppelin.ssl.truststore.type</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_SSL_TRUSTSTORE_PASSWORD</td>
-    <td>zeppelin.ssl.truststore.password</td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
-    <td>zeppelin.notebook.homescreen</td>
-    <td></td>
-    <td>Id of notebook to be displayed in homescreen ex) 2A94M5J1Z</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
-    <td>zeppelin.notebook.homescreen.hide</td>
-    <td>false</td>
-    <td>hide homescreen notebook from list when this value set to "true"</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_WAR_TEMPDIR</td>
-    <td>zeppelin.war.tempdir</td>
-    <td>webapps</td>
-    <td>The location of jetty temporary directory.</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_DIR</td>
-    <td>zeppelin.notebook.dir</td>
-    <td>notebook</td>
-    <td>Where notebook file is saved</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
-    <td>zeppelin.notebook.s3.bucket</td>
-    <td>zeppelin</td>
-    <td>Bucket where notebook saved</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
-    <td>zeppelin.notebook.s3.user</td>
-    <td>user</td>
-    <td>User in bucket where notebook saved. For example bucket/user/notebook/2A94M5J1Z/note.json</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_NOTEBOOK_STORAGE</td>
-    <td>zeppelin.notebook.storage</td>
-    <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
-    <td>Comma separated list of notebook storage</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_INTERPRETERS</td>
-    <td>zeppelin.interpreters</td>
-  <description></description>
-    <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
-    ...
-    </td>
-    <td>Comma separated interpreter configurations [Class]. First interpreter become a default</td>
-  </tr>
-  <tr>
-    <td>ZEPPELIN_INTERPRETER_DIR</td>
-    <td>zeppelin.interpreter.dir</td>
-    <td>interpreter</td>
-    <td>Zeppelin interpreter directory</td>
-  </tr>
-</table>
+## Zeppelin Configuration
 
-<br />
-You'll also need to configure individual interpreter. Information can be found in 'Interpreter' section in this documentation.
+You can configure Zeppelin with both environment variables in `conf/zeppelin-env.sh` and java properties in `conf/zeppelin-site.xml`. If both are defined, then the environment variable will be used priorly.
 
-For example [Spark](../interpreter/spark.html).
+<ul class="nav nav-tabs">
+  <li class="active"><a data-toggle="tab" href="#zeppelin-env"><b>zeppelin-env.sh</b></a></li>
+  <li><a data-toggle="tab" href="#zeppelin-site"><b>zeppelin-site.xml</b></a></li>
+</ul>
 
-<br />
-## Start/Stop
+<div class="tab-content">
+  <div id="zeppelin-env" class="tab-pane fade in active">
+    <table class="table-configuration">
+      <tr>
+        <th>zepplin-env.sh</th>
+        <th>Default Value</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_PORT</td>
+        <td>8080</td>
+        <td>Zeppelin server port</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_MEM</td>
+        <td>-Xmx1024m -XX:MaxPermSize=512m</td>
+        <td>JVM mem options</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_INTP_MEM</td>
+        <td>ZEPPELIN_MEM</td>
+        <td>JVM mem options for interpreter process</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_JAVA_OPTS</td>
+        <td></td>
+        <td>JVM Options</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_ALLOWED_ORIGINS</td>
+        <td>*</td>
+        <td>Enables a way to specify a ',' separated list of allowed origins for rest and websockets. <br /> i.e. http://localhost:8080 </td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SERVER_CONTEXT_PATH</td>
+        <td>/</td>
+        <td>The context path of the web application</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL</td>
+        <td>false</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_CLIENT_AUTH</td>
+        <td>false</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_KEYSTORE_PATH</td>
+        <td>keystore</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_KEYSTORE_TYPE</td>
+        <td>JKS</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_KEYSTORE_PASSWORD</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_KEY_MANAGER_PASSWORD</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_TRUSTSTORE_PATH</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_TRUSTSTORE_TYPE</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_SSL_TRUSTSTORE_PASSWORD</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
+        <td></td>
+        <td>A notebook id displayed in homescreen <br />i.e. 2A94M5J1Z</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
+        <td>false</td>
+        <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_WAR_TEMPDIR</td>
+        <td>webapps</td>
+        <td>Jetty temporary directory location</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_DIR</td>
+        <td>notebook</td>
+        <td>A directory path of Zeppelin notebook files</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
+        <td>zeppelin</td>
+        <td>S3 Bucket where Zeppelin notebook files will be saved</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
+        <td>user</td>
+        <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_NOTEBOOK_STORAGE</td>
+        <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
+        <td>Comma separated list of notebook storage</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_INTERPRETERS</td>
+      <description></description>
+        <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
+        ...
+        </td>
+        <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default.</td>
+      </tr>
+      <tr>
+        <td>ZEPPELIN_INTERPRETER_DIR</td>
+        <td>interpreter</td>
+        <td>Zeppelin interpreter directory</td>
+      </tr>
+    </table>
+  </div>
+  <div id="zeppelin-site" class="tab-pane fade">
+    <table class="table-configuration">
+      <tr>
+        <th>zepplin-site.xml</th>
+        <th>Default value</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>zeppelin.server.port</td>
+        <td>8080</td>
+        <td>Zeppelin server port</td>
+      </tr>
+      <tr>
+        <td>zeppelin.server.allowed.origins</td>
+        <td>*</td>
+        <td>Enables a way to specify a ',' separated list of allowed origins for rest and websockets. <br /> i.e. http://localhost:8080 </td>
+      </tr>
+      <tr>
+        <td>zeppelin.server.context.path</td>
+        <td>/</td>
+        <td>The context path of the web application</td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl</td>
+        <td>false</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.client.auth</td>
+        <td>false</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.keystore.path</td>
+        <td>keystore</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.keystore.type</td>
+        <td>JKS</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.keystore.password</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.key.manager.password</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.truststore.path</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.truststore.type</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.ssl.truststore.password</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.homescreen</td>
+        <td></td>
+        <td>A notebook id displayed in homescreen <br />i.e. 2A94M5J1Z</td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.homescreen.hide</td>
+        <td>false</td>
+        <td>This value can be "true" when you want to hide notebooks from Zeppelin homescreen.</td>
+      </tr>
+      <tr>
+        <td>zeppelin.war.tempdir</td>
+        <td>webapps</td>
+        <td>Jetty temporary directory location</td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.dir</td>
+        <td>notebook</td>
+        <td>A directory path of Zeppelin notebook files</td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.s3.bucket</td>
+        <td>zeppelin</td>
+        <td>S3 Bucket where Zeppelin notebook files will be saved</td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.s3.user</td>
+        <td>user</td>
+        <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
+      </tr>
+      <tr>
+        <td>zeppelin.notebook.storage</td>
+        <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>
+        <td>Comma separated list of notebook storage</td>
+      </tr>
+      <tr>
+        <td>zeppelin.interpreters</td>
+      <description></description>
+        <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />org.apache.zeppelin.hive.HiveInterpreter<br />
+        ...
+        </td>
+        <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default.</td>
+      </tr>
+      <tr>
+        <td>zeppelin.interpreter.dir</td>
+        <td>interpreter</td>
+        <td>Zeppelin interpreter directory</td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.
+[Spark Interpreter for Apache Zeppelin](../interpreter/spark.html) will be a good example. 
+
+## Zeppelin Start / Stop
 #### Start Zeppelin
 
 ```
 bin/zeppelin-daemon.sh start
 ```
-After successful start, visit http://localhost:8080 with your web browser.
+After successful start, visit [http://localhost:8080](http://localhost:8080) with your web browser.
 
 #### Stop Zeppelin
 


### PR DESCRIPTION
### What is this PR for?
As mentioned at [ZEPPELIN-638](https://issues.apache.org/jira/browse/ZEPPELIN-638), there is a dead link in `docs/install/install.md`. So I fixed it. Plus, I also add a table tab to **Zeppelin Configuration** section because current one is not good to look. 

### What type of PR is it?
Improvement | Documentation

### Todos
* [x] - Fix dead link
* [x] - Add table tab to Zeppelin Configuration section

### Is there a relevant Jira issue?
[ZEPPELIN-638](https://issues.apache.org/jira/browse/ZEPPELIN-638) (only for fixing dead link)

### How should this be tested?
After applying this PR, you can check this page `Quick Start` -> `Install` at Zeppelin documentation. 

### Screenshots (if appropriate)
* Before
![before](https://cloud.githubusercontent.com/assets/10060731/12668250/ed1ba00c-c697-11e5-943c-57f140ccf6db.gif)

* After 
![after](https://cloud.githubusercontent.com/assets/10060731/12668254/fb7a067a-c697-11e5-8061-62a79ab2bbc6.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No