### PR TITLE
Propagate maven -DskipTests option to WebApp

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -434,22 +434,6 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('build', [
-    'test',
-    'clean:dist',
-    'wiredep',
-    'useminPrepare',
-    'concurrent:dist',
-    'postcss',
-    'concat',
-    'ngAnnotate',
-    'copy:dist',
-    'cssmin',
-    'uglify',
-    'usemin',
-    'htmlmin'
-  ]);
-
-  grunt.registerTask('buildSkipTests', [
     'clean:dist',
     'wiredep',
     'useminPrepare',

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -86,7 +86,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.23</version>
+        <version>0.0.25</version>
         <executions>
 
           <execution>
@@ -122,11 +122,22 @@
             <goals>
               <goal>grunt</goal>
             </goals>
-
             <configuration>
-              <arguments>--no-color</arguments>
+              <arguments>build</arguments>
             </configuration>
           </execution>
+
+          <execution>
+            <id>grunt test</id>
+            <goals>
+              <goal>grunt</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <arguments>test</arguments>
+            </configuration>
+          </execution>
+
         </executions>
       </plugin>
 


### PR DESCRIPTION
### What is this PR for?
This PR has for goal to help people build Zeppelin when phantomJS is not working properly on their machine:
* [Some Problems Here](https://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/201509.mbox/%3CCAKhwvQtTCDeXaQOhpu+wvxPj1io4ra+dG=mEQE7eVR5xboB8eA@mail.gmail.com%3E)
* [Here Too](https://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/201511.mbox/%3CCABePtM3iMeWayAqOzeDahcL-Bz8A3uXUqSuMU41dehWXMd_vmA@mail.gmail.com%3E)
* And more

Currently, you have to edit some code in order to bypass the test launched by grunt, and it doesn't seem right for `-DskipTests` to no skip the WebApp tests.

In order to apply that rule, we need to bump the version of `frontend-maven-plugin` to 0.0.25. Sadly they do not have a changelog, so we need to make sure everything is alright.

### What type of PR is it?
Improvement

### Is there a relevant Jira issue?
Related: https://issues.apache.org/jira/browse/ZEPPELIN-403
https://issues.apache.org/jira/browse/ZEPPELIN-644

### How should this be tested?
* You should clear your bower cache, since we changed a dependency version.
* Run `mvn package` inside zeppelin-web folder and assess that the test were ran
```
Running "karma:unit" (karma) task
[INFO] INFO [karma]: Karma v0.12.37 server started at http://localhost:9002/
[INFO] INFO [launcher]: Starting browser PhantomJS
[INFO] INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket OHBv4N47NmnKdZx9YUm7 with id 61917714
       PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 37 of 82 SUCCESS (0 secs / 0.249 secs)
       PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 82 of 82 SUCCESS (0.578 secs / 0.562 secs)
```
* Run `mvn package -DskipTests` and assess that PhantomJS didnt run

### Questions:
* Does the licenses files need update? No, its wasn't listed originally
* Is there breaking changes for older versions? No
* Does this needs documentation? No