### PR TITLE
ZEPPELIN-646: Shell interpreter output streaming

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -72,7 +72,7 @@ public class ShellInterpreter extends Interpreter {
     DefaultExecutor executor = new DefaultExecutor();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
-    executor.setStreamHandler(new PumpStreamHandler(outputStream, errorStream));
+    executor.setStreamHandler(new PumpStreamHandler(contextInterpreter.out, errorStream));
     executor.setWatchdog(new ExecuteWatchdog(commandTimeOut));
 
     Job runningJob = getRunningJob(contextInterpreter.getParagraphId());
@@ -82,7 +82,7 @@ public class ShellInterpreter extends Interpreter {
       int exitVal = executor.execute(cmdLine);
       logger.info("Paragraph " + contextInterpreter.getParagraphId()
           + "return with exit value: " + exitVal);
-      return new InterpreterResult(InterpreterResult.Code.SUCCESS, outputStream.toString());
+      return new InterpreterResult(InterpreterResult.Code.SUCCESS, null);
     } catch (ExecuteException e) {
       int exitValue = e.getExitValue();
       logger.error("Can not run " + cmd, e);
@@ -94,7 +94,7 @@ public class ShellInterpreter extends Interpreter {
         logger.info("The paragraph " + contextInterpreter.getParagraphId()
             + " stopped executing: " + msg);
       }
-      msg += "Exitvalue: " + exitValue;
+      msg += "ExitValue: " + exitValue;
       return new InterpreterResult(code, msg);
     } catch (IOException e) {
       logger.error("Can not run " + cmd, e);


### PR DESCRIPTION
### What is this PR for?
After #611 merged, Zeppelin provides streaming output for **spark** and **pyspark** interpreter. For the further improvement, I changed a few code lines using <code>[InterpreterContext](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java#L66)</code> so that **sh** interpreter can be available too.

### What type of PR is it?
Improvement

### Todos

### Is there a relevant Jira issue?
[ZEPPELIN-646: Shell interpreter output streaming](https://issues.apache.org/jira/browse/ZEPPELIN-646)
[ZEPPELIN-554: Streaming interpreter output to front-end]()

### How should this be tested?
After applying this PR, run this below code with `sh` interpreter in Zeppelin.
```
date && sleep 3 &&  date
```

Then you can see two timestamps which have 3 seconds gap. 

### Screenshots (if appropriate)
![shell_interpreter](https://cloud.githubusercontent.com/assets/10060731/12745026/b12e7b28-c9da-11e5-8832-0ebc74bbf4f3.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No