### PR TITLE
[ZEPPELIN-595] Allow displaying decimal format in d3

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1238,7 +1238,7 @@ angular.module('zeppelinWebApp')
 
   };
 
-  var groupedThousandsWith3DigitsFormater = function(x){
+  var groupedThousandsWith3DigitsFormatter = function(x){
     return d3.format(',')(d3.round(x, 3));
   };
 
@@ -1262,7 +1262,7 @@ angular.module('zeppelinWebApp')
     if(d >= Math.pow(10,6)){
       return customAbbrevFormatter(d);
     }
-    return groupedThousandsWith3DigitsFormater(d);
+    return groupedThousandsWith3DigitsFormatter(d);
   };
 
   var setD3Chart = function(type, data, refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1258,7 +1258,7 @@ angular.module('zeppelinWebApp')
     if(d >= Math.pow(10,6)){
       return customAbbrevFormatter(d);
     }
-    return d;
+    return d3.round(d, 3);
   };
 
   var setD3Chart = function(type, data, refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1238,7 +1238,7 @@ angular.module('zeppelinWebApp')
 
   };
 
-  var groupedThousandsWith3DigitsFormmater = function(x){
+  var groupedThousandsWith3DigitsFormater = function(x){
     return d3.format(',')(d3.round(x, 3));
   };
 
@@ -1262,7 +1262,7 @@ angular.module('zeppelinWebApp')
     if(d >= Math.pow(10,6)){
       return customAbbrevFormatter(d);
     }
-    return groupedThousandsWith3DigitsFormmater(d);
+    return groupedThousandsWith3DigitsFormater(d);
   };
 
   var setD3Chart = function(type, data, refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1238,8 +1238,6 @@ angular.module('zeppelinWebApp')
 
   };
 
-  var integerFormatter = d3.format(',.1d');
-
   var customAbbrevFormatter = function(x) {
     var s = d3.format('.3s')(x);
     switch (s[s.length - 1]) {
@@ -1260,7 +1258,7 @@ angular.module('zeppelinWebApp')
     if(d >= Math.pow(10,6)){
       return customAbbrevFormatter(d);
     }
-    return integerFormatter(d);
+    return d;
   };
 
   var setD3Chart = function(type, data, refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1238,6 +1238,10 @@ angular.module('zeppelinWebApp')
 
   };
 
+  var groupedThousandsWith3DigitsFormmater = function(x){
+    return d3.format(',')(d3.round(x, 3));
+  };
+
   var customAbbrevFormatter = function(x) {
     var s = d3.format('.3s')(x);
     switch (s[s.length - 1]) {
@@ -1258,7 +1262,7 @@ angular.module('zeppelinWebApp')
     if(d >= Math.pow(10,6)){
       return customAbbrevFormatter(d);
     }
-    return d3.round(d, 3);
+    return groupedThousandsWith3DigitsFormmater(d);
   };
 
   var setD3Chart = function(type, data, refresh) {


### PR DESCRIPTION
### What is this PR for?
This PR enables displaying decimal format in built-in nvd3 chart

### What type of PR is it?
Bug Fix

### Is there a relevant Jira issue?
[ZEPPELIN-595](https://issues.apache.org/jira/browse/ZEPPELIN-595)

### Screenshots (if appropriate)
Before
<img width="767" alt="screen shot 2016-02-02 at 2 12 38 pm" src="https://cloud.githubusercontent.com/assets/8503346/12766225/836f42b2-c9b7-11e5-8dd2-9135d76324b0.png">
After
<img width="767" alt="screen shot 2016-02-02 at 2 13 17 pm" src="https://cloud.githubusercontent.com/assets/8503346/12766226/848996e8-c9b7-11e5-8104-b6654686dcd4.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No