### PR TITLE
ZEPPELiN-654 Improvement to SparkSqlInterpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -17,15 +17,11 @@
 
 package org.apache.zeppelin.spark;
 
-import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asJavaIterable;
-import static scala.collection.JavaConversions.collectionAsScalaIterable;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,8 +45,6 @@ import org.apache.zeppelin.resource.ResourceSet;
 
 import scala.Tuple2;
 import scala.Unit;
-import scala.collection.Iterable;
-import scala.collection.JavaConversions;
 
 /**
  * Spark context for zeppelin.
@@ -203,16 +197,14 @@ public class ZeppelinContext {
       throw new InterpreterException(e);
     }
 
-    String msg = null;
+    StringBuilder msg = new StringBuilder();
+    msg.append("%table ");
     for (Attribute col : columns) {
-      if (msg == null) {
-        msg = col.name();
-      } else {
-        msg += "\t" + col.name();
-      }
+      msg.append(col.name() + "\t");
     }
-
-    msg += "\n";
+    String trim = msg.toString().trim();
+    msg = new StringBuilder(trim);
+    msg.append("\n");
 
     // ArrayType, BinaryType, BooleanType, ByteType, DecimalType, DoubleType, DynamicType,
     // FloatType, FractionalType, IntegerType, IntegralType, LongType, MapType, NativeType,
@@ -226,15 +218,15 @@ public class ZeppelinContext {
 
         for (int i = 0; i < columns.size(); i++) {
           if (!(Boolean) isNullAt.invoke(row, i)) {
-            msg += apply.invoke(row, i).toString();
+            msg.append(apply.invoke(row, i).toString());
           } else {
-            msg += "null";
+            msg.append("null");
           }
           if (i != columns.size() - 1) {
-            msg += "\t";
+            msg.append("\t");
           }
         }
-        msg += "\n";
+        msg.append("\n");
       }
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException | InvocationTargetException e) {
@@ -242,10 +234,10 @@ public class ZeppelinContext {
     }
 
     if (rows.length > maxResult) {
-      msg += "\n<font color=red>Results are limited by " + maxResult + ".</font>";
+      msg.append("\n<font color=red>Results are limited by " + maxResult + ".</font>");
     }
     sc.clearJobGroup();
-    return "%table " + msg;
+    return msg.toString();
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
Improve performance of Sparksqlinterpreter
Use StringBuilder instead of String when building the results returned by SparksqlInterpreter 

### What type of PR is it?
Improvement

### Todos
NA

### Is there a relevant Jira issue?

### How should this be tested?
Try to run a Sparksql command that returns large number of rows(make sure `zeppelin.spark.maxResult` is set to a larger value) with and without fix.
Keep note of the time taken in each case.
The time taken with this change  is significantly lesser.

### Screenshots (if appropriate) 
NA

### Questions:
* Does the licenses files need update?  No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
