### PR TITLE
ZEPPELIN-656 - Support saving notebooks to Azure cloud storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,8 @@ Here are some things you will need to build and test Zeppelin.
 
 ### Software Configuration Management (SCM)
 
-Zeppelin uses Git for its SCM system. Hosted by github.com. `https://github.com/apache/incubator-zeppelin` you'll need git client installed in your development machine.
+Zeppelin uses Git for its SCM system. `http://git.apache.org/incubator-zeppelin.git` you'll need git client installed in your development machine.
+For write access, `https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git`
 
 ### Integrated Development Environment (IDE)
 
@@ -114,26 +115,31 @@ To build the code, install
  * Apache Maven
 
 ## Getting the source code
-First of all, you need the Zeppelin source code. The official location for Zeppelin is [https://github.com/apache/incubator-zeppelin](https://github.com/apache/incubator-zeppelin)
+First of all, you need the Zeppelin source code. The official location for Zeppelin is [http://git.apache.org/incubator-zeppelin.git](http://git.apache.org/incubator-zeppelin.git).
 
 ### git access
 
 Get the source code on your development machine using git.
 
 ```
-git clone git@github.com:apache/incubator-zeppelin.git zeppelin
+git clone http://git.apache.org/incubator-zeppelin.git zeppelin
 ```
 
 You may also want to develop against a specific release. For example, for branch-0.1
 
 ```
-git clone -b branch-0.1 git@github.com:apache/incubator-zeppelin.git zeppelin
+git clone -b branch-0.1 http://git.apache.org/incubator-zeppelin.git zeppelin
 ```
 
+or with write access
+
+```
+git clone https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git
+```
 
 ### Fork repository
 
-If you want not only build Zeppelin but also make change, then you need fork Zeppelin repository and make pull request.
+If you want not only build Zeppelin but also make change, then you need fork Zeppelin github mirror repository (https://github.com/apache/incubator-zeppelin) and make pull request.
 
 
 ## Build

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-angular</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Angular interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-angular</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Angular interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-angular</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Angular interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -15,21 +15,19 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.6.0-incubating-SNAPSHOT</version>
+        <version>0.5.6-incubating</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-cassandra</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <name>Zeppelin: Cassandra</name>
     <description>Zeppelin cassandra support</description>
     <url>http://zeppelin.incubator.apache.org</url>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.5.6-incubating</version>
+        <version>0.5.7-incubating-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-cassandra</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <name>Zeppelin: Cassandra</name>
     <description>Zeppelin cassandra support</description>
     <url>http://zeppelin.incubator.apache.org</url>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -15,19 +15,21 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.5.7-incubating-SNAPSHOT</version>
+        <version>0.6.0-incubating-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-cassandra</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <name>Zeppelin: Cassandra</name>
     <description>Zeppelin cassandra support</description>
     <url>http://zeppelin.incubator.apache.org</url>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -83,6 +83,33 @@
 </property>
 -->
 
+<!-- If using Azure for storage use the following settings -->
+<!--
+<property>
+  <name>zeppelin.notebook.azure.user</name>
+  <value>user</value>
+  <description>user name for Azure folder structure</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.share</name>
+  <value>zeppelin</value>
+  <description>share name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.connectionString</name>
+  <value>DefaultEndpointsProtocol=https;AccountName=<accountName>;AccountKey=<accountKey></value>
+  <description>share name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.AzureNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+
 <!-- For versioning your local norebook storage using Git repository
 <property>
   <name>zeppelin.notebook.storage</name>

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -125,7 +125,7 @@ function make_binary_release() {
     rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
 }
 
-make_binary_release all "-Pspark-1.5 -Phadoop-2.4 -Pyarn -Ppyspark"
+make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
 
 # remove non release files and dirs
 rm -rf ${WORKING_DIR}/zeppelin

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ This way, you can easily embed it as an iframe inside of your website.</p>
 <br />
 ### 100% Opensource
 
-Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](https://github.com/apache/incubator-zeppelin) and [How to contribute](./development/howtocontribute.html)
+Apache Zeppelin (incubating) is Apache2 Licensed software. Please check out the [source repository](http://git.apache.org/incubator-zeppelin.git) and [How to contribute](./development/howtocontribute.html)
 
 Zeppelin has a very active development community.
 Join the [Mailing list](./community.html) and report issues on our [Issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN).

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Elasticsearch interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Elasticsearch interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Elasticsearch interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-flink</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Flink</name>
   <description>Zeppelin flink support</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-flink</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Flink</name>
   <description>Zeppelin flink support</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-flink</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Flink</name>
   <description>Zeppelin flink support</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-hive</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Hive interpreter</name>
   <url>http://www.apache.org</url>
 <!--

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-hive</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Hive interpreter</name>
   <url>http://www.apache.org</url>
 <!--

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-hive</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Hive interpreter</name>
   <url>http://www.apache.org</url>
 <!--

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>zeppelin-ignite</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Apache Ignite interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>zeppelin-ignite</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Apache Ignite interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>zeppelin-ignite</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Apache Ignite interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -17,20 +17,18 @@
   -->
 
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.6.0-incubating-SNAPSHOT</version>
+        <version>0.5.6-incubating</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-kylin</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <name>Zeppelin: Kylin interpreter</name>
     <url>http://zeppelin.incubator.apache.org</url>
 

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -17,18 +17,20 @@
   -->
 
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.5.7-incubating-SNAPSHOT</version>
+        <version>0.6.0-incubating-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-kylin</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <name>Zeppelin: Kylin interpreter</name>
     <url>http://zeppelin.incubator.apache.org</url>
 

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -21,14 +21,14 @@
     <parent>
         <artifactId>zeppelin</artifactId>
         <groupId>org.apache.zeppelin</groupId>
-        <version>0.5.6-incubating</version>
+        <version>0.5.7-incubating-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.zeppelin</groupId>
     <artifactId>zeppelin-kylin</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <name>Zeppelin: Kylin interpreter</name>
     <url>http://zeppelin.incubator.apache.org</url>
 

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-lens</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Lens interpreter</name>
   <url>http://www.apache.org</url>
   

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-lens</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Lens interpreter</name>
   <url>http://www.apache.org</url>
   

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-lens</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Lens interpreter</name>
   <url>http://www.apache.org</url>
   

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-markdown</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Markdown interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-markdown</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Markdown interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-markdown</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Markdown interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/phoenix/pom.xml
+++ b/phoenix/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-phoenix</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Apache Phoenix Interpreter</name>
   <description>Zeppelin interprter for Apache Phoenix</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/phoenix/pom.xml
+++ b/phoenix/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-phoenix</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Apache Phoenix Interpreter</name>
   <description>Zeppelin interprter for Apache Phoenix</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/phoenix/pom.xml
+++ b/phoenix/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-phoenix</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Apache Phoenix Interpreter</name>
   <description>Zeppelin interprter for Apache Phoenix</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements. See the NOTICE file distributed with this
@@ -35,7 +34,7 @@
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin</artifactId>
   <packaging>pom</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin</name>
   <description>Zeppelin project</description>
   <url>http://zeppelin.incubator.apache.org/</url>
@@ -58,6 +57,7 @@
     <url>https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</url>
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</developerConnection>
+    <tag>v0.5.6</tag>
   </scm>
 
   <developers>
@@ -398,7 +398,7 @@
             <id>enforce</id>
             <configuration>
               <rules>
-                <DependencyConvergence/>
+                <DependencyConvergence />
               </rules>
               <failFast>true</failFast>
             </configuration>
@@ -587,7 +587,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore/>
+                    <ignore />
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -607,7 +607,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore />
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements. See the NOTICE file distributed with this
@@ -34,7 +35,7 @@
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin</artifactId>
   <packaging>pom</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin</name>
   <description>Zeppelin project</description>
   <url>http://zeppelin.incubator.apache.org/</url>
@@ -57,7 +58,6 @@
     <url>https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</url>
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</developerConnection>
-    <tag>HEAD</tag>
   </scm>
 
   <developers>
@@ -398,7 +398,7 @@
             <id>enforce</id>
             <configuration>
               <rules>
-                <DependencyConvergence />
+                <DependencyConvergence/>
               </rules>
               <failFast>true</failFast>
             </configuration>
@@ -587,7 +587,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
                 <pluginExecution>
@@ -607,7 +607,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore></ignore>
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin</artifactId>
   <packaging>pom</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin</name>
   <description>Zeppelin project</description>
   <url>http://zeppelin.incubator.apache.org/</url>
@@ -57,7 +57,7 @@
     <url>https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</url>
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</developerConnection>
-    <tag>v0.5.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -16,20 +16,19 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-postgresql</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: PostgreSQL interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -16,19 +16,20 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-postgresql</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: PostgreSQL interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-postgresql</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: PostgreSQL interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-shell</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Shell interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-shell</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Shell interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-shell</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Shell interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark-dependencies</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Spark dependencies</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>
@@ -43,7 +43,7 @@
     <hadoop.version>2.3.0</hadoop.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <avro.version>1.7.7</avro.version>
-    <avro.mapred.classifier></avro.mapred.classifier>
+    <avro.mapred.classifier />
     <jets3t.version>0.7.1</jets3t.version>
     <protobuf.version>2.4.1</protobuf.version>
 
@@ -792,12 +792,9 @@
                 </goals>
                 <configuration>
                   <target>
-                    <delete dir="../interpreter/spark/pyspark"/>
-                    <copy todir="../interpreter/spark/pyspark"
-                        file="${project.build.directory}/spark-dist/spark-${spark.version}/python/lib/py4j-${py4j.version}-src.zip"/>
-                    <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip"
-                         basedir="${project.build.directory}/spark-dist/spark-${spark.version}/python"
-                         includes="pyspark/*.py,pyspark/**/*.py"/>
+                    <delete dir="../interpreter/spark/pyspark" />
+                    <copy todir="../interpreter/spark/pyspark" file="${project.build.directory}/spark-dist/spark-${spark.version}/python/lib/py4j-${py4j.version}-src.zip" />
+                    <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip" basedir="${project.build.directory}/spark-dist/spark-${spark.version}/python" includes="pyspark/*.py,pyspark/**/*.py" />
                   </target>
                 </configuration>
               </execution>
@@ -878,7 +875,7 @@
             </filter>
           </filters>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
             </transformer>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark-dependencies</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Spark dependencies</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>
@@ -43,7 +43,7 @@
     <hadoop.version>2.3.0</hadoop.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <avro.version>1.7.7</avro.version>
-    <avro.mapred.classifier />
+    <avro.mapred.classifier></avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>
     <protobuf.version>2.4.1</protobuf.version>
 
@@ -792,9 +792,12 @@
                 </goals>
                 <configuration>
                   <target>
-                    <delete dir="../interpreter/spark/pyspark" />
-                    <copy todir="../interpreter/spark/pyspark" file="${project.build.directory}/spark-dist/spark-${spark.version}/python/lib/py4j-${py4j.version}-src.zip" />
-                    <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip" basedir="${project.build.directory}/spark-dist/spark-${spark.version}/python" includes="pyspark/*.py,pyspark/**/*.py" />
+                    <delete dir="../interpreter/spark/pyspark"/>
+                    <copy todir="../interpreter/spark/pyspark"
+                        file="${project.build.directory}/spark-dist/spark-${spark.version}/python/lib/py4j-${py4j.version}-src.zip"/>
+                    <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip"
+                         basedir="${project.build.directory}/spark-dist/spark-${spark.version}/python"
+                         includes="pyspark/*.py,pyspark/**/*.py"/>
                   </target>
                 </configuration>
               </execution>
@@ -875,7 +878,7 @@
             </filter>
           </filters>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
             </transformer>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark-dependencies</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Spark dependencies</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Spark</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>
@@ -408,7 +408,7 @@
             </filter>
           </filters>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
             </transformer>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Spark</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>
@@ -408,7 +408,7 @@
             </filter>
           </filters>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>reference.conf</resource>
             </transformer>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-spark</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Spark</name>
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -335,6 +335,10 @@ public class SparkInterpreter extends Interpreter {
       conf.set("spark.submit.pyArchives", Joiner.on(":").join(pythonLibs));
     }
 
+    // Distributes needed libraries to workers.
+    if (getProperty("master").equals("yarn-client")) {
+      conf.set("spark.yarn.isPython", "true");
+    }
 
     SparkContext sparkContext = new SparkContext(conf);
     return sparkContext;

--- a/tajo/pom.xml
+++ b/tajo/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-tajo</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Tajo interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/tajo/pom.xml
+++ b/tajo/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-tajo</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Tajo interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/tajo/pom.xml
+++ b/tajo/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-tajo</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Tajo interpreter</name>
   <url>http://www.apache.org</url>
 

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -16,14 +16,13 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -16,13 +16,14 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -16,22 +16,21 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-interpreter</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Interpreter</name>
   <description>Zeppelin Interpreter</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-interpreter</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Interpreter</name>
   <description>Zeppelin Interpreter</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -16,21 +16,22 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-interpreter</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Interpreter</name>
   <description>Zeppelin Interpreter</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-server</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Server</name>
   <url>http://www.nflabs.com</url>
 
@@ -337,7 +337,7 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <version>1.0</version>
         <configuration>
-          <stderr />
+          <stderr/>
           <systemProperties>
             <spark.testing>1</spark.testing>
           </systemProperties>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-server</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Server</name>
   <url>http://www.nflabs.com</url>
 
@@ -337,7 +337,7 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <version>1.0</version>
         <configuration>
-          <stderr/>
+          <stderr />
           <systemProperties>
             <spark.testing>1</spark.testing>
           </systemProperties>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-server</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Server</name>
   <url>http://www.nflabs.com</url>
 

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-web</artifactId>
   <packaging>war</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: web Application</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-web</artifactId>
   <packaging>war</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: web Application</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-web</artifactId>
   <packaging>war</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: web Application</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -66,7 +66,7 @@ limitations under the License.
        ng-Init="init(currentParagraph)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
        class="paragraph-col">
-    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly">
+    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe">
       <h4 class="plus-sign">&#43;</h4>
     </div>
     <div id="{{currentParagraph.id}}_paragraphColumn"
@@ -75,7 +75,7 @@ limitations under the License.
                     'lastEmptyParagraph': !paragraph.text && !paragraph.result}"
          ng-hide="currentParagraph.config.tableHide && viewOnly">
     </div>
-    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly">
+    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || asIframe ">
       <h4 class="plus-sign">&#43;</h4>
     </div>
   </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -960,7 +960,7 @@ angular.module('zeppelinWebApp')
       clearUnknownColsFromGraphOption();
       // set graph height
       var height = $scope.paragraph.config.graph.height;
-      angular.element('#p' + $scope.paragraph.id + '_resize').height(height);
+      angular.element('#p' + $scope.paragraph.id + '_graph').height(height);
 
       if (!type || type === 'table') {
         setTable($scope.paragraph.result, refresh);

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -59,6 +59,26 @@
 	</dependency>
 
     <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-storage</artifactId>
+      <version>4.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.6-incubating</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-zengine</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.6-incubating</version>
   <name>Zeppelin: Zengine</name>
   <description>Zeppelin Zengine</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.7-incubating-SNAPSHOT</version>
+    <version>0.6.0-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-zengine</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7-incubating-SNAPSHOT</version>
+  <version>0.6.0-incubating-SNAPSHOT</version>
   <name>Zeppelin: Zengine</name>
   <description>Zeppelin Zengine</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.5.6-incubating</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-zengine</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6-incubating</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Zengine</name>
   <description>Zeppelin Zengine</description>
   <url>http://zeppelin.incubator.apache.org</url>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -423,6 +423,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE("zeppelin.notebook.homescreen.hide", false),
     ZEPPELIN_NOTEBOOK_S3_BUCKET("zeppelin.notebook.s3.bucket", "zeppelin"),
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),
+    ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING("zeppelin.notebook.azure.connectionString", null),
+    ZEPPELIN_NOTEOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner", "bin/interpreter.sh"),
     // Decide when new note is created, interpreter settings will be binded automatically or not.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.repo;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.file.*;
+import org.apache.commons.io.IOUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.scheduler.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.*;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Azure storage backend for notebooks
+ */
+public class AzureNotebookRepo implements NotebookRepo {
+  private static final Logger LOG = LoggerFactory.getLogger(S3NotebookRepo.class);
+
+  private final ZeppelinConfiguration conf;
+  private final String user;
+  private final String shareName;
+  private final CloudFileDirectory rootDir;
+
+  public AzureNotebookRepo(ZeppelinConfiguration conf)
+      throws URISyntaxException, InvalidKeyException, StorageException {
+    this.conf = conf;
+    user = conf.getUser();
+    shareName = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_SHARE);
+
+    CloudStorageAccount account = CloudStorageAccount.parse(
+        conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING));
+    CloudFileClient client = account.createCloudFileClient();
+    CloudFileShare share = client.getShareReference(shareName);
+    share.createIfNotExists();
+
+    CloudFileDirectory userDir = share.getRootDirectoryReference().getDirectoryReference(user);
+    userDir.createIfNotExists();
+
+    rootDir = userDir.getDirectoryReference("notebook");
+    rootDir.createIfNotExists();
+  }
+
+  @Override
+  public List<NoteInfo> list() throws IOException {
+    List<NoteInfo> infos = new LinkedList<NoteInfo>();
+    NoteInfo info = null;
+
+    for (ListFileItem item : rootDir.listFilesAndDirectories()) {
+      if (item.getClass() == CloudFileDirectory.class) {
+        CloudFileDirectory dir = (CloudFileDirectory) item;
+
+        try {
+          if (dir.getFileReference("note.json").exists()) {
+            info = new NoteInfo(getNote(dir.getName()));
+
+            if (info != null) {
+              infos.add(info);
+            }
+          }
+        } catch (URISyntaxException e) {
+          LOG.error("Error enumerating notebooks", e);
+        } catch (StorageException e) {
+          LOG.error("Error enumerating notebooks", e);
+        }
+      }
+    }
+
+    return infos;
+  }
+
+  private Note getNote(String noteId) throws IOException {
+    InputStream ins = null;
+
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
+      CloudFile file = dir.getFileReference("note.json");
+
+      ins = file.openRead();
+    } catch (URISyntaxException e) {
+      LOG.error("Error reading file", e);
+      return null;
+    } catch (StorageException e) {
+      LOG.error("Error reading file", e);
+      return null;
+    }
+
+    String json = IOUtils.toString(ins,
+        conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_ENCODING));
+    ins.close();
+
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+
+    Note note = gson.fromJson(json, Note.class);
+
+    for (Paragraph p : note.getParagraphs()) {
+      if (p.getStatus() == Job.Status.PENDING || p.getStatus() == Job.Status.RUNNING) {
+        p.setStatus(Job.Status.ABORT);
+      }
+    }
+
+    return note;
+  }
+
+  @Override
+  public Note get(String noteId) throws IOException {
+    return getNote(noteId);
+  }
+
+  @Override
+  public void save(Note note) throws IOException {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+    String json = gson.toJson(note);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Writer writer = new OutputStreamWriter(output);
+    writer.write(json);
+    writer.close();
+    output.close();
+
+    byte[] buffer = output.toByteArray();
+
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(note.getId());
+      dir.createIfNotExists();
+
+      CloudFile cloudFile = dir.getFileReference("note.json");
+      cloudFile.uploadFromByteArray(buffer, 0, buffer.length);
+    } catch (URISyntaxException e) {
+      LOG.error("Error saving file", e);
+    } catch (StorageException e) {
+      LOG.error("Error saving file", e);
+    }
+  }
+
+  // unfortunately, we need to use a recursive delete here
+  private void delete(ListFileItem item) throws StorageException {
+    if (item.getClass() == CloudFileDirectory.class) {
+      CloudFileDirectory dir = (CloudFileDirectory) item;
+
+      for (ListFileItem subItem : dir.listFilesAndDirectories()) {
+        delete(subItem);
+      }
+
+      dir.deleteIfExists();
+    } else if (item.getClass() == CloudFile.class) {
+      CloudFile file = (CloudFile) item;
+
+      file.deleteIfExists();
+    }
+  }
+
+  @Override
+  public void remove(String noteId) throws IOException {
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
+
+      delete(dir);
+    } catch (URISyntaxException e) {
+      LOG.error("Error deleting file", e);
+    } catch (StorageException e) {
+      LOG.error("Error deleting file", e);
+    }
+  }
+
+  @Override
+  public void close() {
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This is to allow the usage of Azure for notebook storage.

### What type of PR is it?
Improvement

### Todos
N/A

### Is there a relevant Jira issue?
[ZEPPELIN-656](https://issues.apache.org/jira/browse/ZEPPELIN-656)

### How should this be tested?
A full integration test will require an Azure storage account. I could provide an account offline if necessary unless someone already has one. I based this off the S3 storage repo. I did not see any integration tests for the S3 storage repo, but let me know if I need to add some for this.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No, updates were made to zeppelin-site.xml.template explaining config settings