### PR TITLE
ZEPPELIN-656 - Add support for using Azure storage

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -88,7 +88,7 @@
 <property>
   <name>zeppelin.notebook.azure.user</name>
   <value>user</value>
-  <description>user name for Azure folder structure</description>
+  <description>optional user name for Azure folder structure</description>
 </property>
 
 <property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -83,6 +83,33 @@
 </property>
 -->
 
+<!-- If using Azure for storage use the following settings -->
+<!--
+<property>
+  <name>zeppelin.notebook.azure.user</name>
+  <value>user</value>
+  <description>user name for Azure folder structure</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.share</name>
+  <value>zeppelin</value>
+  <description>share name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.connectionString</name>
+  <value>DefaultEndpointsProtocol=https;AccountName=<accountName>;AccountKey=<accountKey></value>
+  <description>share name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.AzureNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+
 <!-- For versioning your local norebook storage using Git repository
 <property>
   <name>zeppelin.notebook.storage</name>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -188,7 +188,7 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_AZURE_USER</td>
     <td>zeppelin.notebook.azure.user</td>
     <td>user</td>
-    <td>A user name of Azure file share<br />i.e. <code>share/user/notebook/2A94M5J1Z/note.json</code></td>
+    <td>An optional user name of Azure file share<br />i.e. <code>share/user/notebook/2A94M5J1Z/note.json</code></td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_STORAGE</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -173,6 +173,24 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>A user name of S3 bucket<br />i.e. <code>bucket/user/notebook/2A94M5J1Z/note.json</code></td>
   </tr>
   <tr>
+    <td>ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING</td>
+    <td>zeppelin.notebook.azure.connectionString</td>
+    <td></td>
+    <td>The Azure storage account connection string<br />i.e. <code>DefaultEndpointsProtocol=https;AccountName=&lt;accountName&gt;;AccountKey=&lt;accountKey&gt;</code></td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_AZURE_SHARE</td>
+    <td>zeppelin.notebook.azure.share</td>
+    <td>zeppelin</td>
+    <td>Share where the Zeppelin notebook files will be saved</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_AZURE_USER</td>
+    <td>zeppelin.notebook.azure.user</td>
+    <td>user</td>
+    <td>A user name of Azure file share<br />i.e. <code>share/user/notebook/2A94M5J1Z/note.json</code></td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_NOTEBOOK_STORAGE</td>
     <td>zeppelin.notebook.storage</td>
     <td>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</td>

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -100,6 +100,7 @@ The following components are provided under Apache License.
     (Apache 2.0) Tachyon Servers (org.tachyonproject:tachyon-servers:0.8.2 - http://tachyon-project.org)
     (Apache 2.0) Tachyon Minicluster (org.tachyonproject:tachyon-minicluster:0.8.2 - http://tachyon-project.org)
     (Apache 2.0) Tachyon Underfs Local (org.tachyonproject:tachyon-underfs-local:0.8.2 - http://tachyon-project.org)
+    (Apache 2.0) Microsoft Azure Storage Library for Java (com.microsoft.azure:azure-storage:4.0.0 - https://github.com/Azure/azure-storage-java)
 
 
 

--- a/zeppelin-distribution/src/bin_license/licenses/LICENSE-azure-storage-4.0.0
+++ b/zeppelin-distribution/src/bin_license/licenses/LICENSE-azure-storage-4.0.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
@@ -53,7 +53,11 @@ public class ConfigurationsRestApi {
         new ZeppelinConfiguration.ConfigurationKeyPredicate() {
         @Override
         public boolean apply(String key) {
-          return !key.contains("password");
+          return !key.contains("password") &&
+              !key.equals(ZeppelinConfiguration
+                  .ConfVars
+                  .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING
+                  .getVarName());
         }
       }
     );

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
@@ -74,7 +74,12 @@ public class ConfigurationsRestApi {
         new ZeppelinConfiguration.ConfigurationKeyPredicate() {
         @Override
         public boolean apply(String key) {
-          return !key.contains("password") && key.startsWith(prefix);
+          return !key.contains("password") &&
+              !key.equals(ZeppelinConfiguration
+                  .ConfVars
+                  .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING
+                  .getVarName()) &&
+              key.startsWith(prefix);
         }
       }
     );

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -728,7 +728,11 @@ public class NotebookServer extends WebSocketServlet implements
         new ZeppelinConfiguration.ConfigurationKeyPredicate() {
           @Override
           public boolean apply(String key) {
-            return !key.contains("password");
+            return !key.contains("password") &&
+                !key.equals(ZeppelinConfiguration
+                    .ConfVars
+                    .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING
+                    .getVarName());
           }
         });
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -59,6 +59,26 @@
 	</dependency>
 
     <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-storage</artifactId>
+      <version>4.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -474,6 +474,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),
     ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING("zeppelin.notebook.azure.connectionString", null),
     ZEPPELIN_NOTEOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
+    ZEPPELIN_NOTEOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner", "bin/interpreter.sh"),
     // Decide when new note is created, interpreter settings will be binded automatically or not.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -472,6 +472,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE("zeppelin.notebook.homescreen.hide", false),
     ZEPPELIN_NOTEBOOK_S3_BUCKET("zeppelin.notebook.s3.bucket", "zeppelin"),
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),
+    ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING("zeppelin.notebook.azure.connectionString", null),
+    ZEPPELIN_NOTEOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner", "bin/interpreter.sh"),
     // Decide when new note is created, interpreter settings will be binded automatically or not.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -473,8 +473,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_S3_BUCKET("zeppelin.notebook.s3.bucket", "zeppelin"),
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),
     ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING("zeppelin.notebook.azure.connectionString", null),
-    ZEPPELIN_NOTEOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
-    ZEPPELIN_NOTEOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),
+    ZEPPELIN_NOTEBOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
+    ZEPPELIN_NOTEBOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner", "bin/interpreter.sh"),
     // Decide when new note is created, interpreter settings will be binded automatically or not.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.repo;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.file.*;
+import org.apache.commons.io.IOUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.scheduler.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.*;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Azure storage backend for notebooks
+ */
+public class AzureNotebookRepo implements NotebookRepo {
+  private static final Logger LOG = LoggerFactory.getLogger(S3NotebookRepo.class);
+
+  private final ZeppelinConfiguration conf;
+  private final String user;
+  private final String shareName;
+  private final CloudFileDirectory rootDir;
+
+  public AzureNotebookRepo(ZeppelinConfiguration conf)
+      throws URISyntaxException, InvalidKeyException, StorageException {
+    this.conf = conf;
+    user = conf.getUser();
+    shareName = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_SHARE);
+
+    CloudStorageAccount account = CloudStorageAccount.parse(
+        conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING));
+    CloudFileClient client = account.createCloudFileClient();
+    CloudFileShare share = client.getShareReference(shareName);
+    share.createIfNotExists();
+
+    CloudFileDirectory userDir = share.getRootDirectoryReference().getDirectoryReference(user);
+    userDir.createIfNotExists();
+
+    rootDir = userDir.getDirectoryReference("notebook");
+    rootDir.createIfNotExists();
+  }
+
+  @Override
+  public List<NoteInfo> list() throws IOException {
+    List<NoteInfo> infos = new LinkedList<NoteInfo>();
+    NoteInfo info = null;
+
+    for (ListFileItem item : rootDir.listFilesAndDirectories()) {
+      if (item.getClass() == CloudFileDirectory.class) {
+        CloudFileDirectory dir = (CloudFileDirectory) item;
+
+        try {
+          if (dir.getFileReference("note.json").exists()) {
+            info = new NoteInfo(getNote(dir.getName()));
+
+            if (info != null) {
+              infos.add(info);
+            }
+          }
+        } catch (URISyntaxException e) {
+          LOG.error("Error enumerating notebooks", e);
+        } catch (StorageException e) {
+          LOG.error("Error enumerating notebooks", e);
+        }
+      }
+    }
+
+    return infos;
+  }
+
+  private Note getNote(String noteId) throws IOException {
+    InputStream ins = null;
+
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
+      CloudFile file = dir.getFileReference("note.json");
+
+      ins = file.openRead();
+    } catch (URISyntaxException e) {
+      LOG.error("Error reading file", e);
+      return null;
+    } catch (StorageException e) {
+      LOG.error("Error reading file", e);
+      return null;
+    }
+
+    String json = IOUtils.toString(ins,
+        conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_ENCODING));
+    ins.close();
+
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+
+    Note note = gson.fromJson(json, Note.class);
+
+    for (Paragraph p : note.getParagraphs()) {
+      if (p.getStatus() == Job.Status.PENDING || p.getStatus() == Job.Status.RUNNING) {
+        p.setStatus(Job.Status.ABORT);
+      }
+    }
+
+    return note;
+  }
+
+  @Override
+  public Note get(String noteId) throws IOException {
+    return getNote(noteId);
+  }
+
+  @Override
+  public void save(Note note) throws IOException {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+    String json = gson.toJson(note);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Writer writer = new OutputStreamWriter(output);
+    writer.write(json);
+    writer.close();
+    output.close();
+
+    byte[] buffer = output.toByteArray();
+
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(note.getId());
+      dir.createIfNotExists();
+
+      CloudFile cloudFile = dir.getFileReference("note.json");
+      cloudFile.uploadFromByteArray(buffer, 0, buffer.length);
+    } catch (URISyntaxException e) {
+      LOG.error("Error saving file", e);
+    } catch (StorageException e) {
+      LOG.error("Error saving file", e);
+    }
+  }
+
+  // unfortunately, we need to use a recursive delete here
+  private void delete(ListFileItem item) throws StorageException {
+    if (item.getClass() == CloudFileDirectory.class) {
+      CloudFileDirectory dir = (CloudFileDirectory) item;
+
+      for (ListFileItem subItem : dir.listFilesAndDirectories()) {
+        delete(subItem);
+      }
+
+      dir.deleteIfExists();
+    } else if (item.getClass() == CloudFile.class) {
+      CloudFile file = (CloudFile) item;
+
+      file.deleteIfExists();
+    }
+  }
+
+  @Override
+  public void remove(String noteId) throws IOException {
+    try {
+      CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
+
+      delete(dir);
+    } catch (URISyntaxException e) {
+      LOG.error("Error deleting file", e);
+    } catch (StorageException e) {
+      LOG.error("Error deleting file", e);
+    }
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.file.*;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
@@ -50,7 +51,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   public AzureNotebookRepo(ZeppelinConfiguration conf)
       throws URISyntaxException, InvalidKeyException, StorageException {
     this.conf = conf;
-    user = conf.getUser();
+    user = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_USER);
     shareName = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_SHARE);
 
     CloudStorageAccount account = CloudStorageAccount.parse(
@@ -59,7 +60,9 @@ public class AzureNotebookRepo implements NotebookRepo {
     CloudFileShare share = client.getShareReference(shareName);
     share.createIfNotExists();
 
-    CloudFileDirectory userDir = share.getRootDirectoryReference().getDirectoryReference(user);
+    CloudFileDirectory userDir = StringUtils.isBlank(user) ?
+        share.getRootDirectoryReference() :
+        share.getRootDirectoryReference().getDirectoryReference(user);
     userDir.createIfNotExists();
 
     rootDir = userDir.getDirectoryReference("notebook");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -86,10 +86,12 @@ public class AzureNotebookRepo implements NotebookRepo {
               infos.add(info);
             }
           }
-        } catch (URISyntaxException e) {
-          LOG.error("Error enumerating notebooks", e);
-        } catch (StorageException e) {
-          LOG.error("Error enumerating notebooks", e);
+        } catch (StorageException | URISyntaxException e) {
+          String msg = "Error enumerating notebooks from Azure storage";
+
+          LOG.error(msg, e);
+
+          throw new IOException(msg, e);
         }
       }
     }
@@ -105,12 +107,12 @@ public class AzureNotebookRepo implements NotebookRepo {
       CloudFile file = dir.getFileReference("note.json");
 
       ins = file.openRead();
-    } catch (URISyntaxException e) {
-      LOG.error("Error reading file", e);
-      return null;
-    } catch (StorageException e) {
-      LOG.error("Error reading file", e);
-      return null;
+    } catch (URISyntaxException | StorageException e) {
+      String msg = String.format("Error reading notebook %s from Azure storage", noteId);
+
+      LOG.error(msg, e);
+
+      throw new IOException(msg, e);
     }
 
     String json = IOUtils.toString(ins,
@@ -158,10 +160,12 @@ public class AzureNotebookRepo implements NotebookRepo {
 
       CloudFile cloudFile = dir.getFileReference("note.json");
       cloudFile.uploadFromByteArray(buffer, 0, buffer.length);
-    } catch (URISyntaxException e) {
-      LOG.error("Error saving file", e);
-    } catch (StorageException e) {
-      LOG.error("Error saving file", e);
+    } catch (URISyntaxException | StorageException e) {
+      String msg = String.format("Error saving notebook %s to Azure storage", note.getId());
+
+      LOG.error(msg, e);
+
+      throw new IOException(msg, e);
     }
   }
 
@@ -188,10 +192,12 @@ public class AzureNotebookRepo implements NotebookRepo {
       CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
 
       delete(dir);
-    } catch (URISyntaxException e) {
-      LOG.error("Error deleting file", e);
-    } catch (StorageException e) {
-      LOG.error("Error deleting file", e);
+    } catch (URISyntaxException | StorageException e) {
+      String msg = String.format("Error deleting notebook %s from Azure storage", noteId);
+
+      LOG.error(msg, e);
+
+      throw new IOException(msg, e);
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -51,8 +51,8 @@ public class AzureNotebookRepo implements NotebookRepo {
   public AzureNotebookRepo(ZeppelinConfiguration conf)
       throws URISyntaxException, InvalidKeyException, StorageException {
     this.conf = conf;
-    user = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_USER);
-    shareName = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEOOK_AZURE_SHARE);
+    user = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_AZURE_USER);
+    shareName = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_AZURE_SHARE);
 
     CloudStorageAccount account = CloudStorageAccount.parse(
         conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING));


### PR DESCRIPTION
### What is this PR for?
This is to allow the usage of Azure for notebook storage.

### What type of PR is it?
Improvement

### Todos
N/A

### Is there a relevant Jira issue?
[ZEPPELIN-656](https://issues.apache.org/jira/browse/ZEPPELIN-656)

### How should this be tested?
A full integration test will require an Azure storage account. I could provide an account offline if necessary unless someone already has one. I based this off the S3 storage repo. I did not see any integration tests for the S3 storage repo, but let me know if I need to add some for this.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes, license added
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, updates were made to zeppelin-site.xml.template explaining config settings as well as in the install doc