### PR TITLE
Simple improvement to showDF() to use StringBuilder

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -322,16 +322,18 @@ public class ZeppelinContext extends HashMap<String, Object> {
       throw new InterpreterException(e);
     }
 
-    String msg = null;
+    StringBuilder msg = null;
     for (Attribute col : columns) {
       if (msg == null) {
-        msg = col.name();
+        msg = new StringBuilder();
+        msg.append("%table ");
+        msg.append(col.name());
       } else {
-        msg += "\t" + col.name();
+        msg.append("\t" + col.name());
       }
     }
 
-    msg += "\n";
+    msg.append("\n");
 
     // ArrayType, BinaryType, BooleanType, ByteType, DecimalType, DoubleType, DynamicType,
     // FloatType, FractionalType, IntegerType, IntegralType, LongType, MapType, NativeType,
@@ -345,15 +347,15 @@ public class ZeppelinContext extends HashMap<String, Object> {
 
         for (int i = 0; i < columns.size(); i++) {
           if (!(Boolean) isNullAt.invoke(row, i)) {
-            msg += apply.invoke(row, i).toString();
+            msg.append(apply.invoke(row, i).toString());
           } else {
-            msg += "null";
+            msg.append("null");
           }
           if (i != columns.size() - 1) {
-            msg += "\t";
+            msg.append("\t");
           }
         }
-        msg += "\n";
+        msg.append("\n");
       }
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException | InvocationTargetException e) {
@@ -361,10 +363,10 @@ public class ZeppelinContext extends HashMap<String, Object> {
     }
 
     if (rows.length > maxResult) {
-      msg += "\n<font color=red>Results are limited by " + maxResult + ".</font>";
+      msg.append("\n<font color=red>Results are limited by " + maxResult + ".</font>");
     }
     sc.clearJobGroup();
-    return "%table " + msg;
+    return msg.toString();
   }
 
   /**


### PR DESCRIPTION
**What is this PR for?
The way tables of results are currently getting built within
the ZeppelinContext is pretty slow due to way strings are
getting constructed.

https://issues.apache.org/jira/browse/ZEPPELIN-659

**What type of PR is it?
Performance improvement.

**How should this be tested?
The current tests should catch any issues introduced by it.