### PR TITLE
[ZEPPELIN-662] HBase interpreter should support CDH favor of HBase

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -107,6 +107,18 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>vendor-repo</id>
+      <repositories>
+        <repository>
+          <id>cloudera</id>
+          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -107,18 +107,6 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>vendor-repo</id>
-      <repositories>
-        <repository>
-          <id>cloudera</id>
-          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -226,15 +226,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>vendor-repo</id>
-      <repositories>
-        <repository>
-          <id>cloudera</id>
-          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-        </repository>
-      </repositories>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,16 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>vendor-repo</id>
+      <repositories>
+        <repository>
+          <id>cloudera</id>
+          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+      </repositories>
+    </profile>
+
     <!-- Geode can be enabled by -Pgeode. see https://issues.apache.org/jira/browse/ZEPPELIN-375 -->
     <profile>
       <id>geode</id>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -340,16 +340,6 @@
 
   <profiles>
     <profile>
-      <id>vendor-repo</id>
-      <repositories>
-        <repository>
-          <id>cloudera</id>
-          <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-        </repository>
-      </repositories>
-    </profile>
-
-    <profile>
       <id>spark-1.1</id>
       <dependencies>
 


### PR DESCRIPTION
### What is this PR for?
Allow HBase interpreter to be built with vendor repo artifects

### What type of PR is it?
Improvement

### Todos
* [x] - Add vendor repo to hbase pom

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-662

### How should this be tested?
Build with this for CDH 5.4.8
```
mvn clean package -Pspark-1.5 -Dhadoop.version=2.6.0-cdh5.4.8 -Phadoop-2.6 -Pvendor-repo -DskipTests -Ppyspark -P build-distr -Dhbase.hbase.version=1.0.0-cdh5.4.8 -Dhbase.hadoop.version=2.6.0-cdh5.4.8
```

### Screenshots (if appropriate)
N/A
This is what's in interpreter/hbase
```
activation-1.1.jar				aopalliance-1.0.jar
apacheds-i18n-2.0.0-M15.jar			apacheds-kerberos-codec-2.0.0-M15.jar
api-asn1-api-1.0.0-M20.jar			api-util-1.0.0-M20.jar
asm-3.1.jar					avro-1.7.6-cdh5.4.8.jar
commons-cli-1.2.jar				commons-codec-1.5.jar
commons-collections-3.2.1.jar			commons-compress-1.4.1.jar
commons-configuration-1.9.jar			commons-daemon-1.0.13.jar
commons-el-1.0.jar				commons-exec-1.1.jar
commons-httpclient-3.1.jar			commons-io-2.4.jar
commons-lang-2.5.jar				commons-logging-1.1.1.jar
commons-math-2.1.jar				commons-math3-3.1.1.jar
commons-net-3.1.jar				core-3.1.1.jar
curator-client-2.7.1.jar			curator-framework-2.7.1.jar
curator-recipes-2.7.1.jar			disruptor-3.3.0.jar
findbugs-annotations-1.3.9-1.jar		gson-2.2.jar
guava-15.0.jar					guice-3.0.jar
guice-servlet-3.0.jar				hadoop-annotations-2.6.0-cdh5.4.8.jar
hadoop-auth-2.6.0-cdh5.4.8.jar			hadoop-common-2.6.0-cdh5.4.8.jar
hadoop-core-2.6.0-mr1-cdh5.4.8.jar		hadoop-hdfs-2.6.0-cdh5.4.8-tests.jar
hadoop-hdfs-2.6.0-cdh5.4.8.jar			hadoop-yarn-api-2.6.0-cdh5.4.8.jar
hadoop-yarn-common-2.6.0-cdh5.4.8.jar		hamcrest-core-1.3.jar
hbase-annotations-1.0.0-cdh5.4.8.jar		hbase-client-1.0.0-cdh5.4.8.jar
hbase-common-1.0.0-cdh5.4.8-tests.jar		hbase-common-1.0.0-cdh5.4.8.jar
hbase-hadoop-compat-1.0.0-cdh5.4.8.jar		hbase-hadoop2-compat-1.0.0-cdh5.4.8.jar
hbase-prefix-tree-1.0.0-cdh5.4.8.jar		hbase-protocol-1.0.0-cdh5.4.8.jar
hbase-server-1.0.0-cdh5.4.8.jar			high-scale-lib-1.1.1.jar
hsqldb-1.8.0.10.jar				htrace-core-3.0.4.jar
htrace-core-3.1.0-incubating.jar		httpclient-4.3.6.jar
httpcore-4.3.3.jar				jackson-core-asl-1.8.8.jar
jackson-jaxrs-1.8.8.jar				jackson-mapper-asl-1.8.8.jar
jackson-xc-1.8.8.jar				jamon-runtime-2.3.1.jar
jasper-compiler-5.5.23.jar			jasper-runtime-5.5.23.jar
java-xmlbuilder-0.4.jar				javax.inject-1.jar
jaxb-api-2.2.2.jar				jaxb-impl-2.2.3-1.jar
jcodings-1.0.8.jar				jersey-client-1.9.jar
jersey-core-1.9.jar				jersey-guice-1.9.jar
jersey-json-1.9.jar				jersey-server-1.9.jar
jets3t-0.9.0.jar				jettison-1.1.jar
jetty-6.1.26.cloudera.4.jar			jetty-sslengine-6.1.26.cloudera.4.jar
jetty-util-6.1.26.cloudera.4.jar		jline-2.12.1.jar
joni-2.1.2.jar					jruby-complete-1.6.8.jar
jsch-0.1.42.jar					jsp-2.1-6.1.14.jar
jsp-api-2.1-6.1.14.jar				jsp-api-2.1.jar
jsr305-3.0.0.jar				leveldbjni-all-1.8.jar
log4j-1.2.17.jar				metrics-core-2.2.0.jar
netty-3.6.6.Final.jar				paranamer-2.3.jar
protobuf-java-2.5.0.jar				servlet-api-2.5-6.1.14.jar
servlet-api-2.5.jar				slf4j-api-1.7.10.jar
slf4j-log4j12-1.7.10.jar			snappy-java-1.0.4.1.jar
stax-api-1.0-2.jar				xmlenc-0.52.jar
xz-1.0.jar					zeppelin-hbase-0.6.0-incubating-SNAPSHOT.jar
zookeeper-3.4.5-cdh5.4.8.jar
```

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? Possibly, not sure HBase doc is the right place - there should be a vendor specific doc perhaps