### PR TITLE
Add link to code of conduct / how it works, from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Contributing to Zeppelin (Source code, Documents, Image, Website) means you agre
 2. If not, create a ticket describing the change you're proposing in the [Jira issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN)
 3. Contribute your patch via Pull Request.
 
+Before you start, please read the [Code of Conduct](http://www.apache.org/foundation/policies/conduct.html) carefully, familiarise yourself with it and refer to it whenever you need it.
+
 ## Creating a Pull Request
 In order to make the review process easier, please follow this template when making a Pull Request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ Contributing to Zeppelin (Source code, Documents, Image, Website) means you agre
 2. If not, create a ticket describing the change you're proposing in the [Jira issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN)
 3. Contribute your patch via Pull Request.
 
-Before you start, please read the [Code of Conduct](http://www.apache.org/foundation/policies/conduct.html) carefully, familiarise yourself with it and refer to it whenever you need it.
+Before you start, please read the [Code of Conduct](http://www.apache.org/foundation/policies/conduct.html) carefully, familiarize yourself with it and refer to it whenever you need it.
 
-For those of who are not familiar with Apache project, understanding how [How it works](http://www.apache.org/foundation/how-it-works.html) would be quite helpful.
+For those of you who are not familiar with Apache project, understanding [How it works](http://www.apache.org/foundation/how-it-works.html) would be quite helpful.
 
 ## Creating a Pull Request
 In order to make the review process easier, please follow this template when making a Pull Request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Contributing to Zeppelin (Source code, Documents, Image, Website) means you agre
 
 Before you start, please read the [Code of Conduct](http://www.apache.org/foundation/policies/conduct.html) carefully, familiarise yourself with it and refer to it whenever you need it.
 
+For those of who are not familiar with Apache project, understanding how [How it works](http://www.apache.org/foundation/how-it-works.html) would be quite helpful.
+
 ## Creating a Pull Request
 In order to make the review process easier, please follow this template when making a Pull Request:
 


### PR DESCRIPTION
### What is this PR for?
Adding code of conduct link http://www.apache.org/foundation/policies/conduct.html to our contribution guide, as well as http://www.apache.org/foundation/how-it-works.html

### What type of PR is it?
Improvement

### Todos
* [x] - Add link to Code of conduct
* [x] - Add link to the Apache way.

### Is there a relevant Jira issue?
no

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no