### PR TITLE
Exporting to TSV

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -83,6 +83,9 @@ limitations under the License.
         <a ng-click="goToSingleParagraph()"><span class="icon-share-alt"></span> Link this paragraph</a>
       </li>
       <li>
+        <a ng-click="exportToTSV()"><span class="icon-share-alt"></span> Export to TSV</a>
+      </li>
+      <li>
         <a ng-click="clearParagraphOutput()"><span class="fa fa-eraser"></span> Clear output</a>
       </li>
       <li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2187,19 +2187,19 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.exportToTSV = function () {
-    var data = $scope.paragraph.result
+    var data = $scope.paragraph.result;
     var tsv = '';
     for (var titleIndex in $scope.paragraph.result.columnNames) {
       tsv += $scope.paragraph.result.columnNames[titleIndex].name + '\t';
     }
-    tsv = tsv.substring(0, tsv.length - 1) + '\n'
+    tsv = tsv.substring(0, tsv.length - 1) + '\n';
     for (var r in $scope.paragraph.result.msgTable) {
       var row = $scope.paragraph.result.msgTable[r];
-      var tsvRow = ''
+      var tsvRow = '';
       for (var index in row) {
         tsvRow += row[index].value + '\t';
       }
-      tsv += tsvRow.substring(0, tsvRow.length - 1) + '\n'
+      tsv += tsvRow.substring(0, tsvRow.length - 1) + '\n';
     }
     SaveAsService.SaveAs(tsv, 'data', 'tsv');
   };

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -16,7 +16,7 @@
 
 angular.module('zeppelinWebApp')
   .controller('ParagraphCtrl', function($scope,$rootScope, $route, $window, $element, $routeParams, $location,
-                                         $timeout, $compile, websocketMsgSrv, ngToast) {
+                                         $timeout, $compile, websocketMsgSrv, ngToast, SaveAsService) {
   var ANGULAR_FUNCTION_OBJECT_NAME_PREFIX = '_Z_ANGULAR_FUNC_';
   $scope.parentNote = null;
   $scope.paragraph = null;
@@ -2186,4 +2186,21 @@ angular.module('zeppelinWebApp')
     $scope.keepScrollDown = false;
   };
 
+  $scope.exportToTSV = function () {
+    var data = $scope.paragraph.result
+    var tsv = '';
+    for (var titleIndex in $scope.paragraph.result.columnNames) {
+      tsv += $scope.paragraph.result.columnNames[titleIndex].name + '\t';
+    }
+    tsv = tsv.substring(0, tsv.length - 1) + '\n'
+    for (var r in $scope.paragraph.result.msgTable) {
+      var row = $scope.paragraph.result.msgTable[r];
+      var tsvRow = ''
+      for (var index in row) {
+        tsvRow += row[index].value + '\t';
+      }
+      tsv += tsvRow.substring(0, tsvRow.length - 1) + '\n'
+    }
+    SaveAsService.SaveAs(tsv, 'data', 'tsv');
+  };
 });


### PR DESCRIPTION
### What is this PR for?
Allow users to export data in a paragraph to a TSV file.

There is already a [PR](https://github.com/apache/incubator-zeppelin/pull/6) for this, but it uses DataTables, which requires Flash.

### What type of PR is it?
Feature

### Todos
* [ ] - Hide/disable the button if it is not in table/chart view
* [ ] - Find an icon for the new button
* [ ] - Saved file name is not correct in Safari
* [ ] - Test with large data set

### Is there a relevant Jira issue?
[ZEPPELIN-672](https://issues.apache.org/jira/browse/ZEPPELIN-672)

### How should this be tested?
1. create a paragraph with data in %table view
2. select the "Export to TSV" item in the paragraph settings list

### Screenshots (if appropriate)
![vvzhsyciev](https://cloud.githubusercontent.com/assets/3282033/13032147/d589e88e-d29c-11e5-8763-96fca4db2fd0.gif)


### Questions:
* Does the licenses files need update?
NO

* Is there breaking changes for older versions?
NO

* Does this needs documentation?
NO
