### PR TITLE
Bringing compiledScope for backward compatibility

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -21,8 +21,13 @@ angular.module('zeppelinWebApp')
   $scope.paragraph = null;
   $scope.originalText = '';
   $scope.editor = null;
+
   var paragraphScope = $rootScope.$new(true, $rootScope);
+  // to keep backward compatibility
+  $scope.compiledScope = paragraphScope;
+
   var angularObjectRegistry = {};
+
 
   var editorModes = {
     'ace/mode/scala': /^%spark/,


### PR DESCRIPTION
### What is this PR for?
compiledScope was not exposed API for users.
However, some users were using compiledScope in their notebook and [ZEPPELIN-551](http://issues.apache.org/jira/browse/ZEPPELIN-551) break this notebook work by removing compiledScope.

https://gist.github.com/granturing/a09aed4a302a7367be92 is an example notebook that uses compiledScope.

This PR bringing compiledScope back for backward compatibility.

### What type of PR is it?
Improvement

### Todos
* [x] - Bringing compiledScope back for backward compatibility

### Is there a relevant Jira issue?
compiledScope was removed by http://issues.apache.org/jira/browse/ZEPPELIN-551 


### How should this be tested?

Test https://gist.github.com/granturing/a09aed4a302a7367be92


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no