### PR TITLE
allows zeppelin to be run and managed as a service.  ZEPPELIN-641

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -21,7 +21,7 @@
 # description: Start and stop daemon script for.
 #
 
-USAGE="Usage: zeppelin-daemon.sh [--config <conf-dir>] {start|stop|restart|reload|status}"
+USAGE="Usage: zeppelin-daemon.sh [--config <conf-dir>] {start|stop|upstart|restart|reload|status}"
 
 if [[ "$1" == "--config" ]]; then
   shift
@@ -159,6 +159,16 @@ function check_if_process_is_alive() {
   fi
 }
 
+function upstart() {
+
+  # upstart() allows zeppelin to be run and managed as a service
+  # for example, this could be called from an upstart script in /etc/init
+  # where the service manager starts and stops the process
+  initialize_default_directories
+
+  $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_MAIN >> "${ZEPPELIN_OUTFILE}"
+}
+
 function start() {
   local pid
 
@@ -240,6 +250,9 @@ case "${1}" in
     ;;
   stop)
     stop
+    ;;
+  upstart)
+    upstart
     ;;
   reload)
     stop

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -220,8 +220,36 @@ bin/zeppelin-daemon.sh stop
 
 #### Start Zeppelin with a service manager such as upstart
 
+Zeppelin can auto start as a service with an init script, such as services managed by upstart.
+
+The following is an example upstart script to be saved as `/etc/init/zeppelin.conf` 
+This example has been tested with Ubuntu Linux.
+This also allows the service to be managed with commands such as 
+
+`sudo service zeppelin start`  
+`sudo service zeppelin stop`  
+`sudo service zeppelin restart`
+
+Other service managers could use a similar approach with the `upstart` argument passed to the zeppelin-daemon.sh script:  `bin/zeppelin-daemon.sh upstart`
+
+##### zeppelin.conf
+
 ```
-bin/zeppelin-daemon.sh upstart
+description "zeppelin"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on shutdown
+
+# Respawn the process on unexpected termination
+respawn
+
+# respawn the job up to 7 times within a 5 second period.
+# If the job exceeds these values, it will be stopped and marked as failed.
+respawn limit 7 5
+
+# zeppelin was installed in /usr/share/zeppelin in this example
+chdir /usr/share/zeppelin
+exec bin/zeppelin-daemon.sh upstart
 ```
 
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -217,3 +217,11 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 ```
 bin/zeppelin-daemon.sh stop
 ```
+
+#### Start Zeppelin with a service manager such as upstart
+
+```
+bin/zeppelin-daemon.sh upstart
+```
+
+


### PR DESCRIPTION
### What is this PR for?
allows zeppelin to be run and managed as a service, does not start in background via nohup
the service manager handles process instead

### What type of PR is it?
Improvement

### Todos
* None, should work as is

### Is there a relevant Jira issue?
ZEPPELIN-641

### How should this be tested?
bin/zeppelin-daemon.sh upstart

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? updated