### PR TITLE
ZEPPELIN-585: Add troubleshooting information to publish.md

### DIFF
--- a/docs/manual/publish.md
+++ b/docs/manual/publish.md
@@ -42,7 +42,25 @@ For example,
 <iframe src="http://< ip-address >:< port >/#/notebook/2B3QSZTKR/paragraph/...?asIframe" height="" width="" ></iframe>
 ```
 
+Don't forget to also add below lines in your page for loading the Twitter Bootstrap themes and CSS used for Zeppelin notebook style, or your paragraph will be shown ugly.
+
+```
+<head>
+     ....
+    <link rel="stylesheet" href="zeppelin-web/bower_components/bootstrap/dist/css/bootstrap.css" />
+    <link rel="stylesheet" href="zeppelin-web/fonts/font-awesome.min.css">
+    ....
+</head>
+```
+
 Finally, you can show off your beautiful visualization results in your website. 
 <center><img src="../assets/themes/zeppelin/img/docs-img/your-website.png" height="90%" width="90%"></center>
 
 > **Note**: To embed the paragraph in a website, Zeppelin needs to be reachable by that website. 
+
+## Troubleshooting
+Regarding to this feature, a bug was reported by [ZEPPELIN-413](https://issues.apache.org/jira/browse/ZEPPELIN-413) before. 
+It says, when you click **Link this paragraph** menu, it always redirects to notebook page. 
+So after then, this issue was fixed by [Pull Request #464](https://github.com/apache/incubator-zeppelin/pull/464) and the stable feature was included to **0.5.6-incubating release**.
+
+If you have been troubled with this issue, please check your **Zeppelin release version**.


### PR DESCRIPTION
### What is this PR for?
After #672 is merged, a bug was [reported by Zeppelin user](http://apache-zeppelin-users-incubating-mailing-list.75479.x6.nabble.com/Embed-Zeppelin-Results-in-External-page-tt2249.html) a few days ago. 
That issue was addressed already fixed by #464 and included after **release 0.5.6**.

So I add some information to `docs/manual/publish.md` about troubleshooting and style guide mentioned by @doanduyhai at the Zeppelin user mailing thread.

### What type of PR is it?
Documentation

### Todos
* [x] - Add troubleshooting information to `publish.md`

### Is there a relevant Jira issue?
Maybe [ZEPPELIN-413](https://issues.apache.org/jira/browse/ZEPPELIN-413) & [ZEPPELIN-585](https://issues.apache.org/jira/browse/ZEPPELIN-585)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No