### PR TITLE
[ZEPPELIN-680] Cron job will run cells that have had their run disabled

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -349,6 +349,9 @@ public class Note implements Serializable, JobListener {
   public void runAll() {
     synchronized (paragraphs) {
       for (Paragraph p : paragraphs) {
+        if (!p.isEnabled()) {
+          continue;
+        }
         p.setNoteReplLoader(replLoader);
         p.setListener(jobListenerFactory.getParagraphJobListener(this));
         Interpreter intp = replLoader.get(p.getRequiredReplName());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -91,6 +91,11 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     return note;
   }
 
+  public boolean isEnabled() {
+    Boolean enabled = (Boolean) config.get("enabled");
+    return enabled == null || enabled.booleanValue();
+  }
+
   public String getRequiredReplName() {
     return getRequiredReplName(text);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -204,20 +204,38 @@ public class NotebookTest implements JobListenerFactory{
   public void testRunAll() throws IOException {
     Note note = notebook.createNote();
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
+
+    // p1
     Paragraph p1 = note.addParagraph();
-    Map config = p1.getConfig();
-    config.put("enabled", true);
-    p1.setConfig(config);
+    Map config1 = p1.getConfig();
+    config1.put("enabled", true);
+    p1.setConfig(config1);
     p1.setText("p1");
+
+    // p2
     Paragraph p2 = note.addParagraph();
-    Map config1 = p2.getConfig();
-    p2.setConfig(config1);
+    Map config2 = p2.getConfig();
+    config2.put("enabled", false);
+    p2.setConfig(config2);
     p2.setText("p2");
-    assertEquals(null, p2.getResult());
+
+    // p3
+    Paragraph p3 = note.addParagraph();
+    p3.setText("p3");
+
+    // when
     note.runAll();
 
-    while(p2.isTerminated()==false || p2.getResult()==null) Thread.yield();
-    assertEquals("repl1: p2", p2.getResult().message());
+    // wait for finish
+    while(p3.isTerminated()==false) {
+      Thread.yield();
+    }
+
+    assertEquals("repl1: p1", p1.getResult().message());
+    assertNull(p2.getResult());
+    assertEquals("repl1: p3", p3.getResult().message());
+
+    notebook.removeNote(note.getId());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
When I run a cron job, cells that I have selected the "disable run" option will still run.
This PR fixes the problem.

### What type of PR is it?
Bug Fix

### Todos
* [x] - exclude disabled paragraph from runAll

### Is there a relevant Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-680?jql=project%20%3D%20ZEPPELIN

### How should this be tested?
Create paragraph and disable it.
Then enable cron scheduling a notebook.
The paragraph supposed to not run.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no