### PR TITLE
[ZEPPELIN-687] Display paragraph id in config dropdown menu

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -39,6 +39,10 @@ limitations under the License.
           type="button">
     </span>
     <ul class="dropdown-menu" role="menu" style="width:200px;z-index:1002">
+      <li ng-click="$event.stopPropagation()" style="text-align:center;margin-top:4px;">
+        {{paragraph.id}}
+      </li>
+      <li role="separator" class="divider"></li>
       <li>
         <a ng-click="$event.stopPropagation()" class="dropdown"><span class="fa fa-arrows-h"></span> Width
           <form style="display:inline; margin-left:5px;">

--- a/zeppelin-web/src/assets/styles/looknfeel/default.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/default.css
@@ -32,3 +32,4 @@ body {
   box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.3);
   border-color: white;
 }
+


### PR DESCRIPTION
### What is this PR for?
Display paragraph id in the config drop down menu

<em>This is a sub-task of epic **[ZEPPELIN-635]**</em>

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Trivial code review & test

### Is there a relevant Jira issue?
**[ZEPPELIN-687]**

### How should this be tested?
1. `git fetch origin pull/739/head:DisplayParagraphId`
2. `git checkout DisplayParagraphId`
3. `mvn clean package -DskipTests`
4. `bin/zeppelin-daemon.sh restart`
5. Create any note
6. Click on the config drop down menu of any paragraph to see the paragraph id

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/1532977/13231697/70f703fa-d9ab-11e5-8b82-b9daf601622f.png)


### Questions:
* Does the licenses files need update? --> **No**
* Is there breaking changes for older versions? --> **No**
* Does this needs documentation? --> **No**

[ZEPPELIN-687]: https://issues.apache.org/jira/browse/ZEPPELIN-687
[ZEPPELIN-635]: https://issues.apache.org/jira/browse/ZEPPELIN-635