### PR TITLE
[ZEPPELIN-696] Add notification system for AngularJS z functions

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -81,8 +81,7 @@
             ngToastProvider.configure({
                 dismissButton: true,
                 dismissOnClick: false,
-                timeout: 6000,
-                verticalPosition: 'bottom'
+                timeout: 6000
             });
         });
 

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -75,7 +75,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       // add missing field of option
       if (!setting.option) {
         setting.option = {};
-      }      
+      }
       if (setting.option.remote === undefined) {
         // remote always true for now
         setting.option.remote = true;
@@ -94,7 +94,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
         }).
         error(function (data, status, headers, config) {
           console.log('Error %o %o', status, data.message);
-          ngToast.danger(data.message);
+          ngToast.danger({content: data.message, verticalPosition: 'bottom'});
           form.$show();
         });
     }
@@ -210,7 +210,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       }).
       error(function(data, status, headers, config) {
         console.log('Error %o %o', status, data.message);
-        ngToast.danger(data.message);
+        ngToast.danger({content: data.message, verticalPosition: 'bottom'});
       });
   };
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -16,7 +16,7 @@
 
 angular.module('zeppelinWebApp')
   .controller('ParagraphCtrl', function($scope,$rootScope, $route, $window, $element, $routeParams, $location,
-                                         $timeout, $compile, websocketMsgSrv) {
+                                         $timeout, $compile, websocketMsgSrv, ngToast) {
   var ANGULAR_FUNCTION_OBJECT_NAME_PREFIX = '_Z_ANGULAR_FUNC_';
   $scope.parentNote = null;
   $scope.paragraph = null;
@@ -39,8 +39,13 @@ angular.module('zeppelinWebApp')
           websocketMsgSrv.runParagraph(paragraph.id, paragraph.title, paragraph.text,
               paragraph.config, paragraph.settings.params);
         } else {
-          // Error message here
+          ngToast.danger({content: 'Cannot find a paragraph with id \'' + paragraphId + '\'',
+            verticalPosition: 'top', dismissOnTimeout: false});
         }
+      } else {
+        ngToast.danger({
+          content: 'Please provide a \'paragraphId\' when calling z.runParagraph(paragraphId)',
+          verticalPosition: 'top', dismissOnTimeout: false});
       }
     },
 
@@ -49,6 +54,11 @@ angular.module('zeppelinWebApp')
       // Only push to server if there paragraphId is defined
       if (paragraphId) {
         websocketMsgSrv.clientBindAngularObject($routeParams.noteId, varName, value, paragraphId);
+      } else {
+        ngToast.danger({
+          content: 'Please provide a \'paragraphId\' when calling ' +
+          'z.angularBind(varName, value, \'PUT_HERE_PARAGRAPH_ID\')',
+          verticalPosition: 'top', dismissOnTimeout: false});
       }
     },
 
@@ -57,6 +67,11 @@ angular.module('zeppelinWebApp')
       // Only push to server if paragraphId is defined
       if (paragraphId) {
         websocketMsgSrv.clientUnbindAngularObject($routeParams.noteId, varName, paragraphId);
+      } else {
+        ngToast.danger({
+          content: 'Please provide a \'paragraphId\' when calling ' +
+          'z.angularUnbind(varName, \'PUT_HERE_PARAGRAPH_ID\')',
+          verticalPosition: 'top', dismissOnTimeout: false});
       }
     }
   };

--- a/zeppelin-web/src/assets/styles/looknfeel/default.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/default.css
@@ -33,3 +33,7 @@ body {
   border-color: white;
 }
 
+.ng-toast.ng-toast--top {
+  top: 100px;
+}
+

--- a/zeppelin-web/src/assets/styles/looknfeel/report.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/report.css
@@ -73,3 +73,7 @@ body {
 .noteAction button.btn {
   border-radius: 4px !important;
 }
+
+.ng-toast.ng-toast--top {
+  top: 100px;
+}

--- a/zeppelin-web/src/assets/styles/looknfeel/simple.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/simple.css
@@ -89,3 +89,7 @@ body {
 .nv-controlsWrap {
   display: block;
 }
+
+.ng-toast.ng-toast--top {
+  top: 100px;
+}


### PR DESCRIPTION
### What is this PR for?
Add notification system for AngularJS z functions. Now that we expose the `z` Angular object, we should also catch error/exceptions and display error messages properly to the user.

I changed a little bit the default settings for **ngToast**. Instead of having notifications on **bottom right**, I let the default value undefined.

For **Interpreter** page notification, I force the position to **bottom right** as before when using default config.

For `z` functions error messages, I choose to display notifications on **top right** corner because it's clearer. See screen capture


_This is a sub-task of epic **[ZEPPELIN-635]**_

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Code Review
* [ ] - Simple Test

### Is there a relevant Jira issue?
**[ZEPPELIN-696]**

### How should this be tested?
* `git fetch origin pull/744/head:AngularJSNotification`
* `git checkout AngularJSNotification`
* `mvn clean package -DskipTests`
* `bin/zeppelin-daemon.sh restart`
* Create a new note
* In the first paragraph, put the following code

```html
%angular

<form class="form-inline">
  <button type="submit" class="btn btn-primary" ng-click="z.runParagraph()"> Run Paragraph Without Id</button>
  <button type="submit" class="btn btn-primary" ng-click="z.runParagraph('20160223-141919_305734436')"> Run Paragraph Without Wrong Id</button>
  <button type="submit" class="btn btn-primary" ng-click="z.angularBind('superhero', superhero)"> Angular Bind Without Paragraph Id</button>
  <button type="submit" class="btn btn-primary" ng-click="z.angularUnbind('superhero')"> Angular UnBind Without Paragraph Id</button>
</form>
```
* Click on each button to see the appropriate error message

### Screenshots (if appropriate)
![angularnotification](https://cloud.githubusercontent.com/assets/1532977/13901504/734b5112-ee26-11e5-9962-bcf2101eb700.gif)



### Questions:
* Does the licenses files need update? --> **No**
* Is there breaking changes for older versions?  --> **No**
* Does this needs documentation?  --> **Yes**

[angular-growl-2]: http://janstevens.github.io/angular-growl-2/
[ZEPPELIN-635]: https://issues.apache.org/jira/browse/ZEPPELIN-635
[ZEPPELIN-696]: https://issues.apache.org/jira/browse/ZEPPELIN-696