### PR TITLE
[ZEPPELIN-697] Replace dynamic form with angular object from registry if exists

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.notebook;
 
+import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.display.GUI;
@@ -232,6 +233,12 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       String scriptBody = getScriptBody();
       Map<String, Input> inputs = Input.extractSimpleQueryParam(scriptBody); // inputs will be built
                                                                              // from script body
+
+      final AngularObjectRegistry angularRegistry = repl.getInterpreterGroup()
+              .getAngularObjectRegistry();
+
+      scriptBody = extractVariablesFromAngularRegistry(scriptBody, inputs, angularRegistry);
+
       settings.setForms(inputs);
       script = Input.getSimpleQuery(settings.getParams(), scriptBody);
     }
@@ -389,5 +396,26 @@ public class Paragraph extends Job implements Serializable, Cloneable {
   public Object clone() throws CloneNotSupportedException {
     Paragraph paraClone = (Paragraph) this.clone();
     return paraClone;
+  }
+
+  String extractVariablesFromAngularRegistry(String scriptBody, Map<String, Input> inputs,
+                                             AngularObjectRegistry angularRegistry) {
+
+    final String noteId = this.getNote().getId();
+    final String paragraphId = this.getId();
+
+    final Set<String> keys = new HashSet<>(inputs.keySet());
+
+    for (String varName : keys) {
+      final AngularObject paragraphScoped = angularRegistry.get(varName, noteId, paragraphId);
+      final AngularObject noteScoped = angularRegistry.get(varName, noteId, null);
+      final AngularObject angularObject = paragraphScoped != null ? paragraphScoped : noteScoped;
+      if (angularObject != null) {
+        inputs.remove(varName);
+        final String pattern = "[$][{]\\s*" + varName + "\\s*(?:=[^}]+)?[}]";
+        scriptBody = scriptBody.replaceAll(pattern, angularObject.get().toString());
+      }
+    }
+    return scriptBody;
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.display;
+
+public class AngularObjectBuilder {
+
+    public static <T> AngularObject<T> build(String varName, T value, String noteId,
+                                             String paragraphId) {
+        return new AngularObject<>(varName, value, noteId, paragraphId, null);
+    }
+}


### PR DESCRIPTION
### What is this PR for?
Replace dynamic form with angular object from registry if exists

I updated the `Paragraph.jobRun()` method to look for existing variable from the Angular Object Registry first before displaying the dynamic form.

We look for Angular object having same name:

* first at paragraph scope (note id + paragraph id)
* then at note scope (note id only)

I did not look at **global** scope because @Leemoonsoo  was mentioning somewhere that we may likely remove the global scope some day

_This is a sub-task of epic **[ZEPPELIN-635]**_

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Code Review
* [ ] - Simple Test

### Is there a relevant Jira issue?
**[ZEPPELIN-697]**

### How should this be tested?
* `git fetch origin pull/745/head:AngularObjectReplaceDynamicFormVar`
* `git checkout AngularObjectReplaceDynamicFormVar`
* `mvn clean package -DskipTests`
* `bin/zeppelin-daemon.sh restart`
* Create a new note
* In the first paragraph, put the following code

```html
%angular

<form class="form-inline">
  <div class="form-group">
    <label for="superheroId">Super Hero: </label>
    <input type="text" class="form-control" id="superheroId" placeholder="Superhero name ..." ng-model="superhero"></input>
  </div>
  <button type="submit" class="btn btn-primary" ng-click="z.angularBind('superhero', superhero, 'PUT_HERE_PARAGRAPH_ID'); z.runParagraph('PUT_HERE_PARAGRAPH_ID')"> Bind</button>
    <button type="submit" class="btn btn-primary" ng-click="z.angularUnbind('superhero','PUT_HERE_PARAGRAPH_ID'); z.runParagraph('PUT_HERE_PARAGRAPH_ID')"> Unbind</button>
</form>
</form>
```
* Create a second paragraph with the following code:
```scala
%md

### The superhero is : **${superhero}**
```
* In the first paragraph, replace the text PUT_HERE_PARAGRAPH_ID by the paragraph id of the second paragraph
* Execute first the second paragraph to see that the dynamic form system is working as usual
* Now put **Batman** in the input text of the first paragraph and click alternatively on **Bind** to see that dynamic form in the second paragraph is removed
* Click on **Unbind** to see that the dynamic form system is back

### Screenshots (if appropriate)
![replacedynamicform](https://cloud.githubusercontent.com/assets/1532977/14233999/34ea658a-f9d8-11e5-875d-da04dd5d0a9b.gif)


### Questions:
* Does the licenses files need update? --> **No**
* Is there breaking changes for older versions? --> **Yes**
* Does this needs documentation? --> **Yes**

[ZEPPELIN-635]: https://issues.apache.org/jira/browse/ZEPPELIN-635
[ZEPPELIN-697]: https://issues.apache.org/jira/browse/ZEPPELIN-697