### PR TITLE
Remove duplicated java option concats in common.sh

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -96,7 +96,7 @@ if [[ -z "$ZEPPELIN_MEM" ]]; then
   export ZEPPELIN_MEM="-Xms1024m -Xmx1024m -XX:MaxPermSize=512m"
 fi
 
-JAVA_OPTS=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
+JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
 export JAVA_OPTS
 
 # jvm options for interpreter process
@@ -108,7 +108,7 @@ if [[ -z "${ZEPPELIN_INTP_MEM}" ]]; then
   export ZEPPELIN_INTP_MEM="${ZEPPELIN_MEM}"
 fi
 
-JAVA_INTP_OPTS=" ${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
+JAVA_INTP_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
 export JAVA_INTP_OPTS
 
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -96,7 +96,7 @@ if [[ -z "$ZEPPELIN_MEM" ]]; then
   export ZEPPELIN_MEM="-Xms1024m -Xmx1024m -XX:MaxPermSize=512m"
 fi
 
-JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
+JAVA_OPTS=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
 export JAVA_OPTS
 
 # jvm options for interpreter process
@@ -108,7 +108,7 @@ if [[ -z "${ZEPPELIN_INTP_MEM}" ]]; then
   export ZEPPELIN_INTP_MEM="${ZEPPELIN_MEM}"
 fi
 
-JAVA_INTP_OPTS+=" ${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
+JAVA_INTP_OPTS=" ${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
 export JAVA_INTP_OPTS
 
 


### PR DESCRIPTION
### What is this PR for?
There are some java option concats in common.sh, which are executed twice when start an interpreter. This makes some of the options invalid, such as remote debugging options

### What type of PR is it?
Bug Fix

### Todos

### Is there a relevant Jira issue?
[ZEPPELIN-686](https://issues.apache.org/jira/browse/ZEPPELIN-686)

### How should this be tested?
Set remote debug options:
```
export ZEPPELIN_INTP_JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n
```

Start the Zeppelin daemon, then create & run a job to trigger starting an interpreter. The job should fail without the fix.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
NO

* Is there breaking changes for older versions?
NO

* Does this needs documentation?
NO
