### PR TITLE
[ZEPPELIN-679] only print the error message for SQL exceptions

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -137,6 +137,7 @@ public class SparkSqlInterpreter extends Interpreter {
       Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
       rdd = sqlMethod.invoke(sqlc, st);
     } catch (InvocationTargetException ite) {
+      logger.error("Invocation target exception", ite);
       return new InterpreterResult(Code.ERROR, ite.getTargetException().getMessage());
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException e) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -136,12 +136,10 @@ public class SparkSqlInterpreter extends Interpreter {
       // Therefore need to use reflection to keep binary compatibility for all spark versions.
       Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
       rdd = sqlMethod.invoke(sqlc, st);
+    } catch (InvocationTargetException ite) {
+      return new InterpreterResult(Code.ERROR, ite.getTargetException().getMessage());
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
-        | IllegalArgumentException | InvocationTargetException e) {
-      if (e instanceof InvocationTargetException) {
-        return new InterpreterResult(Code.ERROR,
-                ((InvocationTargetException) e).getTargetException().getMessage());
-      }
+        | IllegalArgumentException e) {
       throw new InterpreterException(e);
     }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -138,6 +138,10 @@ public class SparkSqlInterpreter extends Interpreter {
       rdd = sqlMethod.invoke(sqlc, st);
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException | InvocationTargetException e) {
+      if (e instanceof InvocationTargetException) {
+        return new InterpreterResult(Code.ERROR,
+                ((InvocationTargetException) e).getTargetException().getMessage());
+      }
       throw new InterpreterException(e);
     }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -60,6 +60,10 @@ public class SparkSqlInterpreter extends Interpreter {
                 SparkInterpreter.getSystemDefault("ZEPPELIN_SPARK_CONCURRENTSQL",
                     "zeppelin.spark.concurrentSQL", "false"),
                 "Execute multiple SQL concurrently if set true.")
+            .add("zeppelin.spark.sql.stacktrace",
+                SparkInterpreter.getSystemDefault("ZEPPELIN_SPARK_SQL_STACKTRACE",
+                    "zeppelin.spark.sql.stacktrace", "false"),
+                "Show full exception stacktrace for SQL queries if set to true.")
             .build());
   }
 
@@ -137,8 +141,13 @@ public class SparkSqlInterpreter extends Interpreter {
       Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
       rdd = sqlMethod.invoke(sqlc, st);
     } catch (InvocationTargetException ite) {
+      if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
+        throw new InterpreterException(ite);
+      }
       logger.error("Invocation target exception", ite);
-      return new InterpreterResult(Code.ERROR, ite.getTargetException().getMessage());
+      String msg = ite.getTargetException().getMessage()
+              + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
+      return new InterpreterResult(Code.ERROR, msg);
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException e) {
       throw new InterpreterException(e);

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -104,13 +104,10 @@ public class SparkSqlInterpreterTest {
     assertEquals(Type.TABLE, ret.type());
     assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
 
-    try {
-      sql.interpret("select wrong syntax", context);
-      fail("Exception not catched");
-    } catch (Exception e) {
-      // okay
-      LOGGER.info("Exception in SparkSqlInterpreterTest while test ", e);
-    }
+    ret = sql.interpret("select wrong syntax", context);
+    assertEquals(InterpreterResult.Code.ERROR, ret.code());
+    assertTrue(ret.message().length() > 0);
+
     assertEquals(InterpreterResult.Code.SUCCESS, sql.interpret("select case when name==\"aa\" then name else name end from test", context).code());
   }
 


### PR DESCRIPTION
### What is this PR for?

Most of the SQL exceptions are syntax errors. Printing the full stack trace is not necessary. We should only print the error message to avoid distracting the users

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-679](https://issues.apache.org/jira/browse/ZEPPELIN-679)

### How should this be tested?

### Screenshots (if appropriate)
![screen shot 2016-02-26 at 11 44 30 pm](https://cloud.githubusercontent.com/assets/3282033/13377521/7002f6de-dd93-11e5-90da-239aff0239f8.png)


### Questions:
* Does the licenses files need update?
NO

* Is there breaking changes for older versions?
NO

* Does this needs documentation?
NO

