### PR TITLE
ZEPPELIN-711 Load dependencies at startup

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -243,7 +243,14 @@ public class InterpreterFactory {
           setting.getProperties(),
           setting.getDependencies(),
           setting.getOption());
-
+      try {
+        logger.info("Loading dependencies for " + "interpreter setting "
+            + setting.getName());
+        loadInterpreterDependencies(intpSetting);
+      } catch (RepositoryException e) {
+        logger.error("Failed to load dependencies for interpretersetting "
+            + intpSetting.getName() + ":" + e.getMessage());
+      }
       InterpreterGroup interpreterGroup = createInterpreterGroup(setting.id(), setting.getOption());
       intpSetting.setInterpreterGroup(interpreterGroup);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -249,7 +249,7 @@ public class InterpreterFactory {
         loadInterpreterDependencies(intpSetting);
       } catch (RepositoryException e) {
         logger.error("Failed to load dependencies for interpretersetting "
-            + intpSetting.getName() + ":" + e.getMessage());
+            + intpSetting.getName(), e);
       }
       InterpreterGroup interpreterGroup = createInterpreterGroup(setting.id(), setting.getOption());
       intpSetting.setInterpreterGroup(interpreterGroup);


### PR DESCRIPTION
### What is this PR for?
Load  dependencies at startup.
When i try to re-use `interpreter.json` in a different zeppelin instance, the dependencies are not loaded and my paras fail.
If there are some deps configured in the interpretersetting, loading them at startup.


### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-711

### How should this be tested?
Add some dependencies to interpreter settings.
Stop zeppelin daemon
Clean up local-repo folder
Start zeppelin server.
The dependencies should have been downloaded.

### Screenshots (if appropriate) NA

### Questions:
* Does the licenses files need update? NA
* Is there breaking changes for older versions? NA
* Does this needs documentation? NA

