### PR TITLE
[ZEPPELIN-716] fix a deadlock in RemoteInterpreter.open/init

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -131,6 +131,7 @@ public class RemoteInterpreter extends Interpreter {
     interpreterProcess.reference(getInterpreterGroup());
     interpreterProcess.setMaxPoolSize(
         Math.max(this.maxPoolSize, interpreterProcess.getMaxPoolSize()));
+    String groupId = getInterpreterGroup().getId();
 
     synchronized (interpreterProcess) {
       Client client = null;
@@ -144,7 +145,7 @@ public class RemoteInterpreter extends Interpreter {
       try {
         logger.info("Create remote interpreter {}", getClassName());
         property.put("zeppelin.interpreter.localRepo", localRepoPath);
-        client.createInterpreter(getInterpreterGroup().getId(), noteId,
+        client.createInterpreter(groupId, noteId,
             getClassName(), (Map) property);
       } catch (TException e) {
         broken = true;


### PR DESCRIPTION
### What is this PR for?
Fix a deadlock in RemoteInterpreter.init()


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-716](https://issues.apache.org/jira/browse/ZEPPELIN-716)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
NO

* Is there breaking changes for older versions?
NO

* Does this needs documentation?
NO

