### PR TITLE
Interpeter settings update must set the properties

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -664,6 +664,7 @@ public class InterpreterFactory {
         intpsetting.getInterpreterGroup().destroy();
 
         intpsetting.setOption(option);
+        intpsetting.setProperties(properties);
         intpsetting.setDependencies(dependencies);
 
         InterpreterGroup interpreterGroup = createInterpreterGroup(intpsetting.id(), option);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -129,6 +129,10 @@ public class InterpreterSetting {
     return properties;
   }
 
+  public void setProperties(Properties properties) {
+    this.properties = properties;
+  }
+
   public List<Dependency> getDependencies() {
     if (dependencies == null) {
       return new LinkedList<Dependency>();


### PR DESCRIPTION
### What is this PR for?

If you change the intrepreter setting via the UI, the updated values are sent to the REST API but the JSON response coming back from the server contains the previous values (not the updated ones).

This is a regression probably introduced recently.

### What type of PR is it?
[Hot Fix]

### Todos
Nil

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-725

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
