### PR TITLE
Fix interpreter.sh to get Spark interpreter log file

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -19,7 +19,6 @@
 bin=$(dirname "${BASH_SOURCE-$0}")
 bin=$(cd "${bin}">/dev/null; pwd)
 
-
 function usage() {
     echo "usage) $0 -p <port> -d <interpreter dir to load> -l <local interpreter repo dir to load>"
 }

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -82,7 +82,7 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
     export SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
     SPARK_APP_JAR="$(ls ${ZEPPELIN_HOME}/interpreter/spark/zeppelin-spark*.jar)"
     # This will evantually passes SPARK_APP_JAR to classpath of SparkIMain
-    ZEPPELIN_CLASSPATH=${SPARK_APP_JAR}
+    ZEPPELIN_CLASSPATH+=${SPARK_APP_JAR}
 
     pattern="$SPARK_HOME/python/lib/py4j-*-src.zip"
     py4j=($pattern)


### PR DESCRIPTION
### What is this PR for?
Currently, if users set their own `SPARK_HOME`, they can not get `zeppelin-interpreter-spark-xxxx.log` file. This PR is for fixing this issue.
(This issue is reported by @weipuz)

### What type of PR is it?
Hot Fix

### Todos

### What is the Jira issue?
None 

### How should this be tested?
After applying this PR, 
1. Set your own `SPARK_HOME`.
2. Run `sc.version`(or whatever you want) with Spark interpreter.
3. Check under your `ZEPPELIN_HOME/logs/` directory, then you can find `zeppelin-interpreter-spark-xxx.log` file.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

