### PR TITLE
Change icon color when permission setting is open

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -158,7 +158,7 @@ limitations under the License.
       <span style="position:relative; top:2px; margin-right:4px; cursor:pointer;"
             ng-click="togglePermissions()"
             tooltip-placement="bottom" tooltip="Note permissions">
-        <i class="fa fa-lock" ng-style="{color: showSetting ? '#3071A9' : 'black' }"></i>
+        <i class="fa fa-lock" ng-style="{color: showPermissions ? '#3071A9' : 'black' }"></i>
       </span>
 
       <span class="btn-group">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -14,30 +14,6 @@ limitations under the License.
 <!-- Here the controller <NotebookCtrl> is not needed because explicitly set in the app.js (route) -->
 <div ng-include src="'app/notebook/notebook-actionBar.html'"></div>
 <div style="padding-top: 36px;">
-  <!-- permissions -->
-  <div ng-if="showPermissions" class="permissions">
-    <div>
-      <h4>Note Permissions (Only note owners can change)</h4>
-    </div>
-    <hr />
-    <div>
-      <p>
-        Enter comma separated users and groups in the fields. <br />
-        Empty field (*) implies anyone can do the operation.
-      </p>
-      <div class="permissionsForm"
-           data-ng-model="permissions">
-        <p>Owners : <input ng-list ng-model="permissions.owners" placeholder="*"> Owners can change permissions, read and write the note. </p>
-        <p>Readers : <input ng-list ng-model="permissions.readers" placeholder="*"> Readers can only read the note.</p>
-        <p>Writers : <input ng-list ng-model="permissions.writers" placeholder="*"> Writers can read and write the note.</p>
-      </div>
-    </div>
-    <br />
-    <div>
-      <button class="btn btn-primary" ng-click="savePermissions()">Save</button>
-      <button class="btn btn-default" ng-click="closePermissions()">Cancel</button>
-    </div>
-  </div>
   <!-- settings -->
   <div ng-if="showSetting" class="setting">
     <div>
@@ -78,6 +54,31 @@ limitations under the License.
     <div>
       <button class="btn btn-primary" ng-click="saveSetting()">Save</button>
       <button class="btn btn-default" ng-click="closeSetting()">Cancel</button>
+    </div>
+  </div>
+
+  <!-- permissions -->
+  <div ng-if="showPermissions" class="permissions">
+    <div>
+      <h4>Note Permissions (Only note owners can change)</h4>
+    </div>
+    <hr />
+    <div>
+      <p>
+        Enter comma separated users and groups in the fields. <br />
+        Empty field (*) implies anyone can do the operation.
+      </p>
+      <div class="permissionsForm"
+           data-ng-model="permissions">
+        <p>Owners : <input ng-list ng-model="permissions.owners" placeholder="*"> Owners can change permissions, read and write the note. </p>
+        <p>Readers : <input ng-list ng-model="permissions.readers" placeholder="*"> Readers can only read the note.</p>
+        <p>Writers : <input ng-list ng-model="permissions.writers" placeholder="*"> Writers can read and write the note.</p>
+      </div>
+    </div>
+    <br />
+    <div>
+      <button class="btn btn-primary" ng-click="savePermissions()">Save</button>
+      <button class="btn btn-default" ng-click="closePermissions()">Cancel</button>
     </div>
   </div>
 


### PR DESCRIPTION
### What is this PR for?
* Set note action icon color to be changed properly
* Switch location of _Settings_ and _Note permissions_

### What type of PR is it?
Hot Fix

### What is the Jira issue?
There is no jira issue

### Screenshots (if appropriate)

**Before**
![screen shot 2016-03-09 at 3 07 43 pm](https://cloud.githubusercontent.com/assets/8503346/13627348/1cb0f56c-e60d-11e5-94f0-95e824bb5c69.png)

**After**
![screen shot 2016-03-09 at 3 06 44 pm](https://cloud.githubusercontent.com/assets/8503346/13627350/1f0d427a-e60d-11e5-8e74-49c61854c523.png)

**Before**
![screen shot 2016-03-09 at 3 07 56 pm](https://cloud.githubusercontent.com/assets/8503346/13627359/31748658-e60d-11e5-8543-88bf676b2486.png)

**After**
![screen shot 2016-03-09 at 3 07 02 pm](https://cloud.githubusercontent.com/assets/8503346/13627363/362d0f94-e60d-11e5-93f0-5bf4fdc6297b.png)

**Before(Permissions comes first)** 
![screen shot 2016-03-09 at 3 46 24 pm](https://cloud.githubusercontent.com/assets/8503346/13627509/2eb84e62-e60e-11e5-812c-46ac88229782.png)

**After(Settings comes first)** 
![screen shot 2016-03-09 at 3 46 33 pm](https://cloud.githubusercontent.com/assets/8503346/13627506/2b53c45e-e60e-11e5-8dcb-9e27f3ec9ada.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No