### PR TITLE
Hot fix grunt failure

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -434,6 +434,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('build', [
+    'newer:jshint',
     'clean:dist',
     'wiredep',
     'useminPrepare',
@@ -449,12 +450,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('default', [
-    'newer:jshint',
-    /*
-     * Since we dont have test (or up to date) there is no reason to keep this task
-     * I am commented this, but can be changed in the future (if someone want to implement front tests).
-    'test',
-    */
-    'build'
+    'build',
+    'test'
   ]);
 };

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -114,7 +114,7 @@ angular.module('zeppelinWebApp')
           $scope.appendTextOutput($scope.paragraph.result.msg);
         }
 
-        angular.element('#p' + $scope.paragraph.id + '_text').bind("mousewheel", function(e) {
+        angular.element('#p' + $scope.paragraph.id + '_text').bind('mousewheel', function(e) {
           $scope.keepScrollDown = false;
         });
 
@@ -2119,7 +2119,7 @@ angular.module('zeppelinWebApp')
 
   $scope.showScrollUpIcon = function(){
     if(angular.element('#p' + $scope.paragraph.id + '_text')[0]){
-      return angular.element('#p' + $scope.paragraph.id + '_text')[0].scrollTop != 0;
+      return angular.element('#p' + $scope.paragraph.id + '_text')[0].scrollTop !== 0;
     }
     return false;
 


### PR DESCRIPTION
### What is this PR for?
This is a fix for grunt failure due to jshint warnings

Grunt error:
`src/app/notebook/paragraph/paragraph.controller.js
  line 117   col 80  Strings must use singlequote.
  line 2122  col 83  Expected '!==' and instead saw '!='.`

### What type of PR is it?
Hot Fix

### What is the Jira issue?
no

### How should this be tested?
`cd zeppelin-web` and run `grunt` should build without any error/warning

