### PR TITLE
[ZEPPELIN-735] Remove spark.executor.memory default to 512m

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -93,7 +93,7 @@ public class SparkInterpreter extends Interpreter {
           getSystemDefault("MASTER", "spark.master", "local[*]"),
           "Spark master uri. ex) spark://masterhost:7077")
         .add("spark.executor.memory",
-          getSystemDefault(null, "spark.executor.memory", "512m"),
+          getSystemDefault(null, "spark.executor.memory", ""),
           "Executor memory per worker instance. ex) 512m, 32g")
         .add("spark.cores.max",
           getSystemDefault(null, "spark.cores.max", ""),


### PR DESCRIPTION
### What is this PR for?
The Spark interpreter currently honors whatever is set for spark.executor.memory in spark-defaults.conf upon startup, but if you look at the Interpreter page, you'll see that it has a default of 512m. If you restart a running Spark interpreter from this page, the new SparkContext will use this new default of spark.executor.memory=512m instead of what it had previously pulled from spark-defaults.conf.

Removing this 512m default from SparkInterpreter code will allow spark.executor.memory to default to whatever value may be set in spark-defaults.conf, falling back to the Spark built-in default (which, btw, has for a few Spark versions been 1g, not 512m anymore).

### What type of PR is it?
Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-735

### How should this be tested?
* Set spark.executor.memory to some value in spark-defaults.conf (say, 5120m)
* Run a Spark paragraph in Zeppelin
 * The Spark application will correctly use the spark.executor.memory value from spark-defaults.conf (both before and after this change).
* View Interpreter page in Zeppelin UI
 * Before this change: spark.executor.memory will be displayed as 512m instead of what is in spark-defaults.conf
 * After this change: spark.executor.memory will be blank
* Restart Spark Interpreter from this page and run a Spark paragraph
 * Before this change: the new Spark application will incorrectly use the spark.executor.memory=512m value shown on the Interpreter page
 * After this change: the new Spark application will correctly use the spark.executor.memory value from spark-defaults.conf

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO