### PR TITLE
Allow custom location for interpreter.json and die if not writeable

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -32,6 +32,10 @@ if [[ -z "${ZEPPELIN_CONF_DIR}" ]]; then
   export ZEPPELIN_CONF_DIR="${ZEPPELIN_HOME}/conf"
 fi
 
+if [[ -z "${ZEPPELIN_INTERPRETER_CONF}" ]]; then
+  export ZEPPELIN_INTERPRETER_CONF="${ZEPPELIN_CONF_DIR}/interpreter.json"
+fi
+
 if [[ -z "${ZEPPELIN_LOG_DIR}" ]]; then
   export ZEPPELIN_LOG_DIR="${ZEPPELIN_HOME}/logs"
 fi

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -91,6 +91,30 @@ function initialize_default_directories() {
     echo "Pid dir doesn't exist, create ${ZEPPELIN_PID_DIR}"
     $(mkdir -p "${ZEPPELIN_PID_DIR}")
   fi
+
+  if [ ! -e "${ZEPPELIN_INTERPRETER_CONF}" ] ; then # if file doesn't exist
+    # get dir
+    if [ -h $ZEPPELIN_INTERPRETER_CONF ] ; then
+     ZEPPELIN_INTERPRETER_CONF_DIR=$(dirname $(readlink $ZEPPELIN_INTERPRETER_CONF))
+    else
+     ZEPPELIN_INTERPRETER_CONF_DIR=$(dirname $ZEPPELIN_INTERPRETER_CONF)
+    fi
+
+    if [[ ! -d "${ZEPPELIN_INTERPRETER_CONF_DIR}" ]]; then # if dir not there
+      echo "interpreter conf dir doesn't exist, create ${ZEPPELIN_INTERPRETER_CONF_DIR}"
+      $(mkdir -p "${ZEPPELIN_INTERPRETER_CONF_DIR}")
+    fi
+
+    if [ ! -w "${ZEPPELIN_INTERPRETER_CONF_DIR}" ] ; then # if dir not writeable 
+        echo "ERROR : cannot write file in ${ZEPPELIN_INTERPRETER_CONF_DIR}"
+        exit 1
+    fi
+  else
+    if [ ! -w "${ZEPPELIN_INTERPRETER_CONF}" ] ; then # if file not writeable 
+        echo "ERROR : cannot write to ${ZEPPELIN_INTERPRETER_CONF}"
+        exit 1
+    fi
+  fi
 }
 
 function wait_for_zeppelin_to_die() {

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -83,4 +83,28 @@ if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
   $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
 fi
 
+if [ ! -e "${ZEPPELIN_INTERPRETER_CONF}" ] ; then # if file doesn't exist
+  # get dir
+  if [ -h $ZEPPELIN_INTERPRETER_CONF ] ; then
+   ZEPPELIN_INTERPRETER_CONF_DIR=$(dirname $(readlink $ZEPPELIN_INTERPRETER_CONF))
+  else
+   ZEPPELIN_INTERPRETER_CONF_DIR=$(dirname $ZEPPELIN_INTERPRETER_CONF)
+  fi
+
+  if [[ ! -d "${ZEPPELIN_INTERPRETER_CONF_DIR}" ]]; then # if dir not there
+    echo "interpreter conf dir doesn't exist, create ${ZEPPELIN_INTERPRETER_CONF_DIR}"
+    $(mkdir -p "${ZEPPELIN_INTERPRETER_CONF_DIR}")
+  fi
+
+  if [ ! -w "${ZEPPELIN_INTERPRETER_CONF_DIR}" ] ; then # if dir not writeable 
+      echo "ERROR : cannot write file in ${ZEPPELIN_INTERPRETER_CONF_DIR}"
+      exit 1
+  fi
+else
+  if [ ! -w "${ZEPPELIN_INTERPRETER_CONF}" ] ; then # if file not writeable 
+      echo "ERROR : cannot write to ${ZEPPELIN_INTERPRETER_CONF}"
+      exit 1
+  fi
+fi
+
 $(exec $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_SERVER "$@")

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -219,5 +219,11 @@
   <description>Anonymous user allowed by default</description>
 </property>
 
+<property>
+  <name>zeppelin.interpreter.conf</name>
+  <value>conf/interpreter.json</value>
+  <description>Interpreter file location</description>
+</property>
+
 </configuration>
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -225,6 +225,12 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>interpreter</td>
     <td>Zeppelin interpreter directory</td>
   </tr>
+  <tr>
+    <td>ZEPPELIN_INTERPRETER_CONF</td>
+    <td>zeppelin.interpreter.conf</td>
+    <td>conf/interpreter.json</td>
+    <td>Zeppelin interpreter.json file path</td>
+  </tr>
 </table>
 
 Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -339,7 +339,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
   public String getInterpreterSettingPath() {
-    return getRelativeDir(String.format("%s/interpreter.json", getConfDir()));
+    return getString(ConfVars.ZEPPELIN_INTERPRETER_CONF);
   }
 
   public String getInterpreterRemoteRunnerPath() {
@@ -480,6 +480,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     // Decide when new note is created, interpreter settings will be binded automatically or not.
     ZEPPELIN_NOTEBOOK_AUTO_INTERPRETER_BINDING("zeppelin.notebook.autoInterpreterBinding", true),
     ZEPPELIN_CONF_DIR("zeppelin.conf.dir", "conf"),
+    ZEPPELIN_INTERPRETER_CONF("zeppelin.interpreter.conf", "conf/interpreter.json"),
     ZEPPELIN_DEP_LOCALREPO("zeppelin.dep.localrepo", "local-repo"),
     // Allows a way to specify a ',' separated list of allowed origins for rest and websockets
     // i.e. http://localhost:8080


### PR DESCRIPTION
### What is this PR for?
This will allow for custom location for interpreter.json.
This will try to create dir if needed.
This will die if file or file's dir not writeable. 

### What type of PR is it?
Bug Fix: Zeppelin can't manipulate notes when deployed to a write only directory.

### How should this be tested?
1. Test default: when not using a custom file, everything should work as usual.
2. Specify any file via zeppelin-site.xml AND zeppelin-env.sh and that file should be used.
3. If the file exists and is not writeable, zeppelin shouldn't start.
4. If the file's dir doesn't exit, try to create it.
5. If the file doesn't exist and the file's dir is not writeable, zeppelin shouldn't start.

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this need documentation?
Unknown
