### PR TITLE
[ZEPPELIN-734] python error with certain packages

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -41,6 +41,9 @@ class Logger(object):
   def reset(self):
     self.out = ""
 
+  def flush(self):
+    pass
+
 
 class PyZeppelinContext(dict):
   def __init__(self, zc):


### PR DESCRIPTION
### What is this PR for?
Certain python packages interact with stdout - since Zeppelin overwrites stdout to capture output, we need to make sure they have the right methods

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-734

### How should this be tested?
Run the python code outlined in the JIRA

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
