### PR TITLE
ZEPPELIN-748 make websocket maxTextMessageSize configurable

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -61,4 +61,5 @@
 # export ZEPPELIN_SPARK_USEHIVECONTEXT  # Use HiveContext instead of SQLContext if set true. true by default.
 # export ZEPPELIN_SPARK_CONCURRENTSQL   # Execute multiple SQL concurrently if set true. false by default.
 # export ZEPPELIN_SPARK_MAXRESULT       # Max number of SparkSQL result to display. 1000 by default.
+# export ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE       # Size in characters of the maximum text message to be received by websocket. Defaults to 1024000
 

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -219,5 +219,11 @@
   <description>Anonymous user allowed by default</description>
 </property>
 
+<property>
+  <name>zeppelin.websocket.maxTextMessageSize</name>
+  <value>1024000</value>
+  <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
+</property>
+
 </configuration>
 

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -220,7 +220,7 @@
 </property>
 
 <property>
-  <name>zeppelin.websocket.maxTextMessageSize</name>
+  <name>zeppelin.websocket.max.text.message.size</name>
   <value>1024000</value>
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
 </property>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -225,6 +225,12 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>interpreter</td>
     <td>Zeppelin interpreter directory</td>
   </tr>
+  <tr>
+    <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>
+    <td>zeppelin.websocket.maxTextMessageSize</td>
+    <td>1024000</td>
+    <td>Size in characters of the maximum text message to be received by websocket.</td>
+  </tr>
 </table>
 
 Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -227,7 +227,7 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
   </tr>
   <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>
-    <td>zeppelin.websocket.maxTextMessageSize</td>
+    <td>zeppelin.websocket.max.text.message.size</td>
     <td>1024000</td>
     <td>Size in characters of the maximum text message to be received by websocket.</td>
   </tr>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -173,8 +173,9 @@ public class ZeppelinServer extends Application {
 
   private static ServletContextHandler setupNotebookServer(ZeppelinConfiguration conf) {
     notebookWsServer = new NotebookServer();
+    String maxTextMessageSize = conf.getWebsocketMaxTextMessageSize();
     final ServletHolder servletHolder = new ServletHolder(notebookWsServer);
-    servletHolder.setInitParameter("maxTextMessageSize", "1024000");
+    servletHolder.setInitParameter("maxTextMessageSize", maxTextMessageSize);
 
     final ServletContextHandler cxfContext = new ServletContextHandler(
         ServletContextHandler.SESSIONS);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -383,6 +383,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return Arrays.asList(getString(ConfVars.ZEPPELIN_ALLOWED_ORIGINS).toLowerCase().split(","));
   }
 
+  public String getWebsocketMaxTextMessageSize() {
+    return getString(ConfVars.ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -489,7 +493,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     // Allows a way to specify a ',' separated list of allowed origins for rest and websockets
     // i.e. http://localhost:8080
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
-    ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true);
+    ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
+    ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.maxTextMessageSize", "1024000");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -494,7 +494,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     // i.e. http://localhost:8080
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
     ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
-    ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.maxTextMessageSize", "1024000");
+    ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000");
 
     private String varName;
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
### What is this PR for?
Allow the user to modify the value for  websocket maxTextMessageSize via conf. Recently a user filed an issue asking for the size to be configurable.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-748](https://issues.apache.org/jira/browse/ZEPPELIN-748)

### How should this be tested?
modify the value for maxTextMessageSize in zeppelin-site.xml or zeppelin-env.sh

### Screenshots (if appropriate)
<img width="990" alt="screen shot 2016-03-18 at 3 35 19 pm" src="https://cloud.githubusercontent.com/assets/2031306/13874611/1297844c-ed1f-11e5-8512-7307f6c4177d.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? yes. updated.
