### PR TITLE
[ZEPPELIN-755] Invalid notebook JSON file prevents Zeppelin daemon from starting

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -88,10 +88,9 @@ public class AzureNotebookRepo implements NotebookRepo {
           }
         } catch (StorageException | URISyntaxException e) {
           String msg = "Error enumerating notebooks from Azure storage";
-
           LOG.error(msg, e);
-
-          throw new IOException(msg, e);
+        } catch (Exception e) {
+          LOG.error(e.getMessage(), e);
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -102,7 +102,7 @@ public class S3NotebookRepo implements NotebookRepo {
               if (info != null) {
                 infos.add(info);
               }
-            } catch (IOException e) {
+            } catch (Exception e) {
               LOG.error("Can't read note ", e);
             }
           }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -134,7 +134,7 @@ public class VFSNotebookRepo implements NotebookRepo {
         if (info != null) {
           infos.add(info);
         }
-      } catch (IOException e) {
+      } catch (Exception e) {
         logger.error("Can't read note " + f.getName().toString(), e);
       }
     }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -91,6 +91,20 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
   }
 
   @Test
+  public void testInvalidJsonFile() throws IOException {
+    // given
+    int numNotes = notebookRepo.list().size();
+
+    // when create invalid json file
+    File testNoteDir = new File(mainNotebookDir, "test");
+    testNoteDir.mkdir();
+    FileUtils.writeStringToFile(new File(testNoteDir, "note.json"), "");
+
+    // then
+    assertEquals(numNotes, notebookRepo.list().size());
+  }
+
+  @Test
   public void testSaveNotebook() throws IOException, InterruptedException {
     Note note = notebook.createNote();
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());


### PR DESCRIPTION
### What is this PR for?
Invalid json file prevents Zeppelin daemon starting.
This PR catches all exceptions during json file read. So Invalid notebook file will be skipped.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Catch all exception and skip invalid json file reading
* [x] - Unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-755

### How should this be tested?
Create any directory in notebook directory, and put empty note.json. And then start Zeppelin and see if daemon started.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

