### PR TITLE
[ZEPPELIN-751]Log an error and continue reading the remaining notebooks

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -102,6 +102,16 @@ public class S3NotebookRepo implements NotebookRepo {
               if (info != null) {
                 infos.add(info);
               }
+            } catch (AmazonServiceException ase) {
+              LOG.info("Caught an AmazonServiceException for some reason.\n" +
+                      "Error Message: {}", ase.getMessage());
+            } catch (AmazonClientException ace) {
+              LOG.info("Caught an AmazonClientException, " +
+                      "which means the client encountered " +
+                      "an internal error while trying to communicate" +
+                      " with S3, " +
+                      "such as not being able to access the network.");
+              LOG.info("Error Message: " + ace.getMessage());
             } catch (IOException e) {
               LOG.error("Can't read note ", e);
             }
@@ -110,7 +120,8 @@ public class S3NotebookRepo implements NotebookRepo {
         listObjectsRequest.setMarker(objectListing.getNextMarker());
       } while (objectListing.isTruncated());
     } catch (AmazonServiceException ase) {
-
+      LOG.info("Caught an AmazonServiceException for some reason.\n" +
+              "Error Message: {}", ase.getMessage());
     } catch (AmazonClientException ace) {
       LOG.info("Caught an AmazonClientException, " +
           "which means the client encountered " +

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -104,13 +104,13 @@ public class S3NotebookRepo implements NotebookRepo {
               }
             } catch (AmazonServiceException ase) {
               LOG.info("Caught an AmazonServiceException for some reason.\n" +
-                      "Error Message: {}", ase.getMessage());
+                  "Error Message: {}", ase.getMessage());
             } catch (AmazonClientException ace) {
               LOG.info("Caught an AmazonClientException, " +
-                      "which means the client encountered " +
-                      "an internal error while trying to communicate" +
-                      " with S3, " +
-                      "such as not being able to access the network.");
+                  "which means the client encountered " +
+                  "an internal error while trying to communicate" +
+                  " with S3, " +
+                  "such as not being able to access the network.");
               LOG.info("Error Message: " + ace.getMessage());
             } catch (IOException e) {
               LOG.error("Can't read note ", e);
@@ -121,7 +121,7 @@ public class S3NotebookRepo implements NotebookRepo {
       } while (objectListing.isTruncated());
     } catch (AmazonServiceException ase) {
       LOG.info("Caught an AmazonServiceException for some reason.\n" +
-              "Error Message: {}", ase.getMessage());
+          "Error Message: {}", ase.getMessage());
     } catch (AmazonClientException ace) {
       LOG.info("Caught an AmazonClientException, " +
           "which means the client encountered " +

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -103,7 +103,7 @@ public class S3NotebookRepo implements NotebookRepo {
                 infos.add(info);
               }
             } catch (AmazonServiceException ase) {
-              LOG.info("Caught an AmazonServiceException for some reason.\n" +
+              LOG.warn("Caught an AmazonServiceException for some reason.\n" +
                   "Error Message: {}", ase.getMessage());
             } catch (AmazonClientException ace) {
               LOG.info("Caught an AmazonClientException, " +
@@ -120,7 +120,7 @@ public class S3NotebookRepo implements NotebookRepo {
         listObjectsRequest.setMarker(objectListing.getNextMarker());
       } while (objectListing.isTruncated());
     } catch (AmazonServiceException ase) {
-      LOG.info("Caught an AmazonServiceException for some reason.\n" +
+      LOG.warn("Caught an AmazonServiceException for some reason.\n" +
           "Error Message: {}", ase.getMessage());
     } catch (AmazonClientException ace) {
       LOG.info("Caught an AmazonClientException, " +


### PR DESCRIPTION
### What is this PR for?
Log an Amazon Service Exception.
Continue reading the remaining notebooks into S3ObjectSummary.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-751

### Questions:
* Do you have a plan using Guava?
(Sometimes Optional is good stuff)