### PR TITLE
remove overwritten style for p

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -48,10 +48,6 @@
   margin-bottom: 0;
 }
 
-.paragraph p {
-  margin: 0;
-}
-
 .paragraph div svg {
   width: 100%;
 }


### PR DESCRIPTION
### What is this PR for?

I don't know why we overwrite `p` in paragraph.css, but the layout is much nicer for markdown paragraphs

### What type of PR is it?

Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-649](https://issues.apache.org/jira/browse/ZEPPELIN-649)

### How should this be tested?

### Screenshots (if appropriate)

Before:
![screen shot 2016-03-28 at 8 58 54 pm](https://cloud.githubusercontent.com/assets/17979200/14097635/f3cf075e-f527-11e5-8acc-edf2e1a877aa.png)

After:
![screen shot 2016-03-28 at 8 58 36 pm](https://cloud.githubusercontent.com/assets/17979200/14097641/f9c72484-f527-11e5-9253-70b423a64ca0.png)


### Questions:
* Does the licenses files need update?
NO

* Is there breaking changes for older versions?
NO

* Does this needs documentation?
NO

