### PR TITLE
Fix removing notes without specified interpreter settings

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -627,7 +627,9 @@ public class InterpreterFactory {
 
   public void removeNoteInterpreterSettingBinding(String noteId) {
     synchronized (interpreterSettings) {
-      List<String> settingIds = interpreterBindings.remove(noteId);
+      @SuppressWarnings("unchecked")
+      List<String> settingIds = interpreterBindings.containsKey(noteId) ?
+          interpreterBindings.remove(noteId) : Collections.EMPTY_LIST;
       for (String settingId : settingIds) {
         this.removeInterpretersForNote(get(settingId), noteId);
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -627,9 +627,8 @@ public class InterpreterFactory {
 
   public void removeNoteInterpreterSettingBinding(String noteId) {
     synchronized (interpreterSettings) {
-      @SuppressWarnings("unchecked")
-      List<String> settingIds = interpreterBindings.containsKey(noteId) ?
-          interpreterBindings.remove(noteId) : Collections.EMPTY_LIST;
+      List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
+          interpreterBindings.remove(noteId) : Collections.<String>emptyList());
       for (String settingId : settingIds) {
         this.removeInterpretersForNote(get(settingId), noteId);
       }


### PR DESCRIPTION
### What is this PR for?
This PR fixes incorrect behavior when trying to remove note without saving its interpreter binding settings.

### What type of PR is it?
Bug Fix

### Todos
* [x] - don't let null return value

### What is the Jira issue?
[ZEPPELIN-765] (https://issues.apache.org/jira/browse/ZEPPELIN-765)

### How should this be tested?
Try to remove some notebook without saving its interpreter bindings when first entering it

### Screenshots (if appropriate)
Before: 
![remove_before](https://cloud.githubusercontent.com/assets/1642088/14064278/8f1737ea-f438-11e5-978c-44cdaddfd94f.gif)

After:
![remove_after](https://cloud.githubusercontent.com/assets/1642088/14064281/9a034e6e-f438-11e5-999f-e4cc802b234a.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
