### PR TITLE
[ZEPPELIN-767] HBase interpreter does not work with HBase on a remote cluster

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -132,7 +132,7 @@ elif [[ "${INTERPRETER_ID}" == "hbase" ]]; then
   if [[ -n "${HBASE_CONF_DIR}" ]]; then
     ZEPPELIN_CLASSPATH+=":${HBASE_CONF_DIR}"
   elif [[ -n "${HBASE_HOME}" ]]; then
-    ZEPPELIN_CLASSPATH+=":${HBASE_CONF_DIR}/conf"
+    ZEPPELIN_CLASSPATH+=":${HBASE_HOME}/conf"
   else
     echo "HBASE_HOME and HBASE_CONF_DIR are not set, configuration might not be loaded"
   fi

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -128,6 +128,14 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
 
     export SPARK_CLASSPATH+=":${ZEPPELIN_CLASSPATH}"
   fi
+elif [[ "${INTERPRETER_ID}" == "hbase" ]]; then
+  if [[ -n "${HBASE_CONF_DIR}" ]]; then
+    ZEPPELIN_CLASSPATH+=":${HBASE_CONF_DIR}"
+  elif [[ -n "${HBASE_HOME}" ]]; then
+    ZEPPELIN_CLASSPATH+=":${HBASE_CONF_DIR}/conf"
+  else
+    echo "HBASE_HOME and HBASE_CONF_DIR are not set, configuration might not be loaded"
+  fi
 fi
 
 addJarInDir "${LOCAL_INTERPRETER_REPO}"

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -62,3 +62,9 @@
 # export ZEPPELIN_SPARK_CONCURRENTSQL   # Execute multiple SQL concurrently if set true. false by default.
 # export ZEPPELIN_SPARK_MAXRESULT       # Max number of SparkSQL result to display. 1000 by default.
 
+#### HBase interpreter configuration ####
+
+## To connect to HBase running on a cluster, either HBASE_HOME or HBASE_CONF_DIR must be set
+
+# export HBASE_HOME=                    # (require) Under which HBase scripts and configuration should be
+# export HBASE_CONF_DIR=                # (optional) Alternatively, configuration directory can be set to point to the directory that has hbase-site.xml

--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -31,7 +31,7 @@ To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/
     <td>Path to Ruby scripts relative to 'hbase.home'</td>
   </tr>
   <tr>
-    <td>hbase.test.mode</td>
+    <td>zeppelin.hbase.test.mode</td>
     <td>false</td>
     <td>Disable checks for unit and manual tests</td>
   </tr>

--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -23,7 +23,7 @@ To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/
   <tr>
     <td>hbase.home</td>
     <td>/usr/lib/hbase</td>
-    <td>Installation directory of Hbase</td>
+    <td>Installation directory of HBase, defaults to HBASE_HOME in environment</td>
   </tr>
   <tr>
     <td>hbase.ruby.sources</td>
@@ -36,6 +36,25 @@ To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/
     <td>Disable checks for unit and manual tests</td>
   </tr>
 </table>
+
+If you want to connect to HBase running on a cluster, you'll need to follow the next step.
+
+### Export HBASE_HOME
+In **conf/zeppelin-env.sh**, export `HBASE_HOME` environment variable with your HBase installation path. This ensures `hbase-site.xml` can be loaded.
+
+for example
+
+```bash
+export HBASE_HOME=/usr/lib/hbase
+```
+
+or, when running with CDH
+
+```bash
+export HBASE_HOME="/opt/cloudera/parcels/CDH/lib/hbase"
+```
+
+You can optionally export `HBASE_CONF_DIR` instead of `HBASE_HOME` should you have custom HBase configurations.
 
 ## Enabling the HBase Shell Interpreter
 

--- a/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
+++ b/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
@@ -47,11 +47,10 @@ import java.util.Properties;
  * that the client is configured properly.
  *
  * The interpreter takes 3 config parameters:
- * hbase.home: Root dir. where hbase is installed. Default is /usr/lib/hbase/
+ * hbase.home: Root directory where hbase is installed. Default is /usr/lib/hbase/
  * hbase.ruby.sources: Dir where shell ruby code is installed.
  *                          Path is relative to hbase.home. Default: lib/ruby
- * hbase.irb.load: (Testing only) Default is true.
- *                      Whether to load irb in the interpreter.
+ * zeppelin.hbase.test.mode: (Testing only) Disable checks for unit and manual tests. Default: false
  */
 public class HbaseInterpreter extends Interpreter {
   private Logger logger = LoggerFactory.getLogger(HbaseInterpreter.class);
@@ -62,11 +61,13 @@ public class HbaseInterpreter extends Interpreter {
   static {
     Interpreter.register("hbase", "hbase", HbaseInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
-            .add("hbase.home", "/usr/lib/hbase/", "Installation dir. of Hbase")
+            .add("hbase.home",
+              getSystemDefault("HBASE_HOME", "hbase.home", "/usr/lib/hbase/"),
+              "Installation directory of Hbase")
             .add("hbase.ruby.sources", "lib/ruby",
                 "Path to Ruby scripts relative to 'hbase.home'")
-            .add("hbase.test.mode", "false", "Disable checks for unit and manual tests")
-            .build());
+            .add("zeppelin.hbase.test.mode", "false", "Disable checks for unit and manual tests")
+          .build());
   }
 
   public HbaseInterpreter(Properties property) {
@@ -79,7 +80,7 @@ public class HbaseInterpreter extends Interpreter {
     this.writer = new StringWriter();
     scriptingContainer.setOutput(this.writer);
 
-    if (!Boolean.parseBoolean(getProperty("hbase.test.mode"))) {
+    if (!Boolean.parseBoolean(getProperty("zeppelin.hbase.test.mode"))) {
       String hbase_home = getProperty("hbase.home");
       String ruby_src = getProperty("hbase.ruby.sources");
       Path abs_ruby_src = Paths.get(hbase_home, ruby_src).toAbsolutePath();
@@ -155,4 +156,24 @@ public class HbaseInterpreter extends Interpreter {
     return null;
   }
 
+  private static String getSystemDefault(
+      String envName,
+      String propertyName,
+      String defaultValue) {
+
+    if (envName != null && !envName.isEmpty()) {
+      String envValue = System.getenv().get(envName);
+      if (envValue != null) {
+        return envValue;
+      }
+    }
+
+    if (propertyName != null && !propertyName.isEmpty()) {
+      String propValue = System.getProperty(propertyName);
+      if (propValue != null) {
+        return propValue;
+      }
+    }
+    return defaultValue;
+  }
 }

--- a/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
+++ b/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
@@ -37,17 +37,17 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Support for Hbase Shell. All the commands documented here
+ * Support for HBase Shell. All the commands documented here
  * http://hbase.apache.org/book.html#shell is supported.
  *
  * Requirements:
- * Hbase Shell should be installed on the same machine. To be more specific, the following dir.
+ * HBase Shell should be installed on the same machine. To be more specific, the following dir.
  * should be available: https://github.com/apache/hbase/tree/master/hbase-shell/src/main/ruby
- * Hbase Shell should be able to connect to the Hbase cluster from terminal. This makes sure
+ * HBase Shell should be able to connect to the HBase cluster from terminal. This makes sure
  * that the client is configured properly.
  *
  * The interpreter takes 3 config parameters:
- * hbase.home: Root directory where hbase is installed. Default is /usr/lib/hbase/
+ * hbase.home: Root directory where HBase is installed. Default is /usr/lib/hbase/
  * hbase.ruby.sources: Dir where shell ruby code is installed.
  *                          Path is relative to hbase.home. Default: lib/ruby
  * zeppelin.hbase.test.mode: (Testing only) Disable checks for unit and manual tests. Default: false
@@ -63,7 +63,7 @@ public class HbaseInterpreter extends Interpreter {
         new InterpreterPropertyBuilder()
             .add("hbase.home",
               getSystemDefault("HBASE_HOME", "hbase.home", "/usr/lib/hbase/"),
-              "Installation directory of Hbase")
+              "Installation directory of HBase")
             .add("hbase.ruby.sources", "lib/ruby",
                 "Path to Ruby scripts relative to 'hbase.home'")
             .add("zeppelin.hbase.test.mode", "false", "Disable checks for unit and manual tests")
@@ -90,7 +90,7 @@ public class HbaseInterpreter extends Interpreter {
 
       File f = abs_ruby_src.toFile();
       if (!f.exists() || !f.isDirectory()) {
-        throw new InterpreterException("hbase ruby sources is not available at '" + abs_ruby_src
+        throw new InterpreterException("HBase ruby sources is not available at '" + abs_ruby_src
             + "'");
       }
 

--- a/hbase/src/test/java/org/apache/zeppelin/hbase/HbaseInterpreterTest.java
+++ b/hbase/src/test/java/org/apache/zeppelin/hbase/HbaseInterpreterTest.java
@@ -40,7 +40,7 @@ public class HbaseInterpreterTest {
     Properties properties = new Properties();
     properties.put("hbase.home", "");
     properties.put("hbase.ruby.sources", "");
-    properties.put("hbase.test.mode", "true");
+    properties.put("zeppelin.hbase.test.mode", "true");
 
     hbaseInterpreter = new HbaseInterpreter(properties);
     hbaseInterpreter.open();


### PR DESCRIPTION
### What is this PR for?
HBase interpreter fails with message "ERROR: KeeperErrorCode = ConnectionLoss for /hbase" when connecting to a remote HBASE (for instance, HBase running in CDH cluster)

Initially it's thought that zkquoram setttings are not getting applied, but deeper investigations reveal that hbase-site.xml cannot be loaded.

HBASE_HOME or HBASE_CONF_DIR is set by `hbase` script when running hbase shell - interpreter will need to at minimum replicate that behavior to add the directory with hbase-site.xml to CLASS_PATH in order to fix this issue.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Bug fix
* [x] - Update documentation


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-767

### How should this be tested?
(tested) Run HBase locally (standalone: https://hbase.apache.org/book.html#quickstart)
(tested) Set HBASE_HOME in env and work with HBASE on a Hadoop cluster
(tested) Set HBASE_CONF_DIR in env and work with HBASE on a Hadoop cluster

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Added
