### PR TITLE
[ZEPPELIN-768] HBase 1.1.x and 1.2.0 release support documentation

### DIFF
--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -11,7 +11,7 @@ group: manual
 To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/book.html#quickstart)
 
 ## HBase release supported
-By default, Zeppelin is built again HBase 1.0.x releases. To work with HBase 1.1.x releases, use the following build command:
+By default, Zeppelin is built against HBase 1.0.x releases. To work with HBase 1.1.x releases, use the following build command:
 ```bash
 # HBase 1.1.4
 mvn clean package -DskipTests -Phadoop-2.6 -Dhadoop.version=2.6.0 -P build-distr -Dhbase.hbase.version=1.1.4 -Dhbase.hadoop.version=2.6.0

--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -10,7 +10,18 @@ group: manual
 [HBase Shell](http://hbase.apache.org/book.html#shell) is a JRuby IRB client for Apache HBase. This interpreter provides all capabilities of Apache HBase shell within Apache Zeppelin. The interpreter assumes that Apache HBase client software has been installed and it can connect to the Apache HBase cluster from the machine on where Apache Zeppelin is installed.  
 To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/book.html#quickstart)
 
-> Note: currently only HBase 1.0.x releases are supported.
+## HBase release supported
+By default, Zeppelin is built again HBase 1.0.x releases. To work with HBase 1.1.x releases, use the following build command:
+```bash
+# HBase 1.1.4
+mvn clean package -DskipTests -Phadoop-2.6 -Dhadoop.version=2.6.0 -P build-distr -Dhbase.hbase.version=1.1.4 -Dhbase.hadoop.version=2.6.0
+```
+To work with HBase 1.2.0+, use the following build command:
+
+```bash
+# HBase 1.2.0
+mvn clean package -DskipTests -Phadoop-2.6 -Dhadoop.version=2.6.0 -P build-distr -Dhbase.hbase.version=1.2.0 -Dhbase.hadoop.version=2.6.0
+```
 
 ## Configuration
 


### PR DESCRIPTION
### What is this PR for?
When run with HBase 1.1.x or HBase 1.2.0, this error is reported:
```
org.jruby.exceptions.RaiseException: (NameError) cannot load Java class org.apache.hadoop.hbase.quotas.ThrottleType
	at org.jruby.javasupport.JavaUtilities.get_proxy_or_package_under_package(org/jruby/javasupport/JavaUtilities.java:54)
	at (Anonymous).method_missing(/builtin/javasupport/java.rb:51)
	at (Anonymous).(root)(/opt/hbase-1.1.4/lib/ruby/hbase/quotas.rb:23)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1062)
	at (Anonymous).(root)(/opt/hbase-1.1.4/lib/ruby/hbase/quotas.rb:24)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1062)
	at (Anonymous).(root)(/opt/hbase-1.1.4/lib/ruby/hbase/hbase.rb:96)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1062)
	at (Anonymous).(root)(/opt/hbase-1.1.4/lib/ruby/hbase.rb:105)
```
This PR outlines the step to build Zeppelin to resolve this error.

### What type of PR is it?
Documentation

### Todos
* [x] - Test build and run notebook with HBase 1.1.4
* [x] - Test build and run notebook with HBase 1.2.0
* [x] - Document build steps

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-768

### How should this be tested?
Test build and run notebook with HBase 1.1.4
Test build and run notebook with HBase 1.2.0

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes

