### PR TITLE
replace standard alert and confirm with BootstrapDialog

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -686,7 +686,11 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     }).
     error(function(data, status, headers, config) {
       console.log('Error %o %o', status, data.message);
-      alert(data.message);
+      BootstrapDialog.alert({
+        closable: true,
+        title: 'Insufficient privileges',
+        message: data.message
+      });
     });
   };
 

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -54,7 +54,11 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'AUTH_INFO') {
-      alert(data.info.toString());
+      BootstrapDialog.alert({
+        closable: true,
+        title: 'Insufficient privileges',
+        message: data.info.toString()
+      });
     } else if (op === 'PARAGRAPH') {
       $rootScope.$broadcast('updateParagraph', data);
     } else if (op === 'PARAGRAPH_APPEND_OUTPUT') {


### PR DESCRIPTION
### What is this PR for?
Replace standard alert and confirm with BootstrapDialog.
Most of these were already take care by https://github.com/apache/incubator-zeppelin/pull/501

### What type of PR is it?
Bug Fix


### What is the Jira issue?
N/A

### How should this be tested?
Try accessing a notebook by user who is not authorized, instead of standard alert there should be a BootstrapDialog.
 
### Screenshots (if appropriate)
Before:
![screen shot 2016-03-28 at 3 50 59 pm](https://cloud.githubusercontent.com/assets/674497/14076259/d28ee552-f4fd-11e5-80d9-ac648e06c373.png)

After:
![screen shot 2016-03-28 at 3 53 22 pm](https://cloud.githubusercontent.com/assets/674497/14076263/d6410356-f4fd-11e5-8d71-62be584c424f.png)


