### PR TITLE
[ZEPPELIN-770] Add support for MapR 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Available profiles are
 -Pmapr40
 -Pmapr41
 -Pmapr50
+-Pmapr51
 ```
 
 

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -715,6 +715,45 @@
     </profile>
 
     <profile>
+      <id>mapr51</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <hadoop.version>2.7.0-mapr-1602</hadoop.version>
+        <yarn.version>2.7.0-mapr-1602</yarn.version>
+        <jets3t.version>0.9.3</jets3t.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+          <version>2.4.0</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.zookeeper</groupId>
+              <artifactId>zookeeper</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+          <version>3.4.5-mapr-1503</version>
+        </dependency>
+      </dependencies>
+      <repositories>
+         <repository>
+           <id>mapr-releases</id>
+           <url>http://repository.mapr.com/maven/</url>
+           <snapshots><enabled>false</enabled></snapshots>
+           <releases><enabled>true</enabled></releases>
+         </repository>
+      </repositories>
+    </profile>
+
+
+    <profile>
       <id>yarn</id>
       <dependencies>
         <dependency>


### PR DESCRIPTION
### What is this PR for?
Adding support for MapR 5.1 via profile


### What type of PR is it?
Improvement

### Todos
* [x] - Add MapR 5.1 profile to spark-dependencies/pom.xml
* [x] - Update README.md to reflect new profile.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-770

### How should this be tested?
Standard build with the -Pmapr51 profile

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No