### PR TITLE
[ZEPPELIN-772] - Improve text append when streaming

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -167,7 +167,7 @@ angular.module('zeppelinWebApp')
         angular.element('#p' + $scope.paragraph.id + '_text').bind('mousewheel', function(e) {
           $scope.keepScrollDown = false;
         });
-
+        $scope.flushStreamingOutput = true;
       } else {
         $timeout(retryRenderer, 10);
       }
@@ -445,13 +445,17 @@ angular.module('zeppelinWebApp')
 
   $scope.$on('appendParagraphOutput', function(event, data) {
     if ($scope.paragraph.id === data.paragraphId) {
+      if ($scope.flushStreamingOutput) {
+        $scope.clearTextOutput();
+        $scope.flushStreamingOutput = false;
+      }
       $scope.appendTextOutput(data.data);
     }
   });
 
   $scope.$on('updateParagraphOutput', function(event, data) {
     if ($scope.paragraph.id === data.paragraphId) {
-      $scope.clearTextOutput(data.data);
+      $scope.clearTextOutput();
       $scope.appendTextOutput(data.data);
     }
   });


### PR DESCRIPTION
### What is this PR for?
This PR is to improve the result output when having interpreter streaming running.
If you navigate outside the notebook, then come back inside, the streaming output will append below previous result.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-772

### How should this be tested?
You can run this
```
(1 to 40).foreach{ i=>
    Thread.sleep(1000)
    println("Hello " + i)
}
```
Then navigate to home, then back to the notebook.
You should see the newly streamed result only.

### Screenshots
Before:
![before](https://cloud.githubusercontent.com/assets/710411/14101710/2b3608f6-f5d1-11e5-9501-e9ba7b0bc16c.gif)

After:
![after](https://cloud.githubusercontent.com/assets/710411/14101714/31aaab06-f5d1-11e5-8fc1-645a3324a65e.gif)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

