### PR TITLE
[ZEPPELIN-775] - Update Spark-1.6.0 profile to use Spark 1.6.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   include:
     # Test all modules
     - jdk: "oraclejdk7"
-      env: SPARK_VER="1.6.0" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Phadoop-2.3 -Ppyspark -Pscalding" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test spark module for 1.5.2
     - jdk: "oraclejdk7"

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -505,7 +505,7 @@
     <profile>
       <id>spark-1.6</id>
       <properties>
-        <spark.version>1.6.0</spark.version>
+        <spark.version>1.6.1</spark.version>
         <py4j.version>0.9</py4j.version>
         <akka.group>com.typesafe.akka</akka.group>
         <akka.version>2.3.11</akka.version>


### PR DESCRIPTION
### What is this PR for?
Now that Spark 1.6.1 is available, update the Spark 1.6.0 profile to use it.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-775](https://issues.apache.org/jira/browse/ZEPPELIN-775)
