### PR TITLE
ZEPPELIN-776: force CI to always use container-based infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@
 
 language: java
 
+sudo: false
+
 matrix:
   include:
     # Test all modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,3 @@ after_failure:
 after_script:
   - ./testing/stopSparkCluster.sh $SPARK_VER $HADOOP_VER
 
-notifications:
-  slack:
-    secure: dtIkPwlf5uTun19p9TtPEAFmrLOMK2COE8TL9m8LXX/N2WzJaKYvAnovMObEV6KEgK2oZ+72Cke7eBI+Hp4FmHZ2B7mQI/PNCfRZthI3cc3zVmMd25yvLH9AlCRa2bC6R885z2copvzaoZtLBkHnPa8bUrUkbmRp40qkDPQpgO4=


### PR DESCRIPTION
### What is this PR for?
It forces travis CI to use container-based infra for everything, not only `master`.

It will result in [many benefits](https://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F), improving CI stability and including reducing [obscure CI failures \w old Spark versions](https://issues.apache.org/jira/browse/ZEPPELIN-776?focusedCommentId=15219388&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15219388)

### What type of PR is it?
Improvement, Hotfix for #208


### What is the Jira issue?
[ZEPPELIN-776](https://issues.apache.org/jira/browse/ZEPPELIN-776)

### How should this be tested?
CI should be green, that is all.


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

