### PR TITLE
[ZEPPELIN-789] Skip execution of a paragraph in case of error 

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -68,6 +68,14 @@ public abstract class Job {
     public boolean isPending() {
       return this == PENDING;
     }
+
+    public boolean isError() {
+      return this == ERROR;
+    }
+
+    public boolean isFinished() {
+      return this == FINISHED;
+    }
   }
 
   private String jobName;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -52,9 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.google.gson.GsonBuilder;
-import com.google.gson.stream.JsonReader;
-import java.io.StringReader;
 /**
  * Rest api endpoint for the noteBook.
  */
@@ -214,7 +211,7 @@ public class NotebookRestApi {
 
   /**
    * export note REST API
-   * 
+   *
    * @param
    * @return note JSON with status.OK
    * @throws IOException
@@ -228,7 +225,7 @@ public class NotebookRestApi {
 
   /**
    * import new note REST API
-   * 
+   *
    * @param req - notebook Json
    * @return JSON with new note ID
    * @throws IOException
@@ -239,7 +236,7 @@ public class NotebookRestApi {
     Note newNote = notebook.importNote(req, null);
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
-  
+
   /**
    * Create new note REST API
    * @param message - JSON with new note name
@@ -259,6 +256,9 @@ public class NotebookRestApi {
         Paragraph p = note.addParagraph();
         p.setTitle(paragraphRequest.getTitle());
         p.setText(paragraphRequest.getText());
+        if (paragraphRequest.getSkipOnError()) {
+          p.getConfig().put("skipOnError", true);
+        }
       }
     }
     note.addParagraph(); // add one paragraph to the last
@@ -292,7 +292,7 @@ public class NotebookRestApi {
     notebookServer.broadcastNoteList();
     return new JsonResponse<>(Status.OK, "").build();
   }
-  
+
   /**
    * Clone note REST API
    * @param
@@ -451,7 +451,7 @@ public class NotebookRestApi {
     if (note == null) {
       return new JsonResponse<>(Status.NOT_FOUND, "note not found.").build();
     }
-    
+
     note.runAll();
     return new JsonResponse<>(Status.OK).build();
   }
@@ -479,7 +479,7 @@ public class NotebookRestApi {
     }
     return new JsonResponse<>(Status.OK).build();
   }
-  
+
   /**
    * Get notebook job status REST API
    * @param
@@ -498,10 +498,10 @@ public class NotebookRestApi {
 
     return new JsonResponse<>(Status.OK, null, note.generateParagraphsInfo()).build();
   }
-  
+
   /**
    * Run paragraph job REST API
-   * 
+   *
    * @param message - JSON with params if user wants to update dynamic form's value
    *                null, empty string, empty json if user doesn't want to update
    *
@@ -510,7 +510,7 @@ public class NotebookRestApi {
    */
   @POST
   @Path("job/{notebookId}/{paragraphId}")
-  public Response runParagraph(@PathParam("notebookId") String notebookId, 
+  public Response runParagraph(@PathParam("notebookId") String notebookId,
                                @PathParam("paragraphId") String paragraphId,
                                String message) throws
                                IOException, IllegalArgumentException {
@@ -549,7 +549,7 @@ public class NotebookRestApi {
    */
   @DELETE
   @Path("job/{notebookId}/{paragraphId}")
-  public Response stopParagraph(@PathParam("notebookId") String notebookId, 
+  public Response stopParagraph(@PathParam("notebookId") String notebookId,
                                 @PathParam("paragraphId") String paragraphId) throws
                                 IOException, IllegalArgumentException {
     LOG.info("stop paragraph job {} ", notebookId);
@@ -565,7 +565,7 @@ public class NotebookRestApi {
     p.abort();
     return new JsonResponse<>(Status.OK).build();
   }
-    
+
   /**
    * Register cron job REST API
    * @param message - JSON with cron expressions.
@@ -580,12 +580,12 @@ public class NotebookRestApi {
 
     CronRequest request = gson.fromJson(message,
                           CronRequest.class);
-    
+
     Note note = notebook.getNote(notebookId);
     if (note == null) {
       return new JsonResponse<>(Status.NOT_FOUND, "note not found.").build();
     }
-    
+
     if (!CronExpression.isValidExpression(request.getCronString())) {
       return new JsonResponse<>(Status.BAD_REQUEST, "wrong cron expressions.").build();
     }
@@ -594,10 +594,10 @@ public class NotebookRestApi {
     config.put("cron", request.getCronString());
     note.setConfig(config);
     notebook.refreshCron(note.id());
-    
+
     return new JsonResponse<>(Status.OK).build();
   }
-  
+
   /**
    * Remove cron job REST API
    * @param
@@ -614,15 +614,15 @@ public class NotebookRestApi {
     if (note == null) {
       return new JsonResponse<>(Status.NOT_FOUND, "note not found.").build();
     }
-    
+
     Map<String, Object> config = note.getConfig();
     config.put("cron", null);
     note.setConfig(config);
     notebook.refreshCron(note.id());
-    
+
     return new JsonResponse<>(Status.OK).build();
-  }  
-  
+  }
+
   /**
    * Get cron job REST API
    * @param
@@ -639,9 +639,9 @@ public class NotebookRestApi {
     if (note == null) {
       return new JsonResponse<>(Status.NOT_FOUND, "note not found.").build();
     }
-    
+
     return new JsonResponse<>(Status.OK, note.getConfig().get("cron")).build();
-  }  
+  }
 
   /**
    * Search for a Notes

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
@@ -25,6 +25,7 @@ package org.apache.zeppelin.rest.message;
 public class NewParagraphRequest {
   String title;
   String text;
+  boolean skipOnError;
   Double index;
 
   public NewParagraphRequest() {
@@ -37,6 +38,10 @@ public class NewParagraphRequest {
 
   public String getText() {
     return text;
+  }
+
+  public boolean getSkipOnError() {
+    return skipOnError;
   }
 
   public Double getIndex() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
@@ -52,6 +52,8 @@ public class Message {
     IMPORT_NOTE,  // [c-s] import notebook
                   // @param object notebook
     NOTE_UPDATE,
+    RUN_NOTE,   // [c-s] run notebook
+                // @param id note id
 
     RUN_PARAGRAPH, // [c-s] run paragraph
                    // @param id paragraph id
@@ -100,7 +102,7 @@ public class Message {
 
     ANGULAR_OBJECT_UPDATE,  // [s-c] add/update angular object
     ANGULAR_OBJECT_REMOVE,  // [s-c] add angular object del
-    
+
     ANGULAR_OBJECT_UPDATED,  // [c-s] angular object value updated,
 
     ANGULAR_OBJECT_CLIENT_BIND,  // [c-s] angular object updated from AngularJS z object

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -20,14 +20,16 @@ package org.apache.zeppelin.socket;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.servlet.http.HttpServletRequest;
-
-import com.google.common.base.Strings;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
@@ -35,24 +37,33 @@ import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
-import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
-import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
-import org.apache.zeppelin.notebook.*;
+import org.apache.zeppelin.notebook.JobListenerFactory;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.ParagraphJobListener;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.socket.Message.OP;
 import org.apache.zeppelin.ticket.TicketContainer;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.websocket.WebSocket;
 import org.eclipse.jetty.websocket.WebSocketServlet;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 /**
  * Zeppelin websocket service.
@@ -107,7 +118,7 @@ public class NotebookServer extends WebSocketServlet implements
       if (LOG.isTraceEnabled()) {
         LOG.trace("RECEIVE MSG = " + messagereceived);
       }
-      
+
       String ticket = TicketContainer.instance.getTicket(messagereceived.principal);
       if (ticket != null && !ticket.equals(messagereceived.ticket))
         throw new Exception("Invalid ticket " + messagereceived.ticket + " != " + ticket);
@@ -154,6 +165,9 @@ public class NotebookServer extends WebSocketServlet implements
             break;
           case IMPORT_NOTE:
             importNote(conn, userAndRoles, notebook, messagereceived);
+            break;
+          case RUN_NOTE:
+            runNote(conn, userAndRoles, notebook, messagereceived);
             break;
           case COMMIT_PARAGRAPH:
             updateParagraph(conn, userAndRoles, notebook, messagereceived);
@@ -527,6 +541,25 @@ public class NotebookServer extends WebSocketServlet implements
 
     notebook.removeNote(noteId);
     removeNote(noteId);
+    broadcastNoteList();
+  }
+
+  private void runNote(NotebookSocket conn, HashSet<String> userAndRoles,
+          Notebook notebook, Message fromMessage)
+      throws IOException {
+    String noteId = (String) fromMessage.get("id");
+    if (noteId == null) {
+      return;
+    }
+
+    Note note = notebook.getNote(noteId);
+    NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
+    if (!notebookAuthorization.isOwner(noteId, userAndRoles)) {
+      permissionError(conn, "remove", userAndRoles, notebookAuthorization.getOwners(noteId));
+      return;
+    }
+
+    note.runAll();
     broadcastNoteList();
   }
 
@@ -1082,6 +1115,8 @@ public class NotebookServer extends WebSocketServlet implements
 
     @Override
     public void afterStatusChange(Job job, Status before, Status after) {
+      note.setExecutionStatus(job.getId(), after);
+
       if (after == Status.ERROR) {
         if (job.getException() != null) {
           LOG.error("Error", job.getException());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -239,7 +239,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-control-play']")).isDisplayed(), CoreMatchers.equalTo(false)
       );
 
-      driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='runNote()']")).sendKeys(Keys.ENTER);
+      driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='runNote(note.id)']")).sendKeys(Keys.ENTER);
       sleep(1000, true);
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Run all paragraphs?')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -19,7 +19,7 @@ limitations under the License.
     <span class="labelBtn btn-group">
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-click="runNote()"
+              ng-click="runNote(note.id)"
               ng-class="{'disabled':isNoteRunning()}"
               tooltip-placement="bottom" tooltip="Run all paragraphs">
         <i class="icon-control-play"></i>

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -169,17 +169,17 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     document.getElementById('note.checkpoint.message').value='';
   };
 
-  $scope.runNote = function() {
+  $scope.runNote = function(noteId) {
     BootstrapDialog.confirm({
       closable: true,
       title: '',
       message: 'Run all paragraphs?',
       callback: function(result) {
-        if (result) {
-          _.forEach($scope.note.paragraphs, function (n, key) {
-            angular.element('#' + n.id + '_paragraphColumn_main').scope().runParagraph(n.text);
-          });
-        }
+        _.forEach($scope.note.paragraphs, function(n, key) {
+          angular.element('#' + n.id + '_paragraphColumn_main').scope().saveParagraph();
+        });
+
+        websocketMsgSrv.runNote(noteId);
       }
     });
   };

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -80,6 +80,10 @@ limitations under the License.
           {{paragraph.config.enabled ? "Disable" : "Enable"}} run</a>
       </li>
       <li>
+        <a ng-click="toggleSkipOnError()"><span class="icon-control-forward"></span>
+          {{paragraph.config.skipOnError ? "Disable" : "Enable"}} Skip On Error</a>
+      </li>
+      <li>      
         <a ng-click="goToSingleParagraph()"><span class="icon-share-alt"></span> Link this paragraph</a>
       </li>
       <li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -454,6 +454,13 @@ angular.module('zeppelinWebApp')
     websocketMsgSrv.cancelParagraphRun($scope.paragraph.id);
   };
 
+  $scope.toggleSkipOnError = function () {
+    $scope.paragraph.config.skipOnError = $scope.paragraph.config.skipOnError ? false : true;
+    var newParams = angular.copy($scope.paragraph.settings.params);
+    var newConfig = angular.copy($scope.paragraph.config);
+    commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
+  };
+
   $scope.runParagraph = function(data) {
     websocketMsgSrv.runParagraph($scope.paragraph.id, $scope.paragraph.title,
                                  data, $scope.paragraph.config, $scope.paragraph.settings.params);

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -110,6 +110,10 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
+    runNote: function(noteId) {
+      websocketEvents.sendNewEvent({op: 'RUN_NOTE', data: {id: noteId}});
+    },
+
     removeParagraph: function(paragraphId) {
       websocketEvents.sendNewEvent({op: 'PARAGRAPH_REMOVE', data: {id: paragraphId}});
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -333,7 +333,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   public String getBucketName() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_BUCKET);
   }
-  
+
   public String getEndpoint() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_ENDPOINT);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -116,6 +116,11 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     return enabled == null || enabled.booleanValue();
   }
 
+  public boolean isSkipOnError() {
+    Boolean skipOnFailure = (Boolean) config.get("skipOnError");
+    return skipOnFailure != null && skipOnFailure.booleanValue();
+  }
+
   public String getRequiredReplName() {
     return getRequiredReplName(text);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockErrorInterpreter.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockErrorInterpreter.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.scheduler.Scheduler;
+import org.apache.zeppelin.scheduler.SchedulerFactory;
+
+public class MockErrorInterpreter extends Interpreter{
+  Map<String, Object> vars = new HashMap<String, Object>();
+
+  public MockErrorInterpreter(Properties property) {
+    super(property);
+  }
+
+  @Override
+  public void open() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+        InterpreterResult result;
+
+    if ("error".equals(st)) {
+      throw new InterpreterException("Error...");
+    } else {
+      result = new InterpreterResult(InterpreterResult.Code.ERROR, "error: " + st);
+      if (context.getResourcePool() != null) {
+        context.getResourcePool().put(context.getNoteId(), context.getParagraphId(), "result", result);
+      }
+    }
+
+    return result;
+  }
+
+  @Override
+  public void cancel(InterpreterContext context) {
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return 0;
+  }
+
+  @Override
+  public Scheduler getScheduler() {
+    return SchedulerFactory.singleton().createOrGetFIFOScheduler("test_"+this.hashCode());
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    return null;
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -508,7 +508,9 @@ public class NotebookTest implements JobListenerFactory{
       assertEquals(Job.Status.READY, p.getStatus());
     }
 
-    note.runAll();
+    for (Paragraph p : paragraphs) {
+      note.run(p.getId());
+    }
 
     while (paragraphs.get(0).getStatus() != Status.FINISHED) Thread.yield();
 


### PR DESCRIPTION
### What is this PR for?
New option in paragraphs to skip execution, when notebook is executed as a whole and there were some errors in execution of the previous paragraphs.
More details in jira ticket https://issues.apache.org/jira/browse/ZEPPELIN-789

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-789

### How should this be tested?
* Build this PR
* Create a notebook and add three paragraphs in it
* Make sure the first paragraph results in error. Easy way is to have syntax error
* Add some print statement in second paragraph and set skipOnError to true for second paragraph
* Add some more print in third paragraph
* Execute the notebook. Second paragraph execution should be skipped.
* Now set skipOnError to false in second paragraph and execute the notebook. It should be executed as well.


### Screenshots (if appropriate)
![skiponerror](https://cloud.githubusercontent.com/assets/12737168/14239057/8d6e5298-fa55-11e5-88e0-26412f990851.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes

