### PR TITLE
Fix nginx config to use single port for websocket and REST.

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -53,7 +53,7 @@ This instruction based on Ubuntu 14.04 LTS but may work with other OS with few c
 
     ```
     upstream zeppelin {
-        server [YOUR-ZEPPELIN-SERVER-IP]:8090;
+        server [YOUR-ZEPPELIN-SERVER-IP]:8080;
     }
 
     # Zeppelin Website

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -56,10 +56,6 @@ This instruction based on Ubuntu 14.04 LTS but may work with other OS with few c
         server [YOUR-ZEPPELIN-SERVER-IP]:8090;
     }
 
-    upstream zeppelin-wss {
-        server [YOUR-ZEPPELIN-SERVER-IP]:8091;
-    }
-
     # Zeppelin Website
     server {
         listen [YOUR-ZEPPELIN-WEB-SERVER-PORT];
@@ -74,27 +70,18 @@ This instruction based on Ubuntu 14.04 LTS but may work with other OS with few c
         }
 
         location / {
+            proxy_pass http://zeppelin;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_set_header X-NginX-Proxy true;
-            proxy_pass http://zeppelin;
             proxy_redirect off;
             auth_basic "Restricted";
             auth_basic_user_file /etc/nginx/.htpasswd;
         }
-    }
 
-    # Zeppelin Websocket
-    server {
-        listen [YOUR-ZEPPELIN-WEBSOCKET-PORT] ssl;    # add ssl is optional, to serve HTTPS connection
-        server_name [YOUR-ZEPPELIN-SERVER-HOST];    # for example: zeppelin.mycompany.com
-
-        ssl_certificate [PATH-TO-YOUR-CERT-FILE];            # optional, to serve HTTPS connection
-        ssl_certificate_key [PATH-TO-YOUR-CERT-KEY-FILE];    # optional, to serve HTTPS connection
-
-        location / {
-            proxy_pass http://zeppelin-wss;
+        location /ws {
+            proxy_pass http://zeppelin;
             proxy_http_version 1.1;
             proxy_set_header Upgrade websocket;
             proxy_set_header Connection upgrade;


### PR DESCRIPTION
### What is this PR for?
Zeppelin uses single port number for REST and websocket since 0.5.5 so It should be fixed nginx config to use single port for websocket and RESTAPI.

### What type of PR is it?
Bug Fix | Documentation 

### Todos
* [x] - fix to use single port nubmer for websocket and REST.

### How should this be tested?
Try to set up the nginx config to use single port number for websocket and REST. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/3348133/14250636/4c6edf1e-faba-11e5-8d22-1f39e667e140.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no