### PR TITLE
Generate unique temporary files for Python and R Spark Interpreters.

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -91,7 +91,12 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
   public PySparkInterpreter(Properties property) {
     super(property);
 
-    scriptPath = System.getProperty("java.io.tmpdir") + "/zeppelin_pyspark.py";
+    try {
+      File scriptFile = File.createTempFile("zeppelin_pyspark-", ".py");
+      scriptPath = scriptFile.getAbsolutePath();
+    } catch (IOException e) {
+      throw new InterpreterException(e);
+    }
   }
 
   private void createPythonScript() {
@@ -235,6 +240,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
   @Override
   public void close() {
     executor.getWatchdog().destroyProcess();
+    new File(scriptPath).delete();
     gatewayServer.shutdown();
   }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
@@ -111,8 +111,12 @@ public class ZeppelinR implements ExecuteResultHandler {
     this.rCmdPath = rCmdPath;
     this.libPath = libPath;
     this.port = sparkRBackendPort;
-    scriptPath = System.getProperty("java.io.tmpdir") + "/zeppelin_sparkr.R";
-
+    try {
+      File scriptFile = File.createTempFile("zeppelin_sparkr-", ".R");
+      scriptPath = scriptFile.getAbsolutePath();
+    } catch (IOException e) {
+      throw new InterpreterException(e);
+    }
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
Generate unique temporary files for Python and R Spark interpreters using java.io.File.createTempFile.
Remove the temporary file for the Python interpreter when the interpreter is closed (is already being done in the R interpreter).
Without this fix it is not possible to run more than one Zeppelin interpreter on the same server due to file owner conflicts between instances.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
No Jira opened for this

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no