### PR TITLE
ZEPPELIN-797: Shiro authentication dialog does not appear

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.server;
 
 import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
-import org.apache.shiro.web.servlet.IniShiroFilter;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.dep.DependencyResolver;
@@ -235,12 +234,10 @@ public class ZeppelinServer extends Application {
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
 
+    cxfContext.setInitParameter("shiroConfigLocations", "file:" + conf.getConfDir() + "/shiro.ini");
+
     cxfContext.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
         EnumSet.allOf(DispatcherType.class));
-
-    FilterHolder authFilterHolder = new FilterHolder(IniShiroFilter.class);
-    authFilterHolder.setInitParameter("configPath", "file:" + conf.getConfDir() + "/shiro.ini");
-    cxfContext.addFilter(authFilterHolder, "/*", EnumSet.allOf(DispatcherType.class));
 
     cxfContext.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -234,7 +234,8 @@ public class ZeppelinServer extends Application {
     cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
 
-    cxfContext.setInitParameter("shiroConfigLocations", "file:" + conf.getConfDir() + "/shiro.ini");
+    cxfContext.setInitParameter("shiroConfigLocations",
+        new File(conf.getShiroPath()).toURI().toString());
 
     cxfContext.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
         EnumSet.allOf(DispatcherType.class));

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -350,6 +350,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getRelativeDir(String.format("%s/notebook-authorization.json", getConfDir()));
   }
 
+  public String getShiroPath() {
+    return getRelativeDir(String.format("%s/shiro.ini", getConfDir()));
+  }
+
   public String getInterpreterRemoteRunnerPath() {
     return getRelativeDir(ConfVars.ZEPPELIN_INTERPRETER_REMOTE_RUNNER);
   }


### PR DESCRIPTION
### What is this PR for?
Shiro authentication dialog does not appear
This is with reference with shiro authentication dialog not showing up on the mail thread.

https://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/201603.mbox/%3CCALf24sbx9tY-hSXR7zhGXuAirWujn20Sc9CoZnLBmeBt_NbhDw@mail.gmail.com%3E


### What type of PR is it?
Bug Fix

### Todos
* [x] - add ServletContextHandler filter for IniShiroFilter

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-797

### How should this be tested?
Run zeppelin-server from `zeppelin-distribution/target/zeppelin-0.6.0-incubating-SNAPSHOT/zeppelin-0.6.0-incubating-SNAPSHOT/` 
It should honour the `shiro.ini` located inside `zeppelin-distribution/target/zeppelin-0.6.0-incubating-SNAPSHOT/zeppelin-0.6.0-incubating-SNAPSHOT/conf/` 

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

