### PR TITLE
[MINOR] Set log4j.configuration into JAVA_OPTS and JAVA_INTP_OPTS explicitly

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -105,6 +105,7 @@ if [[ -z "$ZEPPELIN_MEM" ]]; then
 fi
 
 JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
+JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
 export JAVA_OPTS
 
 # jvm options for interpreter process
@@ -117,6 +118,7 @@ if [[ -z "${ZEPPELIN_INTP_MEM}" ]]; then
 fi
 
 JAVA_INTP_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
+JAVA_INTP_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
 export JAVA_INTP_OPTS
 
 


### PR DESCRIPTION
### What is this PR for?
Set log4j into JVM option for enforcing logging configuration.


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Set "-Dlog4j.configuration=..." into JVM option

### What is the Jira issue?
Minor issue

### How should this be tested?

1. Run spark with default log4j setting and check logs/zeppelin*.out. you can see logs from Spark.
1. Apply this patch.
1. Run spark with default log4j setting and check logs/zeppelin-interpreter*.log. you can see logs from Spark.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No