### PR TITLE
[ZEPPELIN-798] Migrate to Jetty version 9

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -242,6 +242,10 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+          <artifactId>websocket-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <cxf.version>2.7.7</cxf.version>
-    <jetty.version>8.1.14.v20131031</jetty.version>
+    <jetty.version>9.3.7.v20160115</jetty.version>
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
   </properties>
 
@@ -129,11 +129,16 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all-server</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
       <version>${jetty.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+<!--
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jsp</artifactId>
@@ -165,7 +170,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+-->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <cxf.version>2.7.7</cxf.version>
-    <jetty.version>9.3.7.v20160115</jetty.version>
+    <jetty.version>9.2.15.v20160210</jetty.version>
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
   </properties>
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -31,13 +31,10 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.socket.NotebookServer;
-import org.eclipse.jetty.server.AbstractConnector;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.server.ssl.SslSelectChannelConnector;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -47,7 +44,6 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
 import javax.servlet.DispatcherType;
 import javax.ws.rs.core.Application;
 import java.io.File;
@@ -58,7 +54,6 @@ import java.util.Set;
 
 /**
  * Main class of Zeppelin.
- *
  */
 public class ZeppelinServer extends Application {
   private static final Logger LOG = LoggerFactory.getLogger(ZeppelinServer.class);
@@ -91,24 +86,26 @@ public class ZeppelinServer extends Application {
   }
 
   public static void main(String[] args) throws InterruptedException {
+
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
     conf.setProperty("args", args);
 
-    // REST api
-    final ServletContextHandler restApiContext = setupRestApiContextHandler(conf);
+    jettyWebServer = setupJettyServer(conf);
 
-    // Notebook server
-    final ServletContextHandler notebookContext = setupNotebookServer(conf);
+    ContextHandlerCollection contexts = new ContextHandlerCollection();
+    jettyWebServer.setHandler(contexts);
 
     // Web UI
-    final WebAppContext webApp = setupWebAppContext(conf);
+    final WebAppContext webApp = setupWebAppContext(contexts, conf);
 
-    // add all handlers
-    ContextHandlerCollection contexts = new ContextHandlerCollection();
-    contexts.setHandlers(new Handler[]{restApiContext, notebookContext, webApp});
+    // REST api
+    setupRestApiContextHandler(webApp, conf);
 
-    jettyWebServer = setupJettyServer(conf);
-    jettyWebServer.setHandler(contexts);
+    // Notebook server
+    setupNotebookServer(webApp, conf);
+
+    //Below is commented since zeppelin-docs module is removed.
+    //final WebAppContext webAppSwagg = setupWebAppSwagger(conf);
 
     LOG.info("Starting zeppelin server");
     try {
@@ -150,27 +147,49 @@ public class ZeppelinServer extends Application {
   }
 
   private static Server setupJettyServer(ZeppelinConfiguration conf) {
-    AbstractConnector connector;
+
+    final Server server = new Server();
+    ServerConnector connector;
+
     if (conf.useSsl()) {
-      connector = new SslSelectChannelConnector(getSslContextFactory(conf));
+
+      HttpConfiguration http_config = new HttpConfiguration();
+      http_config.setSecureScheme("https");
+      http_config.setSecurePort(conf.getServerPort());
+      http_config.setOutputBufferSize(32768);
+
+      HttpConfiguration https_config = new HttpConfiguration(http_config);
+      SecureRequestCustomizer src = new SecureRequestCustomizer();
+      src.setStsMaxAge(2000);
+      src.setStsIncludeSubDomains(true);
+      https_config.addCustomizer(src);
+
+      connector = new ServerConnector(
+              server,
+              new SslConnectionFactory(getSslContextFactory(conf), HttpVersion.HTTP_1_1.asString()),
+              new HttpConnectionFactory(https_config));
+
+
     } else {
-      connector = new SelectChannelConnector();
+
+      connector = new ServerConnector(server);
+
     }
 
     // Set some timeout options to make debugging easier.
     int timeout = 1000 * 30;
-    connector.setMaxIdleTime(timeout);
+    connector.setIdleTimeout(timeout);
     connector.setSoLingerTime(-1);
     connector.setHost(conf.getServerAddress());
     connector.setPort(conf.getServerPort());
 
-    final Server server = new Server();
     server.addConnector(connector);
 
     return server;
   }
 
-  private static ServletContextHandler setupNotebookServer(ZeppelinConfiguration conf) {
+  private static void setupNotebookServer(WebAppContext webapp,
+                                                           ZeppelinConfiguration conf) {
     notebookWsServer = new NotebookServer();
     String maxTextMessageSize = conf.getWebsocketMaxTextMessageSize();
     final ServletHolder servletHolder = new ServletHolder(notebookWsServer);
@@ -179,28 +198,23 @@ public class ZeppelinServer extends Application {
     final ServletContextHandler cxfContext = new ServletContextHandler(
         ServletContextHandler.SESSIONS);
 
-    cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath(conf.getServerContextPath());
-    cxfContext.addServlet(servletHolder, "/ws/*");
-    cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
-        EnumSet.allOf(DispatcherType.class));
-    return cxfContext;
+    webapp.addServlet(servletHolder, "/ws/*");
+    webapp.addFilter(new FilterHolder(CorsFilter.class), "/*",
+            EnumSet.allOf(DispatcherType.class));
+
   }
 
-  @SuppressWarnings("deprecation")
   private static SslContextFactory getSslContextFactory(ZeppelinConfiguration conf) {
-    // Note that the API for the SslContextFactory is different for
-    // Jetty version 9
     SslContextFactory sslContextFactory = new SslContextFactory();
 
     // Set keystore
-    sslContextFactory.setKeyStore(conf.getKeyStorePath());
+    sslContextFactory.setKeyStorePath(conf.getKeyStorePath());
     sslContextFactory.setKeyStoreType(conf.getKeyStoreType());
     sslContextFactory.setKeyStorePassword(conf.getKeyStorePassword());
     sslContextFactory.setKeyManagerPassword(conf.getKeyManagerPassword());
 
     // Set truststore
-    sslContextFactory.setTrustStore(conf.getTrustStorePath());
+    sslContextFactory.setTrustStorePath(conf.getTrustStorePath());
     sslContextFactory.setTrustStoreType(conf.getTrustStoreType());
     sslContextFactory.setTrustStorePassword(conf.getTrustStorePassword());
 
@@ -209,43 +223,31 @@ public class ZeppelinServer extends Application {
     return sslContextFactory;
   }
 
-  @SuppressWarnings("unused") //TODO(bzz) why unused?
-  private static SSLContext getSslContext(ZeppelinConfiguration conf)
-      throws Exception {
+  private static void setupRestApiContextHandler(WebAppContext webapp,
+                                                 ZeppelinConfiguration conf) {
 
-    SslContextFactory scf = getSslContextFactory(conf);
-    if (!scf.isStarted()) {
-      scf.start();
-    }
-    return scf.getSslContext();
-  }
-
-  private static ServletContextHandler setupRestApiContextHandler(ZeppelinConfiguration conf) {
     final ServletHolder cxfServletHolder = new ServletHolder(new CXFNonSpringJaxrsServlet());
     cxfServletHolder.setInitParameter("javax.ws.rs.Application", ZeppelinServer.class.getName());
     cxfServletHolder.setName("rest");
     cxfServletHolder.setForcedPath("rest");
 
-    final ServletContextHandler cxfContext = new ServletContextHandler();
-    cxfContext.setSessionHandler(new SessionHandler());
-    cxfContext.setContextPath(conf.getServerContextPath());
-    cxfContext.addServlet(cxfServletHolder, "/api/*");
+    webapp.setSessionHandler(new SessionHandler());
+    webapp.addServlet(cxfServletHolder, "/api/*");
 
-    cxfContext.addFilter(new FilterHolder(CorsFilter.class), "/*",
+    webapp.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
 
-    cxfContext.setInitParameter("shiroConfigLocations",
+    webapp.setInitParameter("shiroConfigLocations",
         new File(conf.getShiroPath()).toURI().toString());
 
-    cxfContext.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
+    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
         EnumSet.allOf(DispatcherType.class));
 
-    cxfContext.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());
+    webapp.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());
 
-    return cxfContext;
   }
 
-  private static WebAppContext setupWebAppContext(
+  private static WebAppContext setupWebAppContext(ContextHandlerCollection contexts,
       ZeppelinConfiguration conf) {
 
     WebAppContext webApp = new WebAppContext();
@@ -266,7 +268,10 @@ public class ZeppelinServer extends Application {
     }
     // Explicit bind to root
     webApp.addServlet(new ServletHolder(new DefaultServlet()), "/*");
+    contexts.addHandler(webApp);
+
     return webApp;
+
   }
 
   @Override

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -153,22 +153,22 @@ public class ZeppelinServer extends Application {
 
     if (conf.useSsl()) {
 
-      HttpConfiguration http_config = new HttpConfiguration();
-      http_config.setSecureScheme("https");
-      http_config.setSecurePort(conf.getServerPort());
-      http_config.setOutputBufferSize(32768);
+      HttpConfiguration httpConfig = new HttpConfiguration();
+      httpConfig.setSecureScheme("https");
+      httpConfig.setSecurePort(conf.getServerPort());
+      httpConfig.setOutputBufferSize(32768);
 
-      HttpConfiguration https_config = new HttpConfiguration(http_config);
+      HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
       SecureRequestCustomizer src = new SecureRequestCustomizer();
       // Only with Jetty 9.3.x
 //      src.setStsMaxAge(2000);
 //      src.setStsIncludeSubDomains(true);
-      https_config.addCustomizer(src);
+      httpsConfig.addCustomizer(src);
 
       connector = new ServerConnector(
               server,
               new SslConnectionFactory(getSslContextFactory(conf), HttpVersion.HTTP_1_1.asString()),
-              new HttpConnectionFactory(https_config));
+              new HttpConnectionFactory(httpsConfig));
 
 
     } else {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -160,8 +160,9 @@ public class ZeppelinServer extends Application {
 
       HttpConfiguration https_config = new HttpConfiguration(http_config);
       SecureRequestCustomizer src = new SecureRequestCustomizer();
-      src.setStsMaxAge(2000);
-      src.setStsIncludeSubDomains(true);
+      // Only with Jetty 9.3.x
+//      src.setStsMaxAge(2000);
+//      src.setStsIncludeSubDomains(true);
       https_config.addCustomizer(src);
 
       connector = new ServerConnector(

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.zeppelin.socket;
 
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -48,15 +47,14 @@ import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.socket.Message.OP;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.utils.SecurityUtils;
-import org.eclipse.jetty.websocket.WebSocket;
-import org.eclipse.jetty.websocket.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Zeppelin websocket service.
- *
  */
 public class NotebookServer extends WebSocketServlet implements
         NotebookSocketListener, JobListenerFactory, AngularObjectRegistryListener,
@@ -71,6 +69,10 @@ public class NotebookServer extends WebSocketServlet implements
   }
 
   @Override
+  public void configure(WebSocketServletFactory factory) {
+    factory.setCreator(new NotebookWebSocketCreator(this));
+  }
+
   public boolean checkOrigin(HttpServletRequest request, String origin) {
     try {
       return SecurityUtils.isValidOrigin(origin, ZeppelinConfiguration.create());
@@ -82,8 +84,7 @@ public class NotebookServer extends WebSocketServlet implements
     return false;
   }
 
-  @Override
-  public WebSocket doWebSocketConnect(HttpServletRequest req, String protocol) {
+  public NotebookSocket doWebSocketConnect(HttpServletRequest req, String protocol) {
     return new NotebookSocket(req, protocol, this);
   }
 
@@ -448,7 +449,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
 
-  private void updateNote(WebSocket conn, HashSet<String> userAndRoles,
+  private void updateNote(NotebookSocket conn, HashSet<String> userAndRoles,
                           Notebook notebook, Message fromMessage)
       throws SchedulerException, IOException {
     String noteId = (String) fromMessage.get("id");

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -20,18 +20,18 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 
 /**
  * Notebook websocket
  */
-public class NotebookSocket implements WebSocket.OnTextMessage{
+public class NotebookSocket extends WebSocketAdapter {
 
-  private Connection connection;
+  private Session connection;
   private NotebookSocketListener listener;
   private HttpServletRequest request;
   private String protocol;
-
 
   public NotebookSocket(HttpServletRequest req, String protocol,
       NotebookSocketListener listener) {
@@ -41,22 +41,22 @@ public class NotebookSocket implements WebSocket.OnTextMessage{
   }
 
   @Override
-  public void onClose(int closeCode, String message) {
+  public void onWebSocketClose(int closeCode, String message) {
     listener.onClose(this, closeCode, message);
   }
 
   @Override
-  public void onOpen(Connection connection) {
+  public void onWebSocketConnect(Session connection) {
     this.connection = connection;
     listener.onOpen(this);
   }
 
   @Override
-  public void onMessage(String message) {
+  public void onWebSocketText(String message) {
     listener.onMessage(this, message);
   }
-  
-  
+
+
   public HttpServletRequest getRequest() {
     return request;
   }
@@ -66,8 +66,7 @@ public class NotebookSocket implements WebSocket.OnTextMessage{
   }
 
   public void send(String serializeMessage) throws IOException {
-    connection.sendMessage(serializeMessage);
+    connection.getRemote().sendString(serializeMessage);
   }
 
-  
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
@@ -16,11 +16,18 @@
  */
 package org.apache.zeppelin.socket;
 
-/**
- * NoteboookSocket listener
- */
-public interface NotebookSocketListener {
-  void onClose(NotebookSocket socket, int code, String message);
-  void onOpen(NotebookSocket socket);
-  void onMessage(NotebookSocket socket, String message);
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+
+public class NotebookWebSocketCreator implements WebSocketCreator {
+  private NotebookServer notebookServer;
+
+  public NotebookWebSocketCreator(NotebookServer notebookServer) {
+    this.notebookServer = notebookServer;
+  }
+  public Object createWebSocket(ServletUpgradeRequest request, ServletUpgradeResponse response) {
+    return new NotebookSocket(request.getHttpServletRequest(), "", notebookServer);
+  }
+
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
@@ -20,6 +20,9 @@ import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 
+/**
+ * Responsible to create the WebSockets for the NotebookServer.
+ */
 public class NotebookWebSocketCreator implements WebSocketCreator {
   private NotebookServer notebookServer;
 


### PR DESCRIPTION
### What is this PR for?
Upgrade from Jetty 8 to Jetty 9 mainly for deadlock bug fix https://bugs.eclipse.org/bugs/show_bug.cgi?id=389645

Jetty 9 has changed the maven names and context building (for web and websocket).

### What type of PR is it?
[Bug Fix]

### Todos
* [x ] - Adapt the unit tests

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-798

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

