### PR TITLE
[ZEPPELIN-741] Re-use existing paragraphId on note import

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -103,11 +103,16 @@ public abstract class Job {
     this(jobName, listener, JobProgressPoller.DEFAULT_INTERVAL_MSEC);
   }
 
+  public Job(String jobId, String jobName, JobListener listener) {
+    this(jobId, jobName, listener, JobProgressPoller.DEFAULT_INTERVAL_MSEC);
+  }
+
   public Job(String jobId, String jobName, JobListener listener, long progressUpdateIntervalMs) {
     this.jobName = jobName;
     this.listener = listener;
     this.progressUpdateIntervalMs = progressUpdateIntervalMs;
 
+    dateCreated = new Date();
     id = jobId;
 
     setStatus(Status.READY);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -167,7 +167,9 @@ public class Note implements Serializable, JobListener {
    * @param srcParagraph
    */
   public void addCloneParagraph(Paragraph srcParagraph) {
-    Paragraph newParagraph = new Paragraph(this, this, replLoader);
+
+    // Keep paragraph original ID
+    final Paragraph newParagraph = new Paragraph(srcParagraph.getId(), this, this, replLoader);
 
     Map<String, Object> config = new HashMap<>(srcParagraph.getConfig());
     Map<String, Object> param = new HashMap<>(srcParagraph.settings.getParams());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -62,6 +62,19 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     settings = new GUI();
   }
 
+  public Paragraph(String paragraphId, Note note, JobListener listener,
+                   NoteInterpreterLoader replLoader) {
+    super(paragraphId, generateId(), listener);
+    this.note = note;
+    this.replLoader = replLoader;
+    title = null;
+    text = null;
+    authenticationInfo = null;
+    dateUpdated = null;
+    settings = new GUI();
+    config = new HashMap<String, Object>();
+  }
+
   public Paragraph(Note note, JobListener listener, NoteInterpreterLoader replLoader) {
     super(generateId(), listener);
     this.note = note;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -322,7 +322,9 @@ public class NotebookTest implements JobListenerFactory{
     Note cloneNote = notebook.cloneNote(note.getId(), "clone note");
     Paragraph cp = cloneNote.paragraphs.get(0);
     assertEquals(cp.getStatus(), Status.READY);
-    assertNotEquals(cp.getId(), p.getId());
+
+    // Keep same ParagraphID
+    assertEquals(cp.getId(), p.getId());
     assertEquals(cp.text, p.text);
     assertEquals(cp.getResult().message(), p.getResult().message());
   }


### PR DESCRIPTION
### What is this PR for?
Upon note.json import, do not generate a new paragraphId but re-use the existing one. 

This is important because the `z.angularBind()/z.angularUnbind()/z.runParagraph()` functions are pointing to static paragraphId


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Code Review
* [ ] - Test

### What is the Jira issue?
**[ZEPPELIN-741]**

### How should this be tested?
1. Create a paragraph with the following content:

```
%md
## The paragraph id is &nbsp; &nbsp; &nbsp; &nbsp; **PUT_HERE_CURRENT_PARAGRAPH_ID**
## The new paragraph id is **${New_Paragraph_Id}**
```

2. Retrieve the current paragraph id and replace the text **PUT_HERE_CURRENT_PARAGRAPH_ID** then re-execute the paragraph
3. Export the paragraph as JSON
4. Delete it
5. Re-import it
6. Retrieve the paragraph id again and put it in the input text form and then execute the paragraph
7. Normally both paragraph ids should be the same
8. Now clone the current note
9. In the new note, retrieve the paragraph id again and put it in the input text form and then execute the paragraph
10. Normally both paragraph ids now are different

### Screenshots (if appropriate)
![static_paragraph_id](https://cloud.githubusercontent.com/assets/1532977/14474821/332e64d4-00ff-11e6-9441-787bb09d73d1.gif)

### Questions:
* Does the licenses files need update?  --> **No**
* Is there breaking changes for older versions? --> **No**
* Does this needs documentation? --> **Yes**

[ZEPPELIN-741]: https://issues.apache.org/jira/browse/ZEPPELIN-741