### PR TITLE
[ZEPPELIN-705]Search should  aware notebook permission

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -644,7 +644,7 @@ public class NotebookRestApi {
   }  
 
   /**
-   * Search for a Notes
+   * Search for a Notes with permissions
    */
   @GET
   @Path("search")
@@ -656,8 +656,7 @@ public class NotebookRestApi {
     userAndRoles.add(principal);
     userAndRoles.addAll(roles);
     List<Map<String, String>> notebooksFound = notebookIndex.query(queryTerm);
-    for (int i = 0; i < notebooksFound.size(); i++)
-    {
+    for (int i = 0; i < notebooksFound.size(); i++) {
       String[] Id = notebooksFound.get(i).get("id").split("/", 2);
       String noteId = Id[0];
       if (!notebookAuthorization.isOwner(noteId, userAndRoles) &&
@@ -666,7 +665,6 @@ public class NotebookRestApi {
         notebooksFound.remove(i);
         i--;
       }
-      LOG.info("noteId", noteId);
     }
     LOG.info("{} notebooks found", notebooksFound.size());
     return new JsonResponse<>(Status.OK, notebooksFound).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -650,8 +650,25 @@ public class NotebookRestApi {
   @Path("search")
   public Response search(@QueryParam("q") String queryTerm) {
     LOG.info("Searching notebooks for: {}", queryTerm);
+    String principal = SecurityUtils.getPrincipal();
+    HashSet<String> roles = SecurityUtils.getRoles();
+    HashSet<String> userAndRoles = new HashSet<String>();
+    userAndRoles.add(principal);
+    userAndRoles.addAll(roles);
     List<Map<String, String>> notebooksFound = notebookIndex.query(queryTerm);
-    LOG.info("{} notbooks found", notebooksFound.size());
+    for (int i = 0; i < notebooksFound.size(); i++)
+    {
+      String[] Id = notebooksFound.get(i).get("id").split("/", 2);
+      String noteId = Id[0];
+      if (!notebookAuthorization.isOwner(noteId, userAndRoles) &&
+              !notebookAuthorization.isReader(noteId, userAndRoles) &&
+              !notebookAuthorization.isWriter(noteId, userAndRoles)) {
+        notebooksFound.remove(i);
+        i--;
+      }
+      LOG.info("noteId", noteId);
+    }
+    LOG.info("{} notebooks found", notebooksFound.size());
     return new JsonResponse<>(Status.OK, notebooksFound).build();
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -746,7 +746,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
         new TypeToken<Map<String, Object>>() {
         }.getType());
     searchBody = (ArrayList) res.get("body");
-
+    assertEquals("At-least two search results are there", true ,searchBody.size()>=2);
     for (int i = 0; i < searchBody.size(); i++) {
       Map<String, String> searchResult = (Map<String, String>) searchBody.get(i);
       String userId = searchResult.get("id").split("/", 2)[0];


### PR DESCRIPTION
### What is this PR for?
Make search aware of notebook permissions and allow only those search results for which user has read permission. 


### What type of PR is it?
Bug Fix

### Todos
NA

### What is the Jira issue?
[ZEPPELIN-705]( https://issues.apache.org/jira/browse/ZEPPELIN-705?jql=project%20%3D%20ZEPPELIN%20AND%20status%20in%20(Open%2C%20Resolved)%20AND%20resolution%20%3D%20Unresolved%20AND%20fixVersion%20%3D%200.6.0%20ORDER%20BY%20due%20ASC%2C%20priority%20DESC%2C%20created%20ASC)

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?No
* Is there breaking changes for older versions?No
* Does this needs documentation?No

