### PR TITLE
[ZEPPELIN-820] Reduce websocket communication by unicasting instead of broadcasting note list 

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -489,6 +489,7 @@ public class NotebookServer extends WebSocketServlet implements
 
       note.persist();
       broadcastNote(note);
+      broadcastNoteList();
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -426,7 +426,6 @@ public class NotebookServer extends WebSocketServlet implements
     if (note != null) {
       if (!notebookAuthorization.isReader(noteId, userAndRoles)) {
         permissionError(conn, "read", userAndRoles, notebookAuthorization.getReaders(noteId));
-        broadcastNoteList();
         return;
       }
       addConnectionToNote(note.id(), conn);
@@ -448,7 +447,6 @@ public class NotebookServer extends WebSocketServlet implements
       NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
       if (!notebookAuthorization.isReader(noteId, userAndRoles)) {
         permissionError(conn, "read", userAndRoles, notebookAuthorization.getReaders(noteId));
-        broadcastNoteList();
         return;
       }
       addConnectionToNote(note.id(), conn);
@@ -491,7 +489,6 @@ public class NotebookServer extends WebSocketServlet implements
 
       note.persist();
       broadcastNote(note);
-      broadcastNoteList();
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Reducing websocket communication by unicasting instead of broadcasting notes list reduces probability of deadlock in jetty8 and also improves response time.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-820] (https://issues.apache.org/jira/browse/ZEPPELIN-820)

### How should this be tested?
1. Open two browser windows.
2. Check if note list shows up on home page.
3. Check if creating, removing note in one window results in updates to notes list in other windows.

### Screenshots (if appropriate)

### Questions:
