### PR TITLE
[ZEPPELIN-799] Modify `index.html` and `karma.conf.js` for `mode-python`

### DIFF
--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -105,6 +105,7 @@ limitations under the License.
     <script src="bower_components/angular-websocket/angular-websocket.min.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/ace.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-scala.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/mode-python.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-sql.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-markdown.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-sh.js"></script>

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -34,6 +34,7 @@ module.exports = function(config) {
       'bower_components/angular-websocket/angular-websocket.min.js',
       'bower_components/ace-builds/src-noconflict/ace.js',
       'bower_components/ace-builds/src-noconflict/mode-scala.js',
+      'bower_components/ace-builds/src-noconflict/mode-python.js',
       'bower_components/ace-builds/src-noconflict/mode-sql.js',
       'bower_components/ace-builds/src-noconflict/mode-markdown.js',
       'bower_components/ace-builds/src-noconflict/mode-sh.js',


### PR DESCRIPTION
### What is this PR for?

Python edit mode was added in #825 thank to @astroshim.

I think we'll need to update the `src/index.html` and `test/karma.conf.js` under `zeppelin-web` accordingly to avoid unstaged changes after building.

### What type of PR is it?
Improvement

### Todos
None

### What is the Jira issue?
Probably a subtask of 
https://issues.apache.org/jira/browse/ZEPPELIN-799

### How should this be tested?
Shouldn't be any since #825 is merged into `master` and has been tested.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? *no*
* Is there breaking changes for older versions? *no*
* Does this needs documentation? *no*

/cc @astroshim 