### PR TITLE
[ZEPPELIN-823] Remove usage of Scala 2.10 depecrated APIs

### DIFF
--- a/cassandra/src/test/java/org/apache/zeppelin/cassandra/InterpreterLogicTest.java
+++ b/cassandra/src/test/java/org/apache/zeppelin/cassandra/InterpreterLogicTest.java
@@ -302,10 +302,10 @@ public class InterpreterLogicTest {
     }
 
     private <A> scala.collection.immutable.List<A> toScalaList(java.util.List<A> list)  {
-        return scala.collection.JavaConversions.asScalaIterable(list).toList();
+        return scala.collection.JavaConversions.collectionAsScalaIterable(list).toList();
     }
 
     private  <A> java.util.List<A> toJavaList(scala.collection.immutable.List<A> list){
-        return scala.collection.JavaConversions.asJavaList(list);
+        return scala.collection.JavaConversions.seqAsJavaList(list);
     }
 }

--- a/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
@@ -262,7 +262,7 @@ public class DepInterpreter extends Interpreter {
   public List<String> completion(String buf, int cursor) {
     ScalaCompleter c = completor.completer();
     Candidates ret = c.complete(buf, cursor);
-    return scala.collection.JavaConversions.asJavaList(ret.candidates());
+    return scala.collection.JavaConversions.seqAsJavaList(ret.candidates());
   }
 
   private List<File> currentClassPath() {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -672,7 +672,7 @@ public class SparkInterpreter extends Interpreter {
     }
     ScalaCompleter c = completor.completer();
     Candidates ret = c.complete(completionText, cursor);
-    return scala.collection.JavaConversions.asJavaList(ret.candidates());
+    return scala.collection.JavaConversions.seqAsJavaList(ret.candidates());
   }
 
   private String getCompletionTargetString(String text, int cursor) {
@@ -901,14 +901,14 @@ public class SparkInterpreter extends Interpreter {
 
     Object completedTaskInfo = null;
 
-    completedTaskInfo = JavaConversions.asJavaMap(
+    completedTaskInfo = JavaConversions.mapAsJavaMap(
         (HashMap<Object, Object>) sparkListener.getClass()
             .getMethod("stageIdToTasksComplete").invoke(sparkListener)).get(id);
 
     if (completedTaskInfo != null) {
       completedTasks += (int) completedTaskInfo;
     }
-    List<Object> parents = JavaConversions.asJavaList((Seq<Object>) stage.getClass()
+    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>) stage.getClass()
         .getMethod("parents").invoke(stage));
     if (parents != null) {
       for (Object s : parents) {
@@ -937,7 +937,7 @@ public class SparkInterpreter extends Interpreter {
 
       Method numCompletedTasks = stageUIDataClass.getMethod("numCompleteTasks");
       Set<Tuple2<Object, Object>> keys =
-          JavaConverters.asJavaSetConverter(stageIdData.keySet()).asJava();
+          JavaConverters.setAsJavaSetConverter(stageIdData.keySet()).asJava();
       for (Tuple2<Object, Object> k : keys) {
         if (id == (int) k._1()) {
           Object uiData = stageIdData.get(k).get();
@@ -948,7 +948,7 @@ public class SparkInterpreter extends Interpreter {
       logger.error("Error on getting progress information", e);
     }
 
-    List<Object> parents = JavaConversions.asJavaList((Seq<Object>) stage.getClass()
+    List<Object> parents = JavaConversions.seqAsJavaList((Seq<Object>) stage.getClass()
         .getMethod("parents").invoke(stage));
     if (parents != null) {
       for (Object s : parents) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -19,7 +19,7 @@ package org.apache.zeppelin.spark;
 
 import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asJavaIterable;
-import static scala.collection.JavaConversions.asScalaIterable;
+import static scala.collection.JavaConversions.collectionAsScalaIterable;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -95,13 +95,13 @@ public class ZeppelinContext {
     for (Tuple2<Object, String> option : asJavaIterable(options)) {
       allChecked.add(option._1());
     }
-    return checkbox(name, asScalaIterable(allChecked), options);
+    return checkbox(name, collectionAsScalaIterable(allChecked), options);
   }
 
   public scala.collection.Iterable<Object> checkbox(String name,
       scala.collection.Iterable<Object> defaultChecked,
       scala.collection.Iterable<Tuple2<Object, String>> options) {
-    return asScalaIterable(gui.checkbox(name, asJavaCollection(defaultChecked),
+    return collectionAsScalaIterable(gui.checkbox(name, asJavaCollection(defaultChecked),
       tuplesToParamOptions(options)));
   }
 


### PR DESCRIPTION
### What is this PR for?
Remove usage of Scala 2.10 depecrated APIs as a few of these deprecated APIs have been removed in Scala 2..11. This change is an incremental step on enabling Scala 2.11 builds.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-823](https://issues.apache.org/jira/browse/ZEPPELIN-823)