### PR TITLE
ZEPPELIN-824 - Make CI Crash when there is jshint errors

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -434,7 +434,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('build', [
-    'newer:jshint',
+    'jshint:all',
     'clean:dist',
     'wiredep',
     'useminPrepare',

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -124,7 +124,6 @@
             </goals>
             <configuration>
               <arguments>build</arguments>
-              <arguments>--force</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
### What is this PR for?
This PR has for goal to fix the CI build regarding the front-end.
The CI is currently not failing due to jshint, even though it fails locally with a `grunt build`
There was two issues making this behaviour:
* Jshint was called only on newer files in build
* Mvn is using --force on grunt


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-824

### How should this be tested?
Make a jshint error (!= instead of !== for example)
then run `mvn package` inside the zeppelin-web forlder


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

