### PR TITLE
add /r/lib/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ zeppelin-web/bower_components
 **nbproject/
 **node/
 
+#R
+/r/lib/
 
 # project level
 /logs/


### PR DESCRIPTION
### What is this PR for?
after compiling/building Zeppelin project with default/R `mvn $BUILD_FLAG $PROFILE -B`, this directory `/r/lib/` gets created.

### What type of PR is it?
Improvement

### Todos
* [x] - add /r/lib/ in .gitignore

### What is the Jira issue?
N/A

### How should this be tested?
Compile/build Zeppelin project with R/default options `mvn $BUILD_FLAG $PROFILE -B`, then do a git status. This directory `/r/lib/` should not show up.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

