### PR TITLE
Prevent duplicated response header insertion

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -73,6 +73,10 @@ public class CorsFilter implements Filter {
   }
 
   private void addCorsHeaders(HttpServletResponse response, String origin) {
+    if ("true".equals(response.getHeader("Access-Control-Allow-Credentials"))) {
+      // addCorsHeaders invoked multiple times. Ignore
+      return;
+    }
     response.addHeader("Access-Control-Allow-Origin", origin);
     response.addHeader("Access-Control-Allow-Credentials", "true");
     response.addHeader("Access-Control-Allow-Headers", "authorization,Content-Type");


### PR DESCRIPTION
### What is this PR for?
Headers are inserted twice in http response message after https://github.com/apache/incubator-zeppelin/pull/831.

it prevents zeppelin-web development mode working (cd zeppelin-web; grunt serve)

![image](https://cloud.githubusercontent.com/assets/1540981/14892895/e7ed9e7a-0d21-11e6-9ff3-f352d18ca721.png)

This PR provides (dirty) fix for the problem. If anyone knows better way to prevent duplicated header insertion, please let me know.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Prevent duplicated header insertion

### What is the Jira issue?

### How should this be tested?
Check if dev mode works. ie. 'cd zeppelin-web; grunt serve', browse http://localhost:9000

or

run `curl -vv http://localhost:8080/api/security/ticket` and see if there're duplicated headers

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
