### PR TITLE
[ZEPPELIN-779] Dynamic form doesn't work with python3

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -83,14 +83,14 @@ class PyZeppelinContext(dict):
 
   def select(self, name, options, defaultValue = ""):
     # auto_convert to ArrayList doesn't match the method signature on JVM side
-    tuples = map(lambda items: self.__tupleToScalaTuple2(items), options)
+    tuples = list(map(lambda items: self.__tupleToScalaTuple2(items), options))
     iterables = gateway.jvm.scala.collection.JavaConversions.collectionAsScalaIterable(tuples)
     return self.z.select(name, defaultValue, iterables)
 
   def checkbox(self, name, options, defaultChecked = None):
     if defaultChecked is None:
-      defaultChecked = map(lambda items: items[0], options)
-    optionTuples = map(lambda items: self.__tupleToScalaTuple2(items), options)
+      defaultChecked = list(map(lambda items: items[0], options))
+    optionTuples = list(map(lambda items: self.__tupleToScalaTuple2(items), options))
     optionIterables = gateway.jvm.scala.collection.JavaConversions.collectionAsScalaIterable(optionTuples)
     defaultCheckedIterables = gateway.jvm.scala.collection.JavaConversions.collectionAsScalaIterable(defaultChecked)
 


### PR DESCRIPTION
### What is this PR for?

When pyspark interpreter configured to use python3, dynamic form doesn't work.
https://issues.apache.org/jira/browse/ZEPPELIN-779


### What type of PR is it?
Bug Fix

### Todos
* [x] - Convert map to list

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-779

### How should this be tested?
configure pyspark interpreter to use python3 and run
```
%pyspark
print("Hello "+z.select("day", [("1","mon"),
                                ("2","tue"),
                                ("3","wed"),
                                ("4","thurs"),
                                ("5","fri"),
                                ("6","sat"),
                                ("7","sun")]))
```


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

