### PR TITLE
[ZEPPELIN-834]Handle Note-name with spaces

### DIFF
--- a/docs/manual/notebookashomepage.md
+++ b/docs/manual/notebookashomepage.md
@@ -88,7 +88,7 @@ you need to do is use our %angular support.
           <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
           <ul style="list-style-type: none;">
             <li ng-repeat="note in home.notes.list track by $index"><i style="font-size: 10px;" class="icon-doc"></i>
-              <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{note.name || 'Note ' + note.id}}</a>
+              <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{note.name.trim()==='' && 'Note ' + note.id || note.name}}</a>
             </li>
           </ul>
       </div>

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -76,8 +76,8 @@ angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, noteboo
     node.hidden = !node.hidden;
   };
 
-  $rootScope.noteName = function (note) {
-    return (note.name.trim()==='' && 'Note ' + note.id || note.name);
+  $rootScope.noteName = function(note) {
+    return arrayOrderingSrv.getNoteName(note);
   };
 
 });

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -43,7 +43,7 @@ limitations under the License.
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
               <li ng-repeat="note in home.notes.list | filter:query | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">
                 <i style="font-size: 10px;" class="icon-doc"></i>
-                <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{note.name || 'Note ' + note.id}}</a>
+                <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{note.name.trim()==='' && 'Note ' + note.id || note.name}}</a>
               </li>
             </ul>
           </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -64,7 +64,7 @@ limitations under the License.
                 <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
               </li>
               <div ng-if="!query || query.name === ''">
-                <li ng-repeat="node in home.notes.root.children" ng-include="'notebook_folder_renderer.html'" />
+                <li ng-repeat="node in home.notes.root.children | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index" ng-include="'notebook_folder_renderer.html'" />
               </div>
               <div ng-if="query && query.name !== ''">
                 <li ng-repeat="note in home.notes.flatList | filter:query | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -13,9 +13,9 @@ limitations under the License.
 -->
 <div class="noteAction" ng-show="note.id && !paragraphUrl">
   <h3>
-    <input type="text" pu-elastic-input class="form-control2" placeholder="{{note.name || 'Note ' + note.id}}" style="min-width: 200px; max-width: 600px;"
+    <input type="text" pu-elastic-input class="form-control2" placeholder="{{note.name.trim()==='' && 'Note ' + note.id || note.name}}" style="min-width: 200px; max-width: 600px;"
            ng-show="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" />
-    <p class="form-control-static2" ng-click="showEditor = true; oldName = note.name" ng-show="!showEditor">{{note.name || 'Note ' + note.id}}</p>
+    <p class="form-control-static2" ng-click="showEditor = true; oldName = note.name" ng-show="!showEditor">{{note.name.trim()==='' && 'Note ' + note.id || note.name}}</p>
     <span class="labelBtn btn-group">
       <button type="button"
               class="btn btn-default btn-xs"

--- a/zeppelin-web/src/app/search/result-list.html
+++ b/zeppelin-web/src/app/search/result-list.html
@@ -21,7 +21,7 @@ limitations under the License.
               <i style="font-size: 10px;" class="icon-doc"></i>
               <a class="search-results-header"
                  href="#/notebook/{{note.id}}">
-                  {{note.name || 'Note ' + note.id}}
+                  {{note.name.trim()==='' && 'Note ' + note.id.split('/',2)[0] || note.name}}
               </a>
             </h4>
           </div>

--- a/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
+++ b/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
@@ -15,8 +15,18 @@
 
 angular.module('zeppelinWebApp').service('arrayOrderingSrv', function() {
 
+  var arrayOrderingSrv = this;
+
   this.notebookListOrdering = function(note) {
-    return (note.name ? note.name : 'Note ' + note.id);
+    return arrayOrderingSrv.getNoteName(note);
+  };
+
+  this.getNoteName = function(note) {
+    if(note.name === undefined || note.name.trim() === '') {
+      return'Note ' + note.id;
+    } else {
+      return note.name;
+    }
   };
 
 });

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -35,7 +35,7 @@ limitations under the License.
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
               <li ng-repeat="note in navbar.notes.list | filter:query | orderBy:navbar.arrayOrderingSrv.notebookListOrdering track by $index"
                   ng-class="{'active' : navbar.isActive(note.id)}">
-                <a href="#/notebook/{{note.id}}">{{note.name || 'Note ' + note.id}} </a>
+                <a href="#/notebook/{{note.id}}">{{note.name.trim()==='' && 'Note ' + note.id || note.name}} </a>
               </li>
             </div>
           </ul>


### PR DESCRIPTION
### What is this PR for?
Handle notename to have only white spaces. 

### What type of PR is it?
[Bug Fix ]

### Todos


### What is the Jira issue?
[ZEPPELIN-834] (https://issues.apache.org/jira/browse/ZEPPELIN-834)

### How should this be tested?
Create note with name having only white spaces.
you should be able to see note id for those note.

### Screenshots (if appropriate)
Before:
![screen shot 2016-04-29 at 10 40 27 am](https://cloud.githubusercontent.com/assets/7026661/14908845/3129c82e-0dfa-11e6-8732-53623974e10f.png)
![screen shot 2016-04-29 at 10 37 56 am](https://cloud.githubusercontent.com/assets/7026661/14908849/3762f13e-0dfa-11e6-9b72-b0c0b032b06d.png)
![screen shot 2016-04-29 at 10 36 23 am](https://cloud.githubusercontent.com/assets/7026661/14908851/3cc8a5e2-0dfa-11e6-8bc9-051da61cf806.png)
 After:
![screen shot 2016-04-29 at 10 40 17 am](https://cloud.githubusercontent.com/assets/7026661/14908854/47e7f3ec-0dfa-11e6-8c02-7979dc04cabb.png)
![screen shot 2016-04-29 at 10 39 57 am](https://cloud.githubusercontent.com/assets/7026661/14908856/4a23675e-0dfa-11e6-9d5b-7dca6faf0998.png)
![screen shot 2016-04-29 at 10 38 16 am](https://cloud.githubusercontent.com/assets/7026661/14908858/4d06a8d2-0dfa-11e6-9b62-63bbe7bdf1e7.png)

### Questions:
* Does the licenses files need update?NO
* Is there breaking changes for older versions?NO
* Does this needs documentation?NO

