### PR TITLE
[HOTFIX] Authentication doesn't work after upgrade to jetty9

### DIFF
--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -37,4 +37,4 @@ shiro.loginUrl = /api/login
 # To enfore security, comment the line below and uncomment the next one
 /api/version = anon
 /** = anon
-#/** = authc
+#/** = authcBasic

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -238,7 +238,7 @@ public class ZeppelinServer extends Application {
     webapp.setInitParameter("shiroConfigLocations",
         new File(conf.getShiroPath()).toURI().toString());
 
-    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/api/*",
+    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
         EnumSet.allOf(DispatcherType.class));
 
     webapp.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -238,7 +238,7 @@ public class ZeppelinServer extends Application {
     webapp.setInitParameter("shiroConfigLocations",
         new File(conf.getShiroPath()).toURI().toString());
 
-    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
+    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/api/*",
         EnumSet.allOf(DispatcherType.class));
 
     webapp.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());


### PR DESCRIPTION
### What is this PR for?
After the jetty9 upgrade https://github.com/apache/incubator-zeppelin/pull/831, authentication seems doesn't work. This PR fixes problem by applying shiro filter only /api/*


### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix

### What is the Jira issue?

### How should this be tested?
enable authentication (edit conf/shiro.ini) and try login

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

