### PR TITLE
CI: debug flaky webapp build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,17 @@ before_script:
 script:
   - mvn $TEST_FLAG $PROFILE -B $TEST_PROJECTS
 
+
+after_success:
+  - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
+
 after_failure:
+  - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
   - cat target/rat.txt
   - cat zeppelin-server/target/rat.txt
   - cat zeppelin-distribution/target/zeppelin-*-SNAPSHOT/zeppelin-*-SNAPSHOT/logs/zeppelin*.log
   - cat zeppelin-distribution/target/zeppelin-*-SNAPSHOT/zeppelin-*-SNAPSHOT/logs/zeppelin*.out
+  - cat zeppelin-web/npm-debug.log
 
 after_script:
   - ./testing/stopSparkCluster.sh $SPARK_VER $HADOOP_VER


### PR DESCRIPTION
### What is this PR for?
Debug flaky webapp builds

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-836](https://issues.apache.org/jira/browse/ZEPPELIN-836)

### How should this be tested?
CI must be green and include Travis exit code in case of success and `npm_debug.log` in case of failure

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

