### PR TITLE
Fixing Zeppelin-838: Minor improvement to error message

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -387,14 +387,17 @@ public class NotebookServer extends WebSocketServlet implements
     broadcastAll(new Message(OP.NOTES_INFO).put("notes", notesInfo));
   }
 
-  void permissionError(NotebookSocket conn, String op, Set<String> current,
-                      Set<String> allowed) throws IOException {
+  void permissionError(NotebookSocket conn, String op, Set<String> userAndRoles,
+                       Set<String> allowed) throws IOException {
     LOG.info("Cannot {}. Connection readers {}. Allowed readers {}",
-            op, current, allowed);
+            op, userAndRoles, allowed);
+
+    String userName = userAndRoles.iterator().next();
+
     conn.send(serializeMessage(new Message(OP.AUTH_INFO).put("info",
-            "Insufficient privileges to " + op + " note.\n\n" +
+            "Insufficient privileges to " + op + " notebook.\n\n" +
                     "Allowed users or roles: " + allowed.toString() + "\n\n" +
-                    "User belongs to: " + current.toString())));
+                    "But the user " + userName + " belongs to: " + userAndRoles.toString())));
   }
 
   private void sendNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,


### PR DESCRIPTION
### What is this PR for?
This JIRA improves the error message displayed when the current user opens a notebook to which the user is not allowed access to.


### What type of PR is it?
[Minor Improvement ]

### Todos
* None

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-838

### How should this be tested?
Get the change in this pull request. Build Zeppelin, configure shiro authentication by commenting out the 1st line below and modifying the corresponding line for 2nd line.
#/** = anon
/** = authcBasic
Log in as user1, configure a notebook to only allow access to only user1, now access that same notebook as  user2 and note the new error message.


### Screenshots (if appropriate)

[Screenshot:-Before](https://issues.apache.org/jira/secure/attachment/12802057/Screen%20Shot%202016-05-03%20at%203.16.58%20PM.png)
[Screenshot:-After](https://issues.apache.org/jira/secure/attachment/12802065/Screen%20Shot%202016-05-03%20at%203.17.36%20PM.png)

### Questions:
* Does the licenses files need update? --No
* Is there breaking changes for older versions? --No
* Does this needs documentation? -- No

