### PR TITLE
ZEPPELIN-837: Bring Bootstrap user auth dialog back

### DIFF
--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -29,6 +29,10 @@ user3 = password4, role2
 #ldapRealm.userDnTemplate = cn={0},cn=engg,ou=testdomain,dc=testdomain,dc=com
 #ldapRealm.contextFactory.url = ldap://ldaphost:389
 #ldapRealm.contextFactory.authenticationMechanism = SIMPLE
+sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+securityManager.sessionManager = $sessionManager
+# 86,400,000 milliseconds = 24 hour
+securityManager.sessionManager.globalSessionTimeout = 86400000
 shiro.loginUrl = /api/login
 
 [urls]
@@ -37,4 +41,4 @@ shiro.loginUrl = /api/login
 # To enfore security, comment the line below and uncomment the next one
 /api/version = anon
 /** = anon
-#/** = authcBasic
+#/** = authc

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -238,7 +238,7 @@ public class ZeppelinServer extends Application {
     webapp.setInitParameter("shiroConfigLocations",
         new File(conf.getShiroPath()).toURI().toString());
 
-    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/*",
+    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/api/*",
         EnumSet.allOf(DispatcherType.class));
 
     webapp.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());


### PR DESCRIPTION
### What is this PR for?
There were hotfix https://github.com/apache/incubator-zeppelin/pull/870 that encourage user use basic auth dialog instead of bootstrap auth dialog.
This issue will address bringing bootstrap auth dialog back.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] -  bringing bootstrap auth dialog back
* [x] -  have a session timeout (optional)

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-837

### How should this be tested?
At the end of shiro.ini file

    #/** = anon
    /** = authc

Bootstrap user auth dialog should work as expected

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no 
* Does this needs documentation? no

