### PR TITLE
[ZEPPELIN-843] Comment showing up on issues.apache.org is wrong

### DIFF
--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -48,7 +48,7 @@ JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "moon")
 # ASF JIRA password
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "00000")
 
-GITHUB_BASE = "https://github.com/apache/incubator-zeppelin/pulls"
+GITHUB_BASE = "https://github.com/apache/incubator-zeppelin/pull"
 GITHUB_API_BASE = "https://api.github.com/repos/apache/incubator-zeppelin"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"


### PR DESCRIPTION
### What is this PR for?
When using merge_zeppelin_pr.py utility the comment that shows up on issues.apache.org is wrong. The URL that prints is "pulls", it should be "pull"
It shows up as :

    Issue resolved by pull request 874
    https://github.com/apache/incubator-zeppelin/pulls/874


It should be :
    
    Issue resolved by pull request 874
    https://github.com/apache/incubator-zeppelin/pull/874


### What type of PR is it?
[Bug Fix]

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-843


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

