### PR TITLE
ZEPPELIN-844: Navbar menu should not show up if user is not authenticated

### DIFF
--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -43,7 +43,7 @@ limitations under the License.
       You can make beautiful data-driven, interactive, collaborative document with SQL, code and even more!<br>
 
       <div class="row">
-        <div class="col-md-4">
+        <div class="col-md-4" ng-if="ticket">
           <h4>Notebook
             <i ng-class="isReloadingNotes ? 'fa fa-refresh fa-spin' : 'fa fa-refresh'"
               ng-style="!isReloadingNotes && {'cursor': 'pointer'}" style="font-size: 13px;"

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -70,10 +70,10 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
     $scope.checkUsername();
     loadNotes();
   });
-  
+
   $scope.logout = function() {
-    $http.post(baseUrlSrv.getRestApiBase()+'/login/logout').
-      success(function(data, status, headers, config) {
+    $http.post(baseUrlSrv.getRestApiBase()+'/login/logout')
+      .success(function(data, status, headers, config) {
         $rootScope.userName = '';
         $rootScope.ticket.principal = '';
         $rootScope.ticket.ticket = '';
@@ -81,11 +81,14 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
         BootstrapDialog.show({
            message: 'Logout Success'
         });
+        setTimeout(function() {
+          window.location = '#';
+          window.location.reload();
+        }, 1000);
       }).
       error(function(data, status, headers, config) {
         console.log('Error %o %o', status, data.message);
       });
-    
   };
 
   $scope.search = function() {

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -94,7 +94,7 @@ limitations under the License.
         <li ng-if="!ticket">
             <button class="btn btn-default" data-toggle="modal" data-target="#loginModal" ng-click="showLoginWindow()" style="margin-left: 10px">Login</button>
         </li>
-        <li ng-show="ticket" style="left: 5px;">
+        <li ng-show="ticket.principal && ticket.principal!='anonymous'" style="left: 5px;">
         	<button class="btn btn-default" ng-click="logout()" tooltip-placement="bottom" tooltip="logout">Logout</button>
         </li>
       </ul>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -94,8 +94,8 @@ limitations under the License.
         <li ng-if="!ticket">
             <button class="btn btn-default" data-toggle="modal" data-target="#loginModal" ng-click="showLoginWindow()" style="margin-left: 10px">Login</button>
         </li>
-        <li ng-show="ticket.principal != 'anonymous'">
-        	<button type="button" class="btn btn-default btn-xs" ng-click="logout()" tooltip-placement="bottom" tooltip="logout">{{ticket.principal}}</button>
+        <li ng-show="ticket" style="left: 5px;">
+        	<button class="btn btn-default" ng-click="logout()" tooltip-placement="bottom" tooltip="logout">Logout</button>
         </li>
       </ul>
     </div>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -35,7 +35,7 @@ limitations under the License.
     </div>
 
     <div class="collapse navbar-collapse" ng-controller="NavCtrl as navbar">
-      <ul class="nav navbar-nav">
+      <ul class="nav navbar-nav" ng-if="ticket">
         <li class="dropdown" dropdown>
           <a href="#" class="dropdown-toggle" dropdown-toggle>Notebook <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
@@ -61,7 +61,7 @@ limitations under the License.
 
 
       <ul class="nav navbar-nav navbar-right" style="margin-top:10px; margin-right:5px;">
-        <li>
+        <li ng-if="ticket">
         <!--TODO(bzz): move to Typeahead https://angular-ui.github.io/bootstrap  -->
           <form role="search"
             style="width: 300px; display: inline-block; margin: 0 10px"


### PR DESCRIPTION
### What is this PR for?
If a user in not authenticated, s/he should not see Navbar menu, or search bar, or import/create note book links.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Hide all option from frontend

### What is the Jira issue?
[ZEPPELIN-844](https://issues.apache.org/jira/browse/ZEPPELIN-844)

### How should this be tested?
Change shiro conf to enable authentication. Now when home page is loaded you should not see any of the Navbar menu or option to create or import notebook

### Screenshots (if appropriate)
Before:
<img width="1439" alt="screen shot 2016-05-10 at 3 08 10 pm" src="https://cloud.githubusercontent.com/assets/674497/15142088/1918535c-16c1-11e6-9c2e-2662fdfb90e6.png">

After:
<img width="1440" alt="screen shot 2016-05-10 at 2 49 05 pm" src="https://cloud.githubusercontent.com/assets/674497/15142087/19183778-16c1-11e6-896e-1dc708c8700b.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? no 