### PR TITLE
Fix notebook folder structure name match bug

### DIFF
--- a/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
+++ b/zeppelin-web/src/components/notebookListDataFactory/notebookList.datafactory.js
@@ -27,7 +27,7 @@ angular.module('zeppelinWebApp').factory('notebookListDataFactory', function() {
       notes.root = {children: []};
       _.reduce(notesList, function(root, note) {
         var noteName = note.name || note.id;
-        var nodes = noteName.match(/([^\\\][^\/]|\\\/)+/g);
+        var nodes = noteName.match(/([^\/][^\/]*)/g);
 
         // recursively add nodes
         addNode(root, nodes, note.id);

--- a/zeppelin-web/test/spec/factory/notebookList.js
+++ b/zeppelin-web/test/spec/factory/notebookList.js
@@ -16,17 +16,18 @@ describe('Factory: NotebookList', function() {
     var notesList = [
       {name: 'A', id: '000001'},
       {name: 'B', id: '000002'},
-      {id: '000003'}, // notebook without name
+      {id: '000003'},                     // notebook without name
       {name: '/C/CA', id: '000004'},
       {name: '/C/CB', id: '000005'},
       {name: '/C/CB/CBA', id: '000006'},  // same name with a dir
-      {name: '/C/CB/CBA', id: '000007'}, // same name with another note
-      {name: 'C///CB//CBB', id: '000008'}
+      {name: '/C/CB/CBA', id: '000007'},  // same name with another note
+      {name: 'C///CB//CBB', id: '000008'},
+      {name: 'D/D[A/DA]B', id:'000009'}   // check if '[' and ']' considered as folder seperator      
     ];
     notebookList.setNotes(notesList);
 
     var flatList = notebookList.flatList;
-    expect(flatList.length).toBe(8);
+    expect(flatList.length).toBe(9);
     expect(flatList[0].name).toBe('A');
     expect(flatList[0].id).toBe('000001');
     expect(flatList[1].name).toBe('B');
@@ -36,9 +37,10 @@ describe('Factory: NotebookList', function() {
     expect(flatList[5].name).toBe('/C/CB/CBA');
     expect(flatList[6].name).toBe('/C/CB/CBA');
     expect(flatList[7].name).toBe('C///CB//CBB');
+    expect(flatList[8].name).toBe('D/D[A/DA]B');
 
     var folderList = notebookList.root.children;
-    expect(folderList.length).toBe(4);
+    expect(folderList.length).toBe(5);
     expect(folderList[0].name).toBe('A');
     expect(folderList[0].id).toBe('000001');
     expect(folderList[1].name).toBe('B');
@@ -64,6 +66,14 @@ describe('Factory: NotebookList', function() {
     expect(folderList[3].children[2].children[2].name).toBe('CBB');
     expect(folderList[3].children[2].children[2].id).toBe('000008');
     expect(folderList[3].children[2].children[2].children).toBeUndefined();
+    expect(folderList[4].name).toBe('D');
+    expect(folderList[4].id).toBeUndefined();
+    expect(folderList[4].children.length).toBe(1);
+    expect(folderList[4].children[0].name).toBe('D[A');
+    expect(folderList[4].children[0].id).toBeUndefined();
+    expect(folderList[4].children[0].children[0].name).toBe('DA]B');
+    expect(folderList[4].children[0].children[0].id).toBe('000009');
+    expect(folderList[4].children[0].children[0].children).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
### What is this PR for?
Current regex match rule for notebook folder takes not only `/` as delimiter but also `[` and `]`.

### What type of PR is it?
Bug Fix

### How should this be tested?
Try to create notebook that contains `[` or `]` in name and see if the folder structure is correct.

### Screenshots (if appropriate)
With notebook name `/A/B[C]D`
**Before**
![screen shot 2016-05-11 at 3 00 42 pm](https://cloud.githubusercontent.com/assets/8503346/15171404/2a7562b6-1789-11e6-87d2-39ba10e962c1.png)

**After**
![screen shot 2016-05-11 at 3 01 31 pm](https://cloud.githubusercontent.com/assets/8503346/15171418/49eb5830-1789-11e6-9362-a15bd9264873.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
