### PR TITLE
Missing upgrade link in docs from Flink 0.10 to 1.0

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -33,7 +33,7 @@ At the "Interpreters" menu, you have to create a new Flink interpreter and provi
   </tr>
 </table>
 
-For more information about Flink configuration, you can find it [here](https://ci.apache.org/projects/flink/flink-docs-release-0.10/setup/config.html).
+For more information about Flink configuration, you can find it [here](https://ci.apache.org/projects/flink/flink-docs-release-1.0/setup/config.html).
 
 ## How to test it's working
 In example, by using the [Zeppelin notebook](https://www.zeppelinhub.com/viewer/notebooks/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL05GTGFicy96ZXBwZWxpbi1ub3RlYm9va3MvbWFzdGVyL25vdGVib29rcy8yQVFFREs1UEMvbm90ZS5qc29u) is from Till Rohrmann's presentation [Interactive data analysis with Apache Flink](http://www.slideshare.net/tillrohrmann/data-analysis-49806564) for Apache Flink Meetup.


### PR DESCRIPTION
### What is this PR for?
A link was pointing to an old version of Flink, 0.10 instead of 1.0.

### What type of PR is it?
Documentation