### PR TITLE
ZEPPELIN-849: Zeppelin Crashes in Chrome and Firefox when Executing Specific %md text.

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -24,7 +24,7 @@
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.2.0",
     "angular-xeditable": "0.1.8",
-    "highlightjs": "~8.4.0",
+    "highlightjs": "^9.2.0",
     "lodash": "~3.9.3",
     "angular-filter": "~0.5.4",
     "ngtoast": "~2.0.0",


### PR DESCRIPTION
### What is this PR for?
The Chrome and Firefox browser tabs become completely unresponsive if the following code is executed in a Zeppelin paragraph:
%md
~~~
-------------------------------------------
Time: 2016-05-12 07:19:14
-------------------------------------------
~~~


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - upgrade version of highlightjs

### What is the Jira issue?
* [ZEPPELIN-849](https://issues.apache.org/jira/browse/ZEPPELIN-849)

### How should this be tested?
Runing folloing on a paragraph should not freeze browser.
    %md
    ~~~
    -------------------------------------------
    Time: 2016-05-12 07:19:14
    -------------------------------------------
    ~~~

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

