### PR TITLE
ZEPPELIN-850 update error message

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1009,6 +1009,7 @@ public class NotebookServer extends WebSocketServlet implements
             new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()),
             ex);
         p.setStatus(Status.ERROR);
+        broadcast(note.id(), new Message(OP.PARAGRAPH).put("paragraph", p));
       }
     }
   }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -364,7 +364,9 @@ angular.module('zeppelinWebApp')
       var newType = $scope.getResultType(data.paragraph);
       var oldGraphMode = $scope.getGraphMode();
       var newGraphMode = $scope.getGraphMode(data.paragraph);
-      var resultRefreshed = (data.paragraph.dateFinished !== $scope.paragraph.dateFinished) || isEmpty(data.paragraph.result) !== isEmpty($scope.paragraph.result);
+      var resultRefreshed = (data.paragraph.dateFinished !== $scope.paragraph.dateFinished) ||
+        isEmpty(data.paragraph.result) !== isEmpty($scope.paragraph.result) ||
+        data.paragraph.status === 'ERROR';
 
       var statusChanged = (data.paragraph.status !== $scope.paragraph.status);
 


### PR DESCRIPTION
### What is this PR for?
If there is an error on a paragraph, and user tries to run that paragraph again, which results in a different error message. In this case paragraph does not show up new error message.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-850](https://issues.apache.org/jira/browse/ZEPPELIN-850)

### How should this be tested?
 - create a new notebook
 - on the try running paragraph by using a wrong value for interpreter like %spark.error
 - on try changing the same with say %spark.error2
observe the paragraph output it should changed.

### Screenshots (if appropriate)
Before:
![error](https://cloud.githubusercontent.com/assets/674497/15212273/6afae5b6-185d-11e6-815e-2de8b0f9364b.gif)

After:
![fixed](https://cloud.githubusercontent.com/assets/674497/15212274/6b012822-185d-11e6-98e1-44cb86951595.gif)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no