### PR TITLE
ZEPPELIN-852 fixed the fields float outside the box.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -354,6 +354,7 @@ table.dataTable.table-condensed .sorting_desc:after {
 
 .tableDisplay .option .columns ul {
   background: white;
+  overflow: auto;
   width: auto;
   padding: 3px 3px 3px 3px;
   height: 150px;


### PR DESCRIPTION
### What is this PR for?
If added multiple fields in either of keys, groups or values boxes of settings button in results section of a paragraph to plot a graph or any representation, the fields floats outside the box.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[ZEPPELIN-852](https://issues.apache.org/jira/browse/ZEPPELIN-852)

### How should this be tested?
Open a notebook and a paragraph.
Run a paragraph with a query providing many columns to be added in any of the box.
Try adding multiple fields and check if it floats outside the box or not.

### Screenshots (if appropriate)
Before fix -
![screen shot 2016-05-13 at 11 52 42 am](https://cloud.githubusercontent.com/assets/12127192/15239928/c5bf1840-1903-11e6-8f65-9645aa3c45ae.png)

After fix -
![screen shot 2016-05-13 at 12 10 15 pm](https://cloud.githubusercontent.com/assets/12127192/15239933/d00d7e54-1903-11e6-8ed5-38bdde32acc0.png)


### Questions:
* Does the licenses files need update?NO
* Is there breaking changes for older versions?NO
* Does this needs documentation?NO

