### PR TITLE
[ZEPPELIN-853] Fix Last update at X by Y

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -969,7 +969,8 @@ angular.module('zeppelinWebApp')
       return '';
     }
     var user = 'anonymous';
-    if (pdata.authenticationInfo !== null && pdata.authenticationInfo.user !== null) {
+    var authInfo = pdata.authenticationInfo;
+    if (authInfo && authInfo.user) {
       user = pdata.authenticationInfo.user;
     }
     var dateUpdated = (pdata.dateUpdated === null) ? 'unknown' : pdata.dateUpdated;


### PR DESCRIPTION
### What is this PR for?
This is a hotfix to solve https://issues.apache.org/jira/browse/ZEPPELIN-853. The reason seems to be that new `AuthenticationInfo` field added to paragraph structure doesn't exist in old notebooks and check for non-existence wasn't complete.

### What type of PR is it?
Hot Fix

### Todos
* [x] - fix `if statement`

### What is the Jira issue?
[#853](https://issues.apache.org/jira/browse/ZEPPELIN-853)

### How should this be tested?
Start zeppelin and go to any existing notebook, check console not to have stacktrace mentioned in the issue.

### Screenshots (if appropriate)
Before:
![screenshot from 2016-05-16 21 12 15](https://cloud.githubusercontent.com/assets/1642088/15289839/b5ccffd4-1baf-11e6-888d-5926df79aafa.png)
After:
![screenshot from 2016-05-16 21 34 30](https://cloud.githubusercontent.com/assets/1642088/15289843/bfee079c-1baf-11e6-8e91-59efa5a26133.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
