### PR TITLE
ZEPPELIN-858: make interpreter searchable and sorted

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -17,11 +17,13 @@
 
 package org.apache.zeppelin.integration;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.AbstractZeppelinIT;
 import org.apache.zeppelin.WebDriverManager;
 import org.hamcrest.CoreMatchers;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -194,19 +196,19 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
     try {
       // navigate to interpreter page
-      WebElement interpreterLink = driver.findElement(By.linkText("Interpreter"));
+      WebElement interpreterLink = driver.findElement(By.xpath("//a[contains(.,'Interpreter')]"));
       interpreterLink.click();
 
       // add new dependency to spark interpreter
-      WebElement sparkEditBtn = pollingWait(By.xpath("//div[h3[text()[contains(.,'spark')]]]//button[contains(.,'edit')]"),
+      driver.findElement(By.xpath("//div[h3[text()[contains(.,'spark')]]]//button[contains(.,'edit')]")).sendKeys(Keys.ENTER);
+
+      WebElement depArtifact = pollingWait(By.xpath("//input[@ng-model='setting.depArtifact']"),
           MAX_BROWSER_TIMEOUT_SEC);
-      sparkEditBtn.click();
-      WebElement depArtifact = driver.findElement(By.xpath("//input[@ng-model='setting.depArtifact']"));
       String artifact = "org.apache.commons:commons-csv:1.1";
       depArtifact.sendKeys(artifact);
-      driver.findElement(By.xpath("//button[contains(.,'Save')]")).submit();
+      driver.findElement(By.xpath("//div[contains(@class,'box')][contains(.,'spark')]//form//button[1]")).click();
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
-              "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+          "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
 
       driver.navigate().back();
       createNewNote();
@@ -230,20 +232,17 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       //delete created notebook for cleanup.
       deleteTestNotebook(driver);
-      sleep(1000, true);
+      sleep(1000, false);
 
       // reset dependency
       interpreterLink.click();
-      sparkEditBtn = pollingWait(By.xpath("//div[h3[text()[contains(.,'spark')]]]//button[contains(.,'edit')]"),
-          MAX_BROWSER_TIMEOUT_SEC);
-      sparkEditBtn.click();
-      WebElement testDepRemoveBtn = driver.findElement(By.xpath("//tr[descendant::text()[contains(.,'" +
-          artifact + "')]]/td[3]/div"));
-      sleep(5000, true);
+      driver.findElement(By.xpath("//div[h3[text()[contains(.,'spark')]]]//button[contains(.,'edit')]")).sendKeys(Keys.ENTER);
+      WebElement testDepRemoveBtn = pollingWait(By.xpath("//tr[descendant::text()[contains(.,'" +
+          artifact + "')]]/td[3]/div"), MAX_IMPLICIT_WAIT);
       testDepRemoveBtn.click();
-      driver.findElement(By.xpath("//button[contains(.,'Save')]")).submit();
+      driver.findElement(By.xpath("//div[contains(@class,'box')][contains(.,'spark')]//form//button[1]")).click();
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
-              "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+          "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
     } catch (Exception e) {
       handleException("Exception in ZeppelinIT while testSparkInterpreterDependencyLoading ", e);
     }

--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -29,7 +29,7 @@ limitations under the License.
              style="width:180px">
           <select class="form-control input-sm" ng-model="newInterpreterSetting.group"
                   ng-change="newInterpreterGroupChange()">
-            <option ng-repeat="availableInterpreter in availableInterpreters | unique: 'group'" value="{{availableInterpreter.group}}">
+            <option ng-repeat="availableInterpreter in availableInterpreters | unique: 'group'| orderBy: 'group'" value="{{availableInterpreter.group}}">
               {{availableInterpreter.group}}
             </option>
           </select>
@@ -69,7 +69,7 @@ limitations under the License.
           <span>Interpreter for note</span>
         </div>
         <br />
-        
+
         <b>Properties</b>
         <table class="table table-striped properties">
           <tr>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -75,10 +75,19 @@ limitations under the License.
   </div>
 
   <div ng-include src="'app/interpreter/interpreter-create/interpreter-create.html'"></div>
+
+  <div class="input-group col-lg-4" style="margin-top: 10px">
+    <input type="text" ng-model="searchInterpreter" class="form-control ng-pristine ng-untouched ng-valid ng-empty" placeholder="Search interpreters">
+              <span class="input-group-btn">
+                <button type="submit" class="btn btn-default" ng-disabled="!navbar.connected">
+                  <i class="glyphicon glyphicon-search"></i>
+                </button>
+              </span>
+  </div>
 </div>
 
 <div class="box width-full home"
-     ng-repeat="setting in interpreterSettings">
+     ng-repeat="setting in interpreterSettings | orderBy: 'group' | filter: searchInterpreter">
   <div>
     <div class="row interpreter">
       <div class="col-md-12">
@@ -144,7 +153,7 @@ limitations under the License.
         <span>Interpreter for note</span>
       </div>
 
-      
+
       <div ng-show="_.isEmpty(setting.properties) && _.isEmpty(setting.dependencies) || valueform.$hidden" class="col-md-12 gray40-message">
         <em>Currently there are no properties and dependencies set for this interpreter</em>
       </div>


### PR DESCRIPTION
### What is this PR for?
Interpreters listed `/#/interpreter` here are slightly difficult to find, also the list that shows up for adding an interpreter is not sorted which adds effort to find the desired interpreter and the add it.
IMO the list should be sorted and searchable.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Interpreter list sorted.
* [x] - Interpreters should be searchable.

### What is the Jira issue?
* [ZEPPELIN-858](https://issues.apache.org/jira/browse/ZEPPELIN-858)

### How should this be tested?
Navigate to URL `/#/interpreter` 
 - the interpreters listed should be sorted
 - click on add interpreter, the interpreter drop down in "Create new interpreter" should also be sorted
 - the search box should search interpreters that are already listed

### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2016-05-18 at 10 32 55 am" src="https://cloud.githubusercontent.com/assets/674497/15347976/11288418-1ce4-11e6-9a57-3e2127ed5675.png">

<img width="1440" alt="screen shot 2016-05-18 at 10 33 44 am" src="https://cloud.githubusercontent.com/assets/674497/15347977/1128e85e-1ce4-11e6-858f-0cb27e6bb097.png">

<img width="296" alt="screen shot 2016-05-18 at 10 33 53 am" src="https://cloud.githubusercontent.com/assets/674497/15347978/112a122e-1ce4-11e6-8241-55b707425e1d.png">



### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

