### PR TITLE
Update HttpClient Dependencies

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -184,9 +184,9 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.6</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -115,16 +115,16 @@
       <version>1.5.2</version>
        <exclusions>
          <exclusion>
-           <groupId>commons-httpclient</groupId>
-           <artifactId>commons-httpclient</artifactId>
+           <groupId>org.apache.httpcomponents</groupId>
+           <artifactId>httpclient</artifactId>
          </exclusion>
        </exclusions>
      </dependency>
 
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.6</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
HttpClient dependencies of the stack needs to be addressed as below (due to end of life of commons-httpclient and security issues)

1] Need to identify all components that are still using commons-httpclient. This is already end-of-lived by apache and consumers need to move to HttpComponents.HttpClient 4.3.6 or later
2] All consumers of HttpComponents.HttpClient needs to be on at least 4.3.6

### What type of PR is it?
[Improvement]

### Todos
* [x] - migrate all commons-httpclient to org.apache.httpcomponents

### What is the Jira issue?
* [ZEPPELIN-860](https://issues.apache.org/jira/browse/ZEPPELIN-860)

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no

