### PR TITLE
Fix link to r interpreter doc

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -56,7 +56,7 @@
                 <li><a href="{{BASE_PATH}}/interpreter/lens.html">Lens</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/markdown.html">Markdown</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/postgresql.html">Postgresql, hawq</a></li>
-                <li><a href="{{BASE_PATH}}/interpreter/R.html">R</a></li>
+                <li><a href="{{BASE_PATH}}/interpreter/r.html">R</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/scalding.html">Scalding</a></li>
                 <li><a href="{{BASE_PATH}}/pleasecontribute.html">Shell</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/spark.html">Spark</a></li>


### PR DESCRIPTION
### What is this PR for?
This PR is hot fix for broken link to r interpreter doc


### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix link

### How should this be tested?
This changes link address from 
http://zeppelin.incubator.apache.org/docs/0.6.0-incubating-SNAPSHOT/interpreter/R.html
to
http://zeppelin.incubator.apache.org/docs/0.6.0-incubating-SNAPSHOT/interpreter/r.html

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

