### PR TITLE
Fix a few image not rendering

### DIFF
--- a/docs/assets/themes/zeppelin/js/docs.js
+++ b/docs/assets/themes/zeppelin/js/docs.js
@@ -99,9 +99,7 @@ function viewSolution() {
 // A script to fix internal hash links because we have an overlapping top bar.
 // Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510
 function maybeScrollToHash() {
-  console.log("HERE");
   if (window.location.hash && $(window.location.hash).length) {
-    console.log("HERE2", $(window.location.hash), $(window.location.hash).offset().top);
     var newTop = $(window.location.hash).offset().top - 57;
     $(window).scrollTop(newTop);
   }
@@ -117,5 +115,5 @@ $(function() {
 
   // Scroll now too in case we had opened the page on a hash, but wait a bit because some browsers
   // will try to do *their* initial scroll after running the onReady handler.
-  $(window).load(function() { setTimeout(function() { maybeScrollToHash(); }, 25); }); 
+  $(window).load(function() { setTimeout(function() { maybeScrollToHash(); }, 25); });
 });

--- a/docs/manual/interpreters.md
+++ b/docs/manual/interpreters.md
@@ -29,18 +29,18 @@ Zeppelin Interpreter is a plug-in which enables Zeppelin users to use a specific
 
 When you click the ```+Create``` button in the interpreter page, the interpreter drop-down list box will show all the available interpreters on your server.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_create.png">
+<img src="../assets/themes/zeppelin/img/screenshots/interpreter_create.png">
 
 ## What is Zeppelin Interpreter Setting?
 Zeppelin interpreter setting is the configuration of a given interpreter on Zeppelin server. For example, the properties are required for hive JDBC interpreter to connect to the Hive server.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_setting.png">
+<img src="../assets/themes/zeppelin/img/screenshots/interpreter_setting.png">
 
 Properties are exported as environment variable when property name is consisted of upper characters, numbers and underscore ([A-Z_0-9]). Otherwise set properties as JVM property.
 
 Each notebook can be bound to multiple Interpreter Settings using setting icon on upper right corner of the notebook.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_binding.png" width="800px">
+<img src="../assets/themes/zeppelin/img/screenshots/interpreter_binding.png" width="800px">
 
 
 
@@ -51,7 +51,7 @@ By default, every interpreter is belonged to a single group, but the group might
 Technically, Zeppelin interpreters from the same group are running in the same JVM. For more information about this, please checkout [here](../development/writingzeppelininterpreter.html).
 
 Each interpreters is belonged to a single group and registered together. All of their properties are listed in the interpreter setting like below image.
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_setting_spark.png">
+<img src="../assets/themes/zeppelin/img/screenshots/interpreter_setting_spark.png">
 
 
 ## Interpreter binding mode
@@ -59,4 +59,4 @@ Each interpreters is belonged to a single group and registered together. All of 
 Each Interpreter Setting can choose one of 'shared', 'scoped', 'isolated' interpreter binding mode.
 In 'shared' mode, every notebook bound to the Interpreter Setting will share the single Interpreter instance. In 'scoped' mode, each notebook will create new Interpreter instance in the same interpreter process. In 'isolated' mode, each notebook will create new Interpreter process.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_persession.png" width="400px">
+<img src="../assets/themes/zeppelin/img/screenshots/interpreter_persession.png" width="400px">

--- a/docs/ui_layout/zeppelin_layout.md
+++ b/docs/ui_layout/zeppelin_layout.md
@@ -21,21 +21,21 @@ limitations under the License.
 
 The first time you connect to Zeppelin, you'll land at the main page similar to the below screen capture
 
-<img src="/assets/themes/zeppelin/img/ui-img/homepage.png" />
+<img src="../assets/themes/zeppelin/img/ui-img/homepage.png" />
 
-On the left of the page are listed all existing notes. Those notes are stored by default in the `$ZEPPELIN_HOME/notebook` folder. 
+On the left of the page are listed all existing notes. Those notes are stored by default in the `$ZEPPELIN_HOME/notebook` folder.
 
-You can filter them by name using the input text form. You can also create an new note, refresh the list of existing notes 
+You can filter them by name using the input text form. You can also create an new note, refresh the list of existing notes
 (in case you manually copy them into the `$ZEPPELIN_HOME/notebook` folder) and import a note
-  
-<img src="/assets/themes/zeppelin/img/ui-img/notes_management.png" />
- 
+
+<img src="../assets/themes/zeppelin/img/ui-img/notes_management.png" />
+
 When clicking on `Import Note` link, a new dialog open. From there you can import your note from local disk or from a remote location
 if you provide the URL.
- 
-<img src="/assets/themes/zeppelin/img/ui-img/note_import_dialog.png" />
 
-By default, the name of the imported note is the same as the original note but you can override it by providing a new name 
+<img src="../assets/themes/zeppelin/img/ui-img/note_import_dialog.png" />
+
+By default, the name of the imported note is the same as the original note but you can override it by providing a new name
 
 <br />
 ## Menus
@@ -67,10 +67,10 @@ This menu displays all the Zeppelin configuration that are set in the config fil
 
 
 <br />
-## Note Layout 
+## Note Layout
 
-Each Zeppelin note is composed of 1 .. N paragraphs. The note can be viewed as a paragraph container. 
- 
+Each Zeppelin note is composed of 1 .. N paragraphs. The note can be viewed as a paragraph container.
+
 <img src="../assets/themes/zeppelin/img/ui-img/note_paragraph_layout.png" />
 
 ### Paragraph
@@ -78,20 +78,20 @@ Each Zeppelin note is composed of 1 .. N paragraphs. The note can be viewed as a
 Each paragraph consists of 2 sections: `code section` where you put your source code and `result section` where you can see the result of the code execution.
 
 <img src="../assets/themes/zeppelin/img/ui-img/paragraph_layout.png" />
- 
+
 On the top-right corner of each paragraph there are some commands to:
- 
+
 * execute the paragraph code
 * hide/show `code section`
 * hide/show `result section`
 * configure the paragraph
 
 To configure the paragraph, just click on the gear icon:
- 
+
 <img src="../assets/themes/zeppelin/img/ui-img/paragraph_configuration_dialog.png" />
- 
+
 From this dialog, you can (in descending order):
- 
+
 * find the **paragraph id** ( **20150924-163507_134879501** )
 * control paragraph width. Since Zeppelin is using the grid system of **Twitter Bootstrap**, each paragraph width can be changed from 1 to 12
 * move the paragraph 1 level up
@@ -103,19 +103,19 @@ From this dialog, you can (in descending order):
 * export the current paragraph as an **iframe** and open the **iframe** in a new window
 * clear the `result section`
 * delete the current paragraph
-  
+
 ### Note toolbar
-  
+
 At the top of the note, you can find a toolbar which exposes command buttons as well as configuration, security and display options
-  
-<img src="../assets/themes/zeppelin/img/ui-img/note_toolbar.png" />  
-   
+
+<img src="../assets/themes/zeppelin/img/ui-img/note_toolbar.png" />
+
 On the far right is displayed the note name, just click on it to reveal the input form and update it
-   
+
 In the middle of the toolbar you can find the command buttons:
-   
+
 * execute all the paragraphs **sequentially**, in their display order
-* hide/show `code section` of all paragraphs      
+* hide/show `code section` of all paragraphs
 * hide/show `result section` of all paragraphs
 * clear the `result section` of all paragraphs
 * clone the current note
@@ -127,13 +127,10 @@ In the middle of the toolbar you can find the command buttons:
 <img src="../assets/themes/zeppelin/img/ui-img/note_commands.png" />
 
 On the right of the note tool bar you can find configuration icons:
- 
+
 * display all the keyboard shorcuts
 * configure the interpreters binding to the current note
 * configure the note permissions
 * switch the node display mode between `default`, `simple` and `report`
 
 <img src="../assets/themes/zeppelin/img/ui-img/note_configuration.png" />
- 
- 
- 


### PR DESCRIPTION
### What is this PR for?
There was a recent PR made by @doanduyhai that was changing some images URL to include `../assets`. However, I found a few more cases in the deployed website.
It is actually a bit hard to understand why this happens in some cases only, maybe it could be better to replace all `/assets` to `../assets`, however this PR is only fixing the current issues.


### What type of PR is it?
Bug Fix

### How should this be tested?
You can build the doc and run it locally

### Screenshots (if appropriate)

<img width="688" alt="screen shot 2016-05-18 at 3 20 53 pm" src="https://cloud.githubusercontent.com/assets/710411/15376817/45648b78-1d0c-11e6-82cb-4ba106e01043.png">
<img width="521" alt="screen shot 2016-05-18 at 3 21 09 pm" src="https://cloud.githubusercontent.com/assets/710411/15376819/493ff976-1d0c-11e6-9960-cbd568f5d0ec.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

