### PR TITLE
Refactor CORS filter into webapp context handler

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -232,9 +232,6 @@ public class ZeppelinServer extends Application {
     webapp.setSessionHandler(new SessionHandler());
     webapp.addServlet(cxfServletHolder, "/api/*");
 
-    webapp.addFilter(new FilterHolder(CorsFilter.class), "/*",
-        EnumSet.allOf(DispatcherType.class));
-
     webapp.setInitParameter("shiroConfigLocations",
         new File(conf.getShiroPath()).toURI().toString());
 
@@ -267,6 +264,9 @@ public class ZeppelinServer extends Application {
     // Explicit bind to root
     webApp.addServlet(new ServletHolder(new DefaultServlet()), "/*");
     contexts.addHandler(webApp);
+
+    webApp.addFilter(new FilterHolder(CorsFilter.class), "/*",
+        EnumSet.allOf(DispatcherType.class));
 
     return webApp;
 


### PR DESCRIPTION
### What is this PR for?
#867 was a hotfix and merged immediately. However we can refactor CORS filter into more appropriate place, which is webapp context handler instead of keeping it in rest api handler (since it also applies to websocket api).


### What type of PR is it?
Refactoring

### Todos
* [x] - move from rest to webapp

### What is the Jira issue?

### How should this be tested?
Basically this is refactoring, and original flow holds. 
For testing, can use same routine as in #867.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
