### PR TITLE
Change the placement of 'Repository Information' icon with '+Create' button

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -19,15 +19,15 @@ limitations under the License.
           Interpreters
         </h3>
         <div class="pull-right" style="margin-top:10px;">
+          <span style="cursor:pointer;margin-right:8px;"
+                ng-click="showRepositoryInfo = !showRepositoryInfo"
+                tooltip-placement="bottom" tooltip="Repository information">
+            <i class="fa fa-cog" ng-style="{color: showRepositoryInfo ? '#3071A9' : 'black' }"></i>
+          </span>
           <span class="btn btn-default fa fa-plus"
                 ng-click="showAddNewSetting = !showAddNewSetting"
                 style="margin-right:6px;">
             Create
-          </span>
-          <span style="cursor:pointer;margin-right:4px;"
-                ng-click="showRepositoryInfo = !showRepositoryInfo"
-                tooltip-placement="bottom" tooltip="Repository information">
-            <i class="fa fa-cog" ng-style="{color: showRepositoryInfo ? '#3071A9' : 'black' }"></i>
           </span>
         </div>
       </div>


### PR DESCRIPTION
### What is this PR for?
I just changed the `Repository Information` icon placement with `+Create` button in Interpreter setting page, since the tooltip is not shown properly.

### What type of PR is it?
Improvement

### Todos
* [x] - Change the icon placement

### What is the Jira issue?
No

### How should this be tested?
After applying this PR and go to interpreter setting page. Then hover the mouse on the gear icon. That's it :)

### Screenshots (if appropriate)

- **Before**
![before](https://cloud.githubusercontent.com/assets/10060731/15386813/b6e741cc-1de4-11e6-997c-ef77bfded50e.gif)

- **After**
![after](https://cloud.githubusercontent.com/assets/10060731/15386816/bd16fd80-1de4-11e6-9802-e82d20c79547.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

