### PR TITLE
[ZEPPELIN-835]Don't persist authentication info into note.json

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -50,7 +50,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
 
   String title;
   String text;
-  AuthenticationInfo authenticationInfo;
+  transient AuthenticationInfo authenticationInfo;
   Date dateUpdated;
   private Map<String, Object> config; // paragraph configs like isOpen, colWidth, etc
   public final GUI settings;          // form and parameter settings

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.notebook;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,8 +28,11 @@ import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.Input;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.Test;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,6 +45,7 @@ public class ParagraphTest {
     text = "%table 1234567";
     assertEquals("1234567", Paragraph.getScriptBody(text));
   }
+
   @Test
   public void scriptBodyWithoutReplName() {
     String text = "12345678";
@@ -84,5 +89,19 @@ public class ParagraphTest {
     verify(registry).get("name", noteId, paragraphId);
     verify(registry).get("age", noteId, null);
     assertEquals(actual, expected);
+  }
+
+  @Test
+  public void not_persist_authentication() throws Exception {
+    Paragraph p = new Paragraph();
+    p.setAuthenticationInfo(new AuthenticationInfo("admin", "test"));
+
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+    String json = gson.toJson(p);
+
+    assertFalse(json.contains("authenticationInfo"));
+    System.out.println(json);
   }
 }


### PR DESCRIPTION
### What is this PR for?
Don't persist authentication info into note.json

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-835

### How should this be tested?
unit test

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

