### PR TITLE
[ZEPPELIN-870] Improvement build and pom normalized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <libthrift.version>0.9.2</libthrift.version>
     <gson.version>2.2</gson.version>
     <guava.version>15.0</guava.version>
+    <shiro.version>1.2.4</shiro.version>
     <jdk.version>1.7</jdk.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
@@ -240,12 +241,12 @@
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-core</artifactId>
-        <version>1.2.3</version>
+        <version>${shiro.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-web</artifactId>
-        <version>1.2.3</version>
+        <version>${shiro.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -671,7 +672,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,9 @@
     <libthrift.version>0.9.2</libthrift.version>
     <gson.version>2.2</gson.version>
     <guava.version>15.0</guava.version>
-
+    <jdk.version>1.7</jdk.version>
+    <scala.version>2.10.4</scala.version>
+    <scala.binary.version>2.10</scala.binary.version>
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
   </properties>
@@ -195,7 +197,6 @@
         <version>2.4</version>
       </dependency>
 
-
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
@@ -214,12 +215,25 @@
         <version>${guava.version}</version>
       </dependency>
 
+      <!--test dependencies-->
+      <dependency>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <version>2.2.6</version>
+        <scope>test</scope>
+      </dependency>
 
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.0.24</version>
       </dependency>
 
       <!-- Apache Shiro -->
@@ -245,10 +259,10 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.5.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${jdk.version}</source>
+          <target>${jdk.version}</target>
         </configuration>
       </plugin>
 
@@ -382,7 +396,8 @@
                 <!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
                 <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
                 <!-- Will generate META-INF/DISCLAIMER  -->
-                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
+                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT
+                </resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>
@@ -460,7 +475,7 @@
               <exclude>.github/*</exclude>
               <exclude>.gitignore</exclude>
               <exclude>.repository/</exclude>
-  	      <exclude>.Rhistory</exclude>
+              <exclude>.Rhistory</exclude>
               <exclude>**/*.diff</exclude>
               <exclude>**/*.patch</exclude>
               <exclude>**/*.avsc</exclude>
@@ -668,6 +683,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.7</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.googlecode.maven-download-plugin</groupId>
+          <artifactId>download-maven-plugin</artifactId>
+          <version>1.3.0</version>
         </plugin>
 
       </plugins>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <script.extension>.sh</script.extension>
     <path.separator>/</path.separator>
-    <spark.version>1.4.1</spark.version>
+    <spark.version>1.6.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
   </properties>
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.4</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -253,7 +253,7 @@
     <!-- Spark -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <exclusions>
         <exclusion>
@@ -265,31 +265,31 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_2.11</artifactId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_2.11</artifactId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.11</artifactId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_2.11</artifactId>
+      <artifactId>spark-streaming-twitter_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
@@ -805,7 +805,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-yarn_2.11</artifactId>
+          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
           <version>${spark.version}</version>
         </dependency>
 

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -37,7 +37,7 @@
 
 
   <properties>
-    <spark.version>1.6.1</spark.version>
+    <spark.version>1.4.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
 
@@ -513,6 +513,9 @@
 
     <profile>
       <id>spark-1.6</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>1.6.1</spark.version>
         <py4j.version>0.9</py4j.version>
@@ -821,7 +824,7 @@
       <!--only used for pyspark/sparkR needed spark dist is downloaded, no need to download auto-->
       <id>spark-dist-cached</id>
       <properties>
-        <spark.iscached>deploy</spark.iscached>
+        <spark.iscached>validate</spark.iscached>
       </properties>
     </profile>
 

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -36,7 +37,7 @@
 
 
   <properties>
-    <spark.version>1.4.1</spark.version>
+    <spark.version>1.6.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
 
@@ -50,11 +51,14 @@
     <akka.group>org.spark-project.akka</akka.group>
     <akka.version>2.3.4-spark</akka.version>
 
+    <spark.iscached>validate</spark.iscached>
     <spark.archive>spark-${spark.version}</spark.archive>
     <spark.download.url>
       http://archive.apache.org/dist/spark/${spark.archive}/${spark.archive}.tgz
     </spark.download.url>
-    <spark.bin.download.url>http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}-bin-without-hadoop.tgz</spark.bin.download.url>
+    <spark.bin.download.url>
+      http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}-bin-without-hadoop.tgz
+    </spark.bin.download.url>
     <spark.dist.cache>${project.build.directory}/../../.spark-dist</spark.dist.cache>
     <py4j.version>0.8.2.1</py4j.version>
   </properties>
@@ -249,7 +253,7 @@
     <!-- Spark -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
       <exclusions>
         <exclusion>
@@ -261,31 +265,31 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_2.10</artifactId>
+      <artifactId>spark-repl_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
+      <artifactId>spark-sql_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_2.10</artifactId>
+      <artifactId>spark-hive_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
+      <artifactId>spark-streaming_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_2.10</artifactId>
+      <artifactId>spark-streaming-twitter_2.11</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
@@ -438,7 +442,7 @@
       </dependencies>
     </profile>
 
-   <profile>
+    <profile>
       <id>spark-1.4</id>
       <properties>
         <spark.version>1.4.1</spark.version>
@@ -516,9 +520,17 @@
         <akka.version>2.3.11</akka.version>
         <protobuf.version>2.5.0</protobuf.version>
       </properties>
+    </profile>
 
-      <dependencies>
-      </dependencies>
+    <profile>
+      <id>spark-2.0</id>
+      <properties>
+        <spark.version>2.0.0</spark.version>
+        <py4j.version>0.10.1</py4j.version>
+        <akka.group>com.typesafe.akka</akka.group>
+        <akka.version>2.3.11</akka.version>
+        <protobuf.version>2.5.0</protobuf.version>
+      </properties>
     </profile>
 
     <profile>
@@ -586,6 +598,16 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.7</id>
+      <properties>
+        <hadoop.version>2.7.2</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.0</jets3t.version>
+        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+      </properties>
+    </profile>
+
+    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -596,12 +618,16 @@
         <jets3t.version>0.7.1</jets3t.version>
       </properties>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -634,12 +660,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -672,12 +702,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -710,12 +744,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -748,12 +786,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -763,7 +805,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-yarn_2.10</artifactId>
+          <artifactId>spark-yarn_2.11</artifactId>
           <version>${spark.version}</version>
         </dependency>
 
@@ -773,6 +815,14 @@
           <version>${yarn.version}</version>
         </dependency>
       </dependencies>
+    </profile>
+
+    <profile>
+      <!--only used for pyspark/sparkR needed spark dist is downloaded, no need to download auto-->
+      <id>spark-dist-cached</id>
+      <properties>
+        <spark.iscached>deploy</spark.iscached>
+      </properties>
     </profile>
 
     <profile>
@@ -786,7 +836,7 @@
             <executions>
               <execution>
                 <id>download-pyspark-files</id>
-                <phase>validate</phase>
+                <phase>${spark.iscached}</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -845,7 +895,7 @@
                     <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip"
                          basedir="${project.build.directory}/spark-dist/${spark.archive}/python"
                          includes="pyspark/*.py,pyspark/**/*.py"/>
-                  </target>                
+                  </target>
                 </configuration>
               </execution>
             </executions>
@@ -865,7 +915,7 @@
             <executions>
               <execution>
                 <id>download-sparkr-files</id>
-                <phase>validate</phase>
+                <phase>${spark.iscached}</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -889,7 +939,6 @@
           </plugin>
           <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>2.7</version>
             <executions>
               <execution>
                 <id>copy-sparkr-files</id>
@@ -901,7 +950,9 @@
                   <outputDirectory>${project.build.directory}/../../interpreter/spark/R/lib</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.build.directory}/spark-bin-dist/spark-${spark.version}-bin-without-hadoop/R/lib</directory>
+                      <directory>
+                        ${project.build.directory}/spark-bin-dist/spark-${spark.version}-bin-without-hadoop/R/lib
+                      </directory>
                     </resource>
                   </resources>
                 </configuration>
@@ -911,7 +962,7 @@
         </plugins>
       </build>
     </profile>
-    
+
   </profiles>
 
   <build>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -38,7 +38,7 @@
     <jsoup.version>1.8.2</jsoup.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.4</powermock.version>
-    <spark.version>1.4.1</spark.version>
+    <spark.version>1.6.1</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
   </properties>
@@ -243,7 +243,6 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -90,8 +90,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.1.1</version>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -272,8 +272,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.1.1</version>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -33,9 +33,9 @@
   <name>Zeppelin: web Application</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->
-  <prerequisites>
-    <maven>3.1.0</maven>
-  </prerequisites>
+  <!--<prerequisites>-->
+    <!--<maven>3.1.0</maven>-->
+  <!--</prerequisites>-->
 
   <build>
     <plugins>
@@ -86,7 +86,8 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.25</version>
+        <version>1.0</version>
+        <!-- optional -->
         <executions>
 
           <execution>


### PR DESCRIPTION
### What is this PR for?
1. frontend-maven-plugin upgrade to 1.0, as low version occur error when build on osx
2. upgrade spark version from 1.4.1 to 1.6.1
3. define maven dependency scala version as property, used by  dependency version include scala version 
4. dependencyManagement define junit and scala-test dependency, same to pluginManagement
5. add `spark.iscached` property, used by  profile when need download spark dist by download-maven-plugin. 
6. add spark-2.0 and hadoop-2.7 profile

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
 [ZEPPELIN-870](https://issues.apache.org/jira/browse/ZEPPELIN-870) 

### How should this be tested?

run build command:
`export MAVEN_OPTS="-Xmx3g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"; mvn clean package -Pbuild-distr -DskipTests -Pspark-1.6 -Phadoop-2.7 -Ppyspark -Pvendor-repo -Dignite.version=1.1.0-incubating -Pscalding -Pspark-dist-cached -Drat.skip=true`

### Questions:

