### PR TITLE
[MINOR] switch location of interpreter search input box

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -37,6 +37,15 @@ limitations under the License.
         Manage interpreters settings. You can create create / remove settings. Note can bind/unbind these interpreter settings.
       </div>
     </div>
+
+    <div class="input-group col-md-4" style="margin-top: 10px">
+      <input type="text" ng-model="searchInterpreter" class="form-control ng-pristine ng-untouched ng-valid ng-empty" placeholder="Search interpreters">
+      <span class="input-group-btn">
+        <button type="submit" class="btn btn-default" ng-disabled="!navbar.connected">
+          <i class="glyphicon glyphicon-search"></i>
+        </button>
+      </span>
+    </div>
   </div>
 
   <div class="row" ng-if="showRepositoryInfo">
@@ -75,15 +84,6 @@ limitations under the License.
   </div>
 
   <div ng-include src="'app/interpreter/interpreter-create/interpreter-create.html'"></div>
-
-  <div class="input-group col-lg-4" style="margin-top: 10px">
-    <input type="text" ng-model="searchInterpreter" class="form-control ng-pristine ng-untouched ng-valid ng-empty" placeholder="Search interpreters">
-              <span class="input-group-btn">
-                <button type="submit" class="btn btn-default" ng-disabled="!navbar.connected">
-                  <i class="glyphicon glyphicon-search"></i>
-                </button>
-              </span>
-  </div>
 </div>
 
 <div class="box width-full home"


### PR DESCRIPTION
### What is this PR for?
Make search interpreter input box always to be placed upper than repository information or interpreter creation form.

### What type of PR is it?
Improvement

### Screenshots (if appropriate)
**Before**
<img width="515" alt="screen shot 2016-05-24 at 3 54 14 pm" src="https://cloud.githubusercontent.com/assets/8503346/15522526/f565c22a-21c7-11e6-95f0-be73e74b3ff7.png">

**After**
<img width="514" alt="screen shot 2016-05-24 at 3 54 24 pm" src="https://cloud.githubusercontent.com/assets/8503346/15522527/f8e6cebc-21c7-11e6-8e63-b05110546d06.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

