### PR TITLE
Change website menu caret color

### DIFF
--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -27,12 +27,12 @@ body {
  background-color:#3071a9;
 }
 
-.navbar-inverse .navbar-nav > li > a:hover, 
+.navbar-inverse .navbar-nav > li > a:hover,
 .navbar-inverse .navbar-nav > li > a:focus {
   color: #ffffff;
   background-color: #2C6094;
 }
-.navbar-inverse .navbar-nav > li > a.active:hover, 
+.navbar-inverse .navbar-nav > li > a.active:hover,
 .navbar-inverse .navbar-nav > li > a.active:focus {
   text-decoration: none;
   background-color: #265380;
@@ -311,9 +311,11 @@ body {
 .navbar-collapse.collapse {
     max-height: 50px;}
 
-#apache .caret {
+.navbar-inverse .navbar-nav a .caret,
+.navbar-inverse .navbar-nav a:hover .caret {
     margin-left: 4px;
     border-top-color: #FFF;
+    border-bottom-color: #FFF;
 }
 
 .navbar-inverse .navbar-nav > .open > a,
@@ -323,7 +325,7 @@ body {
   background-color: #286090;
 }
 
-/* Custom, iPhone Retina */ 
+/* Custom, iPhone Retina */
 @media only screen and (max-width : 480px) {
   .jumbotron h1 {
     display: none;
@@ -356,7 +358,7 @@ and (max-width : 1024px) {
 
 /* docs dropdown menu */
 #docs {
-    
+
 }
 
 #docs .dropdown-menu {


### PR DESCRIPTION
### What is this PR for?
One of the menu from the website has a wrong caret color, this fixed it.


### What type of PR is it?
Bug Fix

### How should this be tested?
You can build the website locally and run it, then check the top menu caret color

### Screenshots
Before:
![screen shot 2016-05-24 at 10 21 29 pm](https://cloud.githubusercontent.com/assets/710411/15528999/6a681ed4-21fe-11e6-86c4-06199a059681.png)

After:
![screen shot 2016-05-24 at 10 21 37 pm](https://cloud.githubusercontent.com/assets/710411/15529003/726b4250-21fe-11e6-9507-556de528ad1b.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

