### PR TITLE
[ZEPPELIN 894] add new hadoop/spark profile and default spark 1.6 active

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -524,15 +524,6 @@
     </profile>
 
     <profile>
-      <id>spark-2.0</id>
-      <properties>
-        <spark.version>2.0.0</spark.version>
-        <py4j.version>0.10.1</py4j.version>
-        <protobuf.version>2.5.0</protobuf.version>
-      </properties>
-    </profile>
-
-    <profile>
       <id>hadoop-0.23</id>
       <!-- SPARK-1121: Adds an explicit dependency on Avro to work around a
         Hadoop 0.23.X issue -->

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -34,7 +35,6 @@
   <description>Zeppelin spark support</description>
   <url>http://zeppelin.incubator.apache.org</url>
 
-
   <properties>
     <spark.version>1.4.1</spark.version>
     <scala.version>2.10.4</scala.version>
@@ -43,7 +43,7 @@
     <hadoop.version>2.3.0</hadoop.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <avro.version>1.7.7</avro.version>
-    <avro.mapred.classifier></avro.mapred.classifier>
+    <avro.mapred.classifier/>
     <jets3t.version>0.7.1</jets3t.version>
     <protobuf.version>2.4.1</protobuf.version>
 
@@ -54,7 +54,9 @@
     <spark.download.url>
       http://archive.apache.org/dist/spark/${spark.archive}/${spark.archive}.tgz
     </spark.download.url>
-    <spark.bin.download.url>http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}-bin-without-hadoop.tgz</spark.bin.download.url>
+    <spark.bin.download.url>
+      http://archive.apache.org/dist/spark/spark-${spark.version}/spark-${spark.version}-bin-without-hadoop.tgz
+    </spark.bin.download.url>
     <spark.dist.cache>${project.build.directory}/../../.spark-dist</spark.dist.cache>
     <py4j.version>0.8.2.1</py4j.version>
   </properties>
@@ -249,7 +251,7 @@
     <!-- Spark -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <exclusions>
         <exclusion>
@@ -261,31 +263,31 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_2.10</artifactId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_2.10</artifactId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_2.10</artifactId>
+      <artifactId>spark-streaming-twitter_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
 
@@ -438,7 +440,7 @@
       </dependencies>
     </profile>
 
-   <profile>
+    <profile>
       <id>spark-1.4</id>
       <properties>
         <spark.version>1.4.1</spark.version>
@@ -509,6 +511,9 @@
 
     <profile>
       <id>spark-1.6</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>1.6.1</spark.version>
         <py4j.version>0.9</py4j.version>
@@ -516,9 +521,15 @@
         <akka.version>2.3.11</akka.version>
         <protobuf.version>2.5.0</protobuf.version>
       </properties>
+    </profile>
 
-      <dependencies>
-      </dependencies>
+    <profile>
+      <id>spark-2.0</id>
+      <properties>
+        <spark.version>2.0.0</spark.version>
+        <py4j.version>0.10.1</py4j.version>
+        <protobuf.version>2.5.0</protobuf.version>
+      </properties>
     </profile>
 
     <profile>
@@ -586,6 +597,16 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.7</id>
+      <properties>
+        <hadoop.version>2.7.2</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.0</jets3t.version>
+        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+      </properties>
+    </profile>
+
+    <profile>
       <id>mapr3</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -596,12 +617,16 @@
         <jets3t.version>0.7.1</jets3t.version>
       </properties>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -634,12 +659,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -672,12 +701,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -710,12 +743,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -748,12 +785,16 @@
         </dependency>
       </dependencies>
       <repositories>
-         <repository>
-           <id>mapr-releases</id>
-           <url>http://repository.mapr.com/maven/</url>
-           <snapshots><enabled>false</enabled></snapshots>
-           <releases><enabled>true</enabled></releases>
-         </repository>
+        <repository>
+          <id>mapr-releases</id>
+          <url>http://repository.mapr.com/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
       </repositories>
     </profile>
 
@@ -763,7 +804,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-yarn_2.10</artifactId>
+          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
           <version>${spark.version}</version>
         </dependency>
 
@@ -845,7 +886,7 @@
                     <zip destfile="${project.build.directory}/../../interpreter/spark/pyspark/pyspark.zip"
                          basedir="${project.build.directory}/spark-dist/${spark.archive}/python"
                          includes="pyspark/*.py,pyspark/**/*.py"/>
-                  </target>                
+                  </target>
                 </configuration>
               </execution>
             </executions>
@@ -901,7 +942,9 @@
                   <outputDirectory>${project.build.directory}/../../interpreter/spark/R/lib</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.build.directory}/spark-bin-dist/spark-${spark.version}-bin-without-hadoop/R/lib</directory>
+                      <directory>
+                        ${project.build.directory}/spark-bin-dist/spark-${spark.version}-bin-without-hadoop/R/lib
+                      </directory>
                     </resource>
                   </resources>
                 </configuration>
@@ -911,7 +954,7 @@
         </plugins>
       </build>
     </profile>
-    
+
   </profiles>
 
   <build>


### PR DESCRIPTION
### What is this PR for?
spark-dependencies module pom: 
1. add spark-2.0 profile
2. add hadoop-2.7 profile
3. profile spark-1.6 activeByDefault
4. replace scala version 2.10 with property `scala.binary.version`
