### PR TITLE
Remove unnedeed commons-exec declaration in scope test [ZEPPELIN-904]

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -247,12 +247,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
 
 
     <dependency> <!-- because there are two of them above  -->


### PR DESCRIPTION
### What is this PR for?
zeppelin-server should simply rely on transitive commons-exec from zeppelin-interpreter.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-533

### How should this be tested?
Simply build

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N

