### PR TITLE
[ZEPPELIN-926] Set maxClassfileName to 128

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -70,6 +70,7 @@ import scala.reflect.io.AbstractFile;
 import scala.tools.nsc.Settings;
 import scala.tools.nsc.interpreter.Completion.Candidates;
 import scala.tools.nsc.interpreter.Completion.ScalaCompleter;
+import scala.tools.nsc.settings.MutableSettings;
 import scala.tools.nsc.settings.MutableSettings.BooleanSetting;
 import scala.tools.nsc.settings.MutableSettings.PathSetting;
 
@@ -461,6 +462,12 @@ public class SparkInterpreter extends Interpreter {
     settings.scala$tools$nsc$settings$StandardScalaSettings$_setter_$usejavacp_$eq(b);
 
     System.setProperty("scala.repl.name.line", "line" + this.hashCode() + "$");
+
+    // To prevent 'File name too long' error on some file system.
+    MutableSettings.IntSetting numClassFileSetting = settings.maxClassfileName();
+    numClassFileSetting.v_$eq(128);
+    settings.scala$tools$nsc$settings$ScalaSettings$_setter_$maxClassfileName_$eq(
+        numClassFileSetting);
 
     synchronized (sharedInterpreterLock) {
       /* create scala repl */


### PR DESCRIPTION
### What is this PR for?
set scala Settings.numClassFileSetting to 128 to prevent "Getting 'File name too long'" error.
See https://issues.apache.org/jira/browse/SPARK-4820

### What type of PR is it?
Bug Fix

### Todos
* [x] - Programatically set numClassFileSetting to 128

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-926
https://issues.apache.org/jira/browse/SPARK-4820

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

