### PR TITLE
[HOTFIX] ZEPPELIN-931: fix interpreter listing bug

### DIFF
--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -47,9 +47,9 @@ Here is an example of `interpareter-setting.json` on your own interpreter.
 ```json
 [
   {
-    "interpreterGroup": "your-group",
-    "interpreterName": "your-name",
-    "interpreterClassName": "your.own.interpreter.class",
+    "group": "your-group",
+    "name": "your-name",
+    "className": "your.own.interpreter.class",
     "properties": {
       "propertiies1": {
         "envName": null,

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -1,8 +1,8 @@
 [
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "spark",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkInterpreter",
+    "group": "spark",
+    "name": "spark",
+    "className": "org.apache.zeppelin.spark.SparkInterpreter",
     "properties": {
       "spark.executor.memory": {
         "envName": null,
@@ -56,9 +56,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "sql",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkSqlInterpreter",
+    "group": "spark",
+    "name": "sql",
+    "className": "org.apache.zeppelin.spark.SparkSqlInterpreter",
     "properties": {
       "zeppelin.spark.concurrentSQL": {
         "envName": "ZEPPELIN_SPARK_CONCURRENTSQL",
@@ -81,9 +81,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "dep",
-    "interpreterClassName": "org.apache.zeppelin.spark.DepInterpreter",
+    "group": "spark",
+    "name": "dep",
+    "className": "org.apache.zeppelin.spark.DepInterpreter",
     "properties": {
       "zeppelin.dep.localrepo": {
         "envName": "ZEPPELIN_DEP_LOCALREPO",
@@ -100,9 +100,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "pyspark",
-    "interpreterClassName": "org.apache.zeppelin.spark.PySparkInterpreter",
+    "group": "spark",
+    "name": "pyspark",
+    "className": "org.apache.zeppelin.spark.PySparkInterpreter",
     "properties": {
       "zeppelin.pyspark.python": {
         "envName": "PYSPARK_PYTHON",
@@ -113,9 +113,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "r",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkRInterpreter",
+    "group": "spark",
+    "name": "r",
+    "className": "org.apache.zeppelin.spark.SparkRInterpreter",
     "properties": {
       "zeppelin.R.knitr": {
         "envName": "ZEPPELIN_R_KNITR",

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -225,11 +225,11 @@ public abstract class Interpreter {
    * Represent registered interpreter class
    */
   public static class RegisteredInterpreter {
-    @SerializedName("interpreterGroup")
+    //@SerializedName("interpreterGroup")
     private String group;
-    @SerializedName("interpreterName")
+    //@SerializedName("interpreterName")
     private String name;
-    @SerializedName("interpreterClassName")
+    //@SerializedName("interpreterClassName")
     private String className;
     private Map<String, InterpreterProperty> properties;
     private String path;


### PR DESCRIPTION
### What is this PR for?
Currently available interpreter list is not shown in `Creating New Interpreter` section. It seems this bug was generated after #835 was merged. So I temporally deactivated [3 SerializedName code lines](https://github.com/apache/incubator-zeppelin/pull/945/commits/6d7f1bc43437e8a876eef1a3e36a17fbd5805cb1). 

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix interpreter listing bug when creating new interpreter 

### What is the Jira issue?
[ZEPPELIN-931](https://issues.apache.org/jira/browse/ZEPPELIN-931)

### How should this be tested?
1. Build latest master branch and browse Zeppelin home
2. Create new interpreter -> You can not see the available interpreter list in this step like below attached screenshot 
3. Apply this patch
4. Build again and browse  -> You can see the available interpreter list as normal

### Screenshots (if appropriate)
 - **Before**
<img width="1273" alt="screen shot 2016-06-01 at 12 36 42 pm" src="https://cloud.githubusercontent.com/assets/10060731/15723066/9082435e-27f5-11e6-9783-df44638dbbec.png">

 - **After**
<img width="1273" alt="screen shot 2016-06-01 at 12 33 06 pm" src="https://cloud.githubusercontent.com/assets/10060731/15723067/92bcc8ce-27f5-11e6-82f5-6c0db7b4342c.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
