### PR TITLE
ZEPPELIN-937 : broken layout of Interpreter and Configurations table in mobile view.

### DIFF
--- a/zeppelin-web/src/app/configuration/configuration.css
+++ b/zeppelin-web/src/app/configuration/configuration.css
@@ -43,6 +43,7 @@
 
 .configuration table {
   table-layout: fixed;
+  word-break: break-all;
 }
 
 .configuration table tr .configurationPropertyKey {

--- a/zeppelin-web/src/app/interpreter/interpreter.css
+++ b/zeppelin-web/src/app/interpreter/interpreter.css
@@ -58,6 +58,11 @@
   list-style-type: none;
 }
 
+.interpreter table {
+  table-layout: fixed;
+  word-break: break-all;
+}
+
 .interpreter table tr .interpreterPropertyKey {
   padding : 5px 5px 5px 5px;
 }


### PR DESCRIPTION
### What is this PR for?
Current contents table of Interpreter and Configurations menu are broken on mobile view.
This PR for fixing this issue.

### What type of PR is it?
Bug Fix 


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-937


### How should this be tested?
check Interpreter and Configurations menu on mobile view.


### Screenshots (if appropriate)
- before (Configurations)
![image](https://cloud.githubusercontent.com/assets/3348133/15724632/e0d1c266-2882-11e6-81f2-97d9eefc8734.png)

- before (Interpreter)
![image](https://cloud.githubusercontent.com/assets/3348133/15724635/e3dbe89c-2882-11e6-90ec-e0deb61986e4.png)

- after
![image](https://cloud.githubusercontent.com/assets/3348133/15724643/f1ef3240-2882-11e6-8c80-99282976520c.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no