### PR TITLE
[ZEPPELIN-941] jsoup NoSuchMethodError in ZeppelinRDisplay.scala

### DIFF
--- a/spark/src/main/scala/org/apache/zeppelin/spark/ZeppelinRDisplay.scala
+++ b/spark/src/main/scala/org/apache/zeppelin/spark/ZeppelinRDisplay.scala
@@ -68,18 +68,18 @@ object ZeppelinRDisplay {
   }
 
   private def textDisplay(body: Element): RDisplay = {
-    RDisplay(body.getElementsByTag("p").get(0).html(), TEXT, SUCCESS)
+    RDisplay(body.getElementsByTag("p").first().html(), TEXT, SUCCESS)
   }
 
   private def tableDisplay(body: Element): RDisplay = {
-    val p = body.getElementsByTag("p").get(0).html.replace("“%table " , "").replace("”", "")
+    val p = body.getElementsByTag("p").first().html.replace("“%table " , "").replace("”", "")
     val r = (pattern findFirstIn p).getOrElse("")
     val table = p.replace(r, "").replace("\\t", "\t").replace("\\n", "\n")
     RDisplay(table, TABLE, SUCCESS)
   }
 
   private def imgDisplay(body: Element): RDisplay = {
-    val p = body.getElementsByTag("p").get(0).html.replace("“%img " , "").replace("”", "")
+    val p = body.getElementsByTag("p").first().html.replace("“%img " , "").replace("”", "")
     val r = (pattern findFirstIn p).getOrElse("")
     val img = p.replace(r, "")
     RDisplay(img, IMG, SUCCESS)


### PR DESCRIPTION
### What is this PR for?
Since version 1.8.2 of jsoup, org.jsoup.select.Elements class no longer has "get(int index)" method. It contradicts to <jsoup.version>1.8.2</jsoup.version> written in scala/pom.xml. Currently %r scripts fail with "java.lang.NoSuchMethodError: org.jsoup.select.Elements.get(I)Lorg/jsoup/nodes/Element;" 

This PR changes obsolete get(0) method to more universal and logically equivalent first() method, removing error message and removing 1.8.1 restriction to jsoup library (at least in ZeppelinRDisplay part of zeppelin).


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-941

### How should this be tested?
Execute R-Tutorial Notebook in default installation of zeppelin and confirm that you can see output.

### Questions:
It shouldn't break older versions.

