### PR TITLE
[ZEPPELIN-915] New registration mechanism applied to JDBCInterpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -106,21 +106,6 @@ public class JDBCInterpreter extends Interpreter {
 
   private final Map<String, ArrayList<Connection>> propertyKeyUnusedConnectionListMap;
   private final Map<String, Connection> paragraphIdConnectionMap;
-  
-  static {
-    Interpreter.register(
-        "sql",
-        "jdbc",
-        JDBCInterpreter.class.getName(),
-        new InterpreterPropertyBuilder()
-            .add(DEFAULT_URL, "jdbc:postgresql://localhost:5432/", "The URL for JDBC.")
-            .add(DEFAULT_USER, "gpadmin", "The JDBC user name")
-            .add(DEFAULT_PASSWORD, "",
-                "The JDBC user password")
-            .add(DEFAULT_DRIVER, "org.postgresql.Driver", "JDBC Driver Name")
-            .add(COMMON_MAX_LINE, MAX_LINE_DEFAULT,
-                "Max number of SQL result to display.").build());
-  }
 
   public JDBCInterpreter(Properties property) {
     super(property);

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -1,0 +1,39 @@
+[
+  {
+    "group": "jdbc",
+    "name": "sql",
+    "className": "org.apache.zeppelin.jdbc.JDBCInterpreter",
+    "properties": {
+      "default.url": {
+        "envName": null,
+        "propertyName": "default.url",
+        "defaultValue": "jdbc:postgresql://localhost:5432/",
+        "description": "The URL for JDBC."
+      },
+      "default.user": {
+        "envName": null,
+        "propertyName": "default.user",
+        "defaultValue": "gpadmin",
+        "description": "The JDBC user name"
+      },
+      "default.password": {
+        "envName": null,
+        "propertyName": "default.password",
+        "defaultValue": "",
+        "description": "The JDBC user password"
+      },
+      "default.driver": {
+        "envName": null,
+        "propertyName": "default.driver",
+        "defaultValue": "org.postgresql.Driver",
+        "description": "JDBC Driver Name"
+      },
+      "common.max_count": {
+        "envName": null,
+        "propertyName": "common.max_count",
+        "defaultValue": "1000",
+        "description": "Max number of SQL result to display."
+      }
+    }
+  }
+]

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -51,6 +51,17 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     }
     return jdbcConnection;
   }
+
+  public static Properties getJDBCTestProperties() {
+    Properties p = new Properties();
+    p.setProperty("default.driver", "org.postgresql.Driver");
+    p.setProperty("default.url", "jdbc:postgresql://localhost:5432/");
+    p.setProperty("default.user", "gpadmin");
+    p.setProperty("default.password", "");
+    p.setProperty("common.max_count", "1000");
+
+    return p;
+  }
   
   @Before
   public void setUp() throws Exception {
@@ -116,7 +127,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   
   @Test
   public void testDefaultProperties() throws SQLException {
-    JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(new Properties());
+    JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(getJDBCTestProperties());
     
     assertEquals("org.postgresql.Driver", jdbcInterpreter.getProperty(DEFAULT_DRIVER));
     assertEquals("jdbc:postgresql://localhost:5432/", jdbcInterpreter.getProperty(DEFAULT_URL));

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,7 @@
               <exclude>conf/zeppelin-env.sh</exclude>
               <exclude>spark-*-bin*/**</exclude>
               <exclude>.spark-dist/**</exclude>
+              <exclude>**/interpreter-setting.json</exclude>
 
               <!-- bundled from bootstrap -->
               <exclude>docs/assets/themes/zeppelin/bootstrap/**</exclude>


### PR DESCRIPTION
### What is this PR for?
This PR applies the new interpreter registration mechanism to the JDBCInterpreter.

### What type of PR is it?
Improvement

### Todos
* [x ] - Move interpreter registration properties from static block to interpreter-setting.json

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-915

### How should this be tested?
1. apply patch
2. rm -r interpreter/jdbc
3. rm conf/interpreter.json
4. mvn clean package -DskipTests -pl jdbc
5. bin/zeppelin-daemon.sh start
6. run some paragraph with simple sql queries

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

