### PR TITLE
[Hot Fix] Fix flaky ZeppelinIT build

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -238,8 +238,8 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       interpreterLink.click();
       driver.findElement(By.xpath("//div[@id='spark']//button[contains(.,'edit')]")).sendKeys(Keys.ENTER);
       WebElement testDepRemoveBtn = pollingWait(By.xpath("//tr[descendant::text()[contains(.,'" +
-          artifact + "')]]/td[3]/div"), MAX_IMPLICIT_WAIT);
-      testDepRemoveBtn.click();
+          artifact + "')]]/td[3]/button"), MAX_IMPLICIT_WAIT);
+      testDepRemoveBtn.sendKeys(Keys.ENTER);
       driver.findElement(By.xpath("//div[@id='spark']//form//button[1]")).click();
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();

--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -83,8 +83,8 @@ limitations under the License.
             <td><textarea msd-elastic ng-model="value.value"></textarea></td>
             <td>{{value.description}}</td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-remove" ng-click="removeInterpreterProperty(key)">
-              </div>
+              <button class="btn btn-default btn-sm fa fa-remove" ng-click="removeInterpreterProperty(key)">
+              </button>
             </td>
           </tr>
 
@@ -96,8 +96,8 @@ limitations under the License.
             <td><textarea msd-elastic ng-model="newInterpreterSetting.propertyValue"></textarea></td>
             <td></td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-plus" ng-click="addNewInterpreterProperty()">
-              </div>
+              <button class="btn btn-default btn-sm fa fa-plus" ng-click="addNewInterpreterProperty()">
+              </button>
             </td>
           </tr>
         </table>
@@ -121,9 +121,9 @@ limitations under the License.
               </textarea>
             </td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-remove"
+              <button class="btn btn-default btn-sm fa fa-remove"
                    ng-click="removeInterpreterDependency(dep.groupArtifactVersion)">
-              </div>
+              </button>
             </td>
           </tr>
 
@@ -140,8 +140,8 @@ limitations under the License.
               </textarea>
             </td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-plus" ng-click="addNewInterpreterDependency()">
-              </div>
+              <button class="btn btn-default btn-sm fa fa-plus" ng-click="addNewInterpreterDependency()">
+              </button>
             </td>
           </tr>
         </table>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -175,9 +175,9 @@ limitations under the License.
               </span>
             </td>
             <td ng-if="valueform.$visible">
-              <div class="btn btn-default btn-sm fa fa-remove"
+              <button class="btn btn-default btn-sm fa fa-remove"
                    ng-click="removeInterpreterProperty(key, setting.id)">
-              </div>
+              </button>
             </td>
           </tr>
           <tr ng-if="valueform.$visible">
@@ -190,9 +190,9 @@ limitations under the License.
               <textarea msd-elastic ng-model="setting.propertyValue"></textarea>
             </td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-plus"
+              <button class="btn btn-default btn-sm fa fa-plus"
                    ng-click="addNewInterpreterProperty(setting.id)">
-              </div>
+              </button>
             </td>
           </tr>
         </table>
@@ -227,9 +227,9 @@ limitations under the License.
               <div ng-if="!valueform.$visible">{{dep.exclusions.join()}}</div>
             </td>
             <td ng-if="valueform.$visible">
-              <div class="btn btn-default btn-sm fa fa-remove"
+              <button class="btn btn-default btn-sm fa fa-remove"
                    ng-click="removeInterpreterDependency(dep.groupArtifactVersion, setting.id)">
-              </div>
+              </button>
             </td>
           </tr>
           <tr ng-if="valueform.$visible">
@@ -246,9 +246,9 @@ limitations under the License.
               </textarea>
             </td>
             <td>
-              <div class="btn btn-default btn-sm fa fa-plus"
+              <button class="btn btn-default btn-sm fa fa-plus"
                    ng-click="addNewInterpreterDependency(setting.id)">
-              </div>
+              </button>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
### What is this PR for?
Most of the builds are failing for ZeppelinIT at testSparkInterpreterDependencyLoading:243, as the previous line's `testDepRemoveBtn.click()` is taking it to a different page. 



### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Change all add/remove dependencies/property's div to button
* [x] - make relevant change in selenium test case.

### What is the Jira issue?
[ZEPPELIN-950](https://issues.apache.org/jira/browse/ZEPPELIN-950)

### How should this be tested?
CI should pass



### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A

