### PR TITLE
[ZEPPELIN-955] Redirect docs/0.6.0-incubating-SNAPSHOT to docs/0.6.0-SNAPSHOT/

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,10 @@
-# redirect rules to prevent old links from breaking
 RewriteEngine On
 
-RewriteRule ^/?docs/0.6.0-incubating-SNAPSHOT/(.*) http://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/$1  [R=301,L,NE]
+# redirect 0.6.0-xxxx to 0.6.0-SNAPSHOT
+RewriteRule ^/?docs/0.6.0(?!-SNAPSHOT).*/(.*) /docs/0.6.0-SNAPSHOT/$2  [R=301,L,NE]
+
+# redirect 0.5.[056]-xxxx to 0.5.[056]-incubating
+RewriteRule ^/?docs/(0.5.[056])(?!-incubating).*/(.*) /docs/$1-incubating/$3  [R=301,L,NE]
+
+# rewrite docs/latest to latest stable release
+RewriteRule ^/?docs/latest/(.*) /docs/0.5.6-incubating/$1  [PT]

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+# redirect rules to prevent old links from breaking
+RewriteEngine On
+
+RewriteRule ^/?docs/0.6.0-incubating-SNAPSHOT/(.*) http://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/$1  [R=301,L,NE]


### PR DESCRIPTION
### What is this PR for?
Redirect docs/0.6.0-incubating-SNAPSHOT to docs/0.6.0-SNAPSHOT/

### What type of PR is it?
Improvement

### Todos
* [x] - Create .htaccess with rewirte rule

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-955

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

