### PR TITLE
Update external links to project code style guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,8 +125,8 @@ please check [its own contribution guidelines](https://github.com/apache/incubat
 
 ### Code convention
 We are following Google Code style:
-* [Java style](http://google-styleguide.googlecode.com/svn/trunk/javaguide.html) 
-* [Shell style](https://google-styleguide.googlecode.com/svn/trunk/shell.xml)
+* [Java style](https://google.github.io/styleguide/javaguide.html)
+* [Shell style](https://google.github.io/styleguide/shell.xml)
 
 Check style report location are in `${submodule}/target/site/checkstyle.html`
 Test coverage report location are in `${submodule}/target/site/cobertura/index.html`


### PR DESCRIPTION
### What is this PR for?
Update external links to project code style guides in CONTRIBUTING.md as old ones give 404 now

### What type of PR is it?
Bug Fix

### How should this be tested?
Lins should be clickable and return 200


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

