### PR TITLE
[HOTFIX] ZEPPELIN-959: Fix odd code block in writingzeppelininterpreter.md

### DIFF
--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -39,11 +39,13 @@ Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.int
 You can include `org.apache.zeppelin:zeppelin-interpreter:[VERSION]` artifact in your build system. And you should your jars under your interpreter directory with specific directory name. Zeppelin server reads interpreter directories recursively and initializes interpreters including your own interpreter.
 
 There are three locations where you can store your interpreter group, name and other information. Zeppelin server tries to find the location below. Next, Zeppelin tries to find `interpareter-setting.json` in your interpreter jar. 
+
 ```
 {ZEPPELIN_INTERPRETER_DIR}/{YOUR_OWN_INTERPRETER_DIR}/interpreter-setting.json
 ```
 
 Here is an example of `interpareter-setting.json` on your own interpreter.
+
 ```json
 [
   {
@@ -72,11 +74,13 @@ Here is an example of `interpareter-setting.json` on your own interpreter.
 ```
 
 Finally, Zeppelin uses static initialization with the following:
+
 ```
 static {
     Interpreter.register("MyInterpreterName", MyClassName.class.getName());
   }
 ```
+
 **Static initialization is deprecated and will be supported until 0.6.0.**
 
 The name will appear later in the interpreter name option box during the interpreter configuration process.

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -39,13 +39,11 @@ Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.int
 You can include `org.apache.zeppelin:zeppelin-interpreter:[VERSION]` artifact in your build system. And you should your jars under your interpreter directory with specific directory name. Zeppelin server reads interpreter directories recursively and initializes interpreters including your own interpreter.
 
 There are three locations where you can store your interpreter group, name and other information. Zeppelin server tries to find the location below. Next, Zeppelin tries to find `interpareter-setting.json` in your interpreter jar. 
-
 ```
 {ZEPPELIN_INTERPRETER_DIR}/{YOUR_OWN_INTERPRETER_DIR}/interpreter-setting.json
 ```
 
 Here is an example of `interpareter-setting.json` on your own interpreter.
-
 ```json
 [
   {
@@ -74,13 +72,11 @@ Here is an example of `interpareter-setting.json` on your own interpreter.
 ```
 
 Finally, Zeppelin uses static initialization with the following:
-
 ```
 static {
     Interpreter.register("MyInterpreterName", MyClassName.class.getName());
   }
 ```
-
 **Static initialization is deprecated and will be supported until 0.6.0.**
 
 The name will appear later in the interpreter name option box during the interpreter configuration process.

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -114,7 +114,6 @@ export ZEPPELIN_NOTEBOOK_S3_KMS_KEY_ID = kms-key-id
 ```
 
 Or using the following setting in **zeppelin-site.xml**:
-
 ```
 <property>
   <name>zeppelin.notebook.s3.kmsKeyID</name>
@@ -133,7 +132,6 @@ export ZEPPELIN_NOTEBOOK_S3_EMP = class-name
 ```
 
 Or using the following setting in **zeppelin-site.xml**:
-
 ```
 <property>
   <name>zeppelin.notebook.s3.encryptionMaterialsProvider</name>
@@ -146,6 +144,7 @@ Or using the following setting in **zeppelin-site.xml**:
 
 Using `AzureNotebookRepo` you can connect your Zeppelin with your Azure account for notebook storage.
 
+</br>
 
 First of all, input your `AccountName`, `AccountKey`, and `Share Name` in the file **zeppelin-site.xml** by commenting out and completing the next properties:
 

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -114,6 +114,7 @@ export ZEPPELIN_NOTEBOOK_S3_KMS_KEY_ID = kms-key-id
 ```
 
 Or using the following setting in **zeppelin-site.xml**:
+
 ```
 <property>
   <name>zeppelin.notebook.s3.kmsKeyID</name>
@@ -132,6 +133,7 @@ export ZEPPELIN_NOTEBOOK_S3_EMP = class-name
 ```
 
 Or using the following setting in **zeppelin-site.xml**:
+
 ```
 <property>
   <name>zeppelin.notebook.s3.encryptionMaterialsProvider</name>
@@ -144,7 +146,6 @@ Or using the following setting in **zeppelin-site.xml**:
 
 Using `AzureNotebookRepo` you can connect your Zeppelin with your Azure account for notebook storage.
 
-</br>
 
 First of all, input your `AccountName`, `AccountKey`, and `Share Name` in the file **zeppelin-site.xml** by commenting out and completing the next properties:
 


### PR DESCRIPTION
### What is this PR for?
Currently some code blocks in [docs/development/writingzeppelininterpreter.html](https://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/development/writingzeppelininterpreter.html) & [docs/storage/storage.html#S3](https://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/storage/storage.html) are broken. 

But it seems the broken code block  in `docs/storage/storage.html` is already handled in #962. So I just updated in `docs/development/writingzeppelininterpreter.html`

### What type of PR is it?
Hot Fix 

### Todos

### What is the Jira issue?
[ZEPPELIN-959](https://issues.apache.org/jira/browse/ZEPPELIN-959)

### How should this be tested?
See the attached images :)

### Screenshots (if appropriate)
- Before
![docs-before2](https://cloud.githubusercontent.com/assets/10060731/15812570/6d70ba16-2b6b-11e6-8486-86052e8ceeed.gif)

- After
<img width="1077" alt="screen shot 2016-06-05 at 7 38 50 pm" src="https://cloud.githubusercontent.com/assets/10060731/15812563/4b36e696-2b6b-11e6-8f14-f4572331eec6.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
