### PR TITLE
Update README.md for fixing ignite flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ mvn clean package -Pspark-1.5 -Pmapr50 -DskipTests
 #### Ignite Interpreter
 
 ```sh
-mvn clean package -Dignite.version=1.1.0-incubating -DskipTests
+mvn clean package -Dignite.version=1.6.0 -DskipTests
 ```
 
 #### Scalding Interpreter


### PR DESCRIPTION
### What is this PR for?
While Apache Ignite version in Zeppelin was bumped up by #916, but ignite build flag in [README.md](https://github.com/apache/incubator-zeppelin/blob/master/README.md#ignite-interpreter) is outdated so far. So I just changed `1.1.0-incubating` -> `1.6.0`. 


### What type of PR is it?
Hot Fix

### Todos

### What is the Jira issue?

### How should this be tested?
Just see [here](https://github.com/apache/incubator-zeppelin/blob/master/README.md#ignite-interpreter).

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
