### PR TITLE
[ZEPPELIN-973, ZEPPELIN-954] Table rendering improvements

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1241,20 +1241,19 @@ angular.module('zeppelinWebApp')
         manualRowResize: true,
         editor: false,
         fillHandle: false,
-        disableVisualSelection: true,
         cells: function (row, col, prop) {
           var cellProperties = {};
-            cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {
-              Handsontable.NumericCell.renderer.apply(this, arguments);
-              if (!isNaN(value)) {
-                cellProperties.type = 'numeric';
-                cellProperties.format = '0,0';
-                cellProperties.editor = false;
-                td.style.textAlign = 'left';
-              } else if (value.length > '%html'.length && '%html ' === value.substring(0, '%html '.length)) {
-                td.innerHTML = value.substring('%html'.length);
-              }
-            };
+          cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {
+            if (!isNaN(value)) {
+              cellProperties.format = '0,0.[00000]';
+              td.style.textAlign = 'left';
+              Handsontable.renderers.NumericRenderer.apply(this, arguments);
+            } else if (value.length > '%html'.length && '%html ' === value.substring(0, '%html '.length)) {
+              td.innerHTML = value.substring('%html'.length);
+            } else {
+              Handsontable.renderers.TextRenderer.apply(this, arguments);
+            }
+          };
           return cellProperties;
         }
       });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1241,6 +1241,8 @@ angular.module('zeppelinWebApp')
         manualRowResize: true,
         editor: false,
         fillHandle: false,
+        fragmentSelection: true,
+        disableVisualSelection: true,
         cells: function (row, col, prop) {
           var cellProperties = {};
           cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {


### PR DESCRIPTION
### What is this PR for?
This PR fixes a few minor issues from the recent introduction of Handsontable for table rendering (https://github.com/apache/incubator-zeppelin/pull/858):
* Render up to 5 digits after decimal point instead of always rounding to integers
* Allow visual selection of table cells (for copy)
* Default to text renderer instead of numeric renderer

### What type of PR is it?
Bug Fix, Improvement

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-973
* https://issues.apache.org/jira/browse/ZEPPELIN-954

### How should this be tested?
Output some rows with floating point numbers and render them in a table.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No