### PR TITLE
[ZEPPELIN-911] Apply new mechanism to FlinkInterpreter

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -159,6 +159,7 @@
             <exclude>**/.project</exclude>
             <exclude>**/target/**</exclude>
             <exclude>**/README.md</exclude>
+            <exclude>**/interpreter-setting.json</exclude>
             <exclude>dependency-reduced-pom.xml</exclude>
           </excludes>
         </configuration>

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -67,19 +67,6 @@ public class FlinkInterpreter extends Interpreter {
     super(property);
   }
 
-  static {
-    Interpreter.register(
-        "flink",
-        "flink",
-        FlinkInterpreter.class.getName(),
-        new InterpreterPropertyBuilder()
-                .add("host", "local",
-                    "host name of running JobManager. 'local' runs flink in local mode")
-          .add("port", "6123", "port of running JobManager")
-          .build()
-    );
-  }
-
   @Override
   public void open() {
     out = new ByteArrayOutputStream();

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -1,0 +1,21 @@
+[
+  {
+    "group": "flink",
+    "name": "flink",
+    "className": "org.apache.zeppelin.flink.FlinkInterpreter",
+    "properties": {
+      "host": {
+        "envName": "host",
+        "propertyName": null,
+        "defaultValue": "local",
+        "description": "host name of running JobManager. 'local' runs flink in local mode."
+      },
+      "port": {
+        "envName": "port",
+        "propertyName": null,
+        "defaultValue": "6123",
+        "description": "port of running JobManager."
+      }
+    }
+  }
+]


### PR DESCRIPTION
### What is this PR for?
This PR applies the new interpreter registration mechanism to FlinkInterpreter.

### What type of PR is it?
Improvement

### Todos
 - Move interpreter registration properties from static block to interpreter-setting.json

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-911

### How should this be tested?
1. apply patch
2. rm -r interpreter/flink
3. rm conf/interpreter.json
4. mvn clean package -DskipTests -pl flink
5. bin/zeppelin-daemon.sh start
6. run some paragraph with simple Flink queries

Questions:

Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? No